### PR TITLE
include locations in Core output if --pp_flags=annot specified

### DIFF
--- a/backend/common/pipeline.ml
+++ b/backend/common/pipeline.ml
@@ -480,7 +480,7 @@ let print_core (conf, io) ~filename core_file =
   end >>= fun () ->
   whenM (List.mem Core conf.pprints) begin
       fun () ->
-      let pp_file = if List.mem Annot conf.ppflags then Pp_core.WithLocations.pp_file else Pp_core.Basic.pp_file in
+      let pp_file = if List.mem Annot conf.ppflags then Pp_core.WithLocationsAndStd.pp_file else Pp_core.Basic.pp_file in
       io.run_pp (wrap_fout (Some (filename, "core"))) (pp_file core_file)
   end >>= fun () ->
   return core_file

--- a/backend/common/pipeline.ml
+++ b/backend/common/pipeline.ml
@@ -479,8 +479,9 @@ let print_core (conf, io) ~filename core_file =
       io.run_pp (wrap_fout (Some (filename, "core"))) (Ast_core.ast_file core_file)
   end >>= fun () ->
   whenM (List.mem Core conf.pprints) begin
-    fun () ->
-      io.run_pp (wrap_fout (Some (filename, "core"))) (Pp_core.Basic.pp_file core_file)
+      fun () ->
+      let pp_file = if List.mem Annot conf.ppflags then Pp_core.WithLocations.pp_file else Pp_core.Basic.pp_file in
+      io.run_pp (wrap_fout (Some (filename, "core"))) (pp_file core_file)
   end >>= fun () ->
   return core_file
 

--- a/ocaml_frontend/pprinters/pp_core.ml
+++ b/ocaml_frontend/pprinters/pp_core.ml
@@ -959,9 +959,17 @@ module All = Make (struct
   let handle_uid _ _ = ()
 end)
 
-
 module WithLocations = Make (struct
   let show_std = false
+  let show_include = false
+  let show_locations = true
+  let show_explode_annot = false
+  let handle_location _ _ = ()
+  let handle_uid _ _ = ()
+end)
+
+module WithLocationsAndStd = Make (struct
+  let show_std = true
   let show_include = false
   let show_locations = true
   let show_explode_annot = false

--- a/ocaml_frontend/pprinters/pp_core.mli
+++ b/ocaml_frontend/pprinters/pp_core.mli
@@ -40,5 +40,6 @@ module Make (C : CONFIG) : PP_CORE
 module Basic : PP_CORE
 module All : PP_CORE
 module WithLocations : PP_CORE
+module WithLocationsAndStd: PP_CORE
 module WithExplode : PP_CORE
 


### PR DESCRIPTION
According to command-line options description: "Pretty print flags [annot: include location and ISO annotations".
For Core files, this flag has no effect.  This PR fixes that.

