### PR TITLE
tabs.ts: Loosen type of SvgGraph.svg

### DIFF
--- a/public/src/tabs.ts
+++ b/public/src/tabs.ts
@@ -80,7 +80,7 @@ export class Experimental extends Tab {
 class SvgGraph extends Tab {
   panzoomOptions: any
   container: JQuery<HTMLElement>
-  svg: JQuery<HTMLElement>
+  svg: JQuery<Element>
   
   constructor(name: string, ee: EventEmitter) {
     super (name, ee)


### PR DESCRIPTION
`@types/jquery` version 3.3.35 and 3.3.36 made some changes to the type
of JQuery.find(), see the PRs:

  * https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43857

  * https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44051

As a result, the following line in SvgGraph.setSVG would fail to
typecheck:

```typescript
      this.svg = this.container.find('svg')
```

But if we change the svg property's type from `JQuery<HTMLElement>` to
`JQuery<Element>`, we don't have to care about the changes: it typechecks
either way.