### PR TITLE
simplification and handling some corner cases in `split_bytes`

### DIFF
--- a/memory/concrete/impl_mem.ml
+++ b/memory/concrete/impl_mem.ml
@@ -408,11 +408,13 @@ module Concrete : Memory = struct
                 | _ ->
                     `OtherBytes in
               (prov_acc', b.value :: val_acc, offset_acc')
-            ) (`VALID b.prov, [], `PtrBytes 0) bl in
-          ( (match _prov with `INVALID -> Prov_none | `VALID z -> z)
-          , (match offset_status with `OtherBytes -> `NotValidPtrProv | _ -> `ValidPtrProv)
-          , List.rev rev_values )
-    
+              ) (`VALID b.prov, [], `PtrBytes 0) bl in
+          let values = List.rev rev_values in
+          match _prov, offset_status with
+          | `VALID z, `PtrBytes _ -> (z, `ValidPtrProv, values)
+          | `VALID z, _ -> (z, `NotValidPtrProv, rev_values)
+          | `INVALID, _ -> (Prov_none, `NotValidPtrProv, rev_values)
+
     (* PNVI-ae-udi *)
     let provs_of_bytes bs =
       let xs = List.fold_left (fun acc b ->

--- a/memory/concrete/impl_mem.ml
+++ b/memory/concrete/impl_mem.ml
@@ -408,10 +408,9 @@ module Concrete : Memory = struct
                 | _ ->
                     `OtherBytes in
               (prov_acc', b.value :: val_acc, offset_acc')
-              ) (`VALID b.prov, [], `PtrBytes 0) bl in
-          let values = List.rev rev_values in
+              ) (`VALID b.prov, [], `PtrBytes 0) (List.rev bl) in
           match _prov, offset_status with
-          | `VALID z, `PtrBytes _ -> (z, `ValidPtrProv, values)
+          | `VALID z, `PtrBytes _ -> (z, `ValidPtrProv, rev_values)
           | `VALID z, _ -> (z, `NotValidPtrProv, rev_values)
           | `INVALID, _ -> (Prov_none, `NotValidPtrProv, rev_values)
 

--- a/memory/concrete/impl_mem.ml
+++ b/memory/concrete/impl_mem.ml
@@ -438,12 +438,13 @@ module Concrete : Memory = struct
                 | _ ->
                     `OtherBytes in
               (prov_acc', b.value :: val_acc, offset_acc')
-              ) (`VALID b.prov, [], `PtrBytes 0) (List.rev bl) in
+              ) (`VALID b.prov, [], `PtrBytes 0) bl in
+          let values = List.rev rev_values in
           match _prov, offset_status with
-          | `VALID z, `PtrBytes _ -> (z, `ValidPtrProv, rev_values)
-          | `VALID z, _ -> (z, `NotValidPtrProv, rev_values)
-          | `INVALID, _ -> (Prov_none, `NotValidPtrProv, rev_values)
-
+          | `VALID z, `PtrBytes _ -> (z, `ValidPtrProv, values)
+          | `VALID z, _ -> (z, `NotValidPtrProv, values)
+          | `INVALID, _ -> (Prov_none, `NotValidPtrProv, values)
+    
     (* PNVI-ae-udi *)
     let provs_of_bytes bs =
       let xs = List.fold_left (fun acc b ->

--- a/memory/concrete/impl_mem.ml
+++ b/memory/concrete/impl_mem.ml
@@ -356,6 +356,36 @@ module Concrete : Memory = struct
   
   open Eff
   
+  let combine_prov prov1 prov2 =
+    match (prov1, prov2) with
+      | (Prov_none, Prov_none) ->
+          Prov_none
+      | (Prov_none, Prov_some id) ->
+          Prov_some id
+      | (Prov_none, Prov_device) ->
+          Prov_device
+      | (Prov_some id, Prov_none) ->
+          Prov_some id
+      | (Prov_some id1, Prov_some id2) ->
+          if id1 = id2 then
+            Prov_some id1
+          else
+            Prov_none
+      | (Prov_some _, Prov_device) ->
+          Prov_device
+      | (Prov_device, Prov_none) ->
+          Prov_device
+      | (Prov_device, Prov_some _) ->
+          Prov_device
+      | (Prov_device, Prov_device) ->
+          Prov_device
+      
+      (* PNVI-ae-udi *)
+      (* TODO: this is improvised, need to check with P *)
+      | (Prov_symbolic _, _)
+      | (_, Prov_symbolic _) ->
+          failwith "Concrete.combine_prov: found a Prov_symbolic"  
+
   
   (* INTERNAL: address *)
   type address = N.num
@@ -2387,36 +2417,6 @@ let eff_member_shift_ptrval _ tag_sym membr_ident ptrval =
             fail ~loc MerrIntFromPtr
           else
             return (mk_ival prov addr)
-
-let combine_prov prov1 prov2 =
-  match (prov1, prov2) with
-    | (Prov_none, Prov_none) ->
-        Prov_none
-    | (Prov_none, Prov_some id) ->
-        Prov_some id
-    | (Prov_none, Prov_device) ->
-        Prov_device
-    | (Prov_some id, Prov_none) ->
-        Prov_some id
-    | (Prov_some id1, Prov_some id2) ->
-        if id1 = id2 then
-          Prov_some id1
-        else
-          Prov_none
-    | (Prov_some _, Prov_device) ->
-        Prov_device
-    | (Prov_device, Prov_none) ->
-        Prov_device
-    | (Prov_device, Prov_some _) ->
-        Prov_device
-    | (Prov_device, Prov_device) ->
-        Prov_device
-    
-    (* PNVI-ae-udi *)
-    (* TODO: this is improvised, need to check with P *)
-    | (Prov_symbolic _, _)
-    | (_, Prov_symbolic _) ->
-        failwith "Concrete.combine_prov: found a Prov_symbolic"
 
 
   let op_ival iop (IV (prov1, n1)) (IV (prov2, n2)) =

--- a/memory/concrete/impl_mem.ml
+++ b/memory/concrete/impl_mem.ml
@@ -445,6 +445,13 @@ module Concrete : Memory = struct
           | `VALID z, _ -> (z, `NotValidPtrProv, values)
           | `INVALID, _ -> (Prov_none, `NotValidPtrProv, values)
     
+    let pvi_split_bytes bs =
+      let prov, rev_bs =
+        List.fold_left (fun (prov_acc, rev_bs_acc) b ->
+          (combine_prov b.prov prov_acc, b.value :: rev_bs_acc)
+        ) (Prov_none, []) bs in
+      prov, List.rev rev_bs
+    
     (* PNVI-ae-udi *)
     let provs_of_bytes bs =
       let xs = List.fold_left (fun acc b ->
@@ -924,7 +931,7 @@ module Concrete : Memory = struct
           assert false
       | Basic (Integer ity) ->
           let (bs1, bs2) = L.split_at (N.to_int (sizeof cty)) bs in
-          let (prov, _, bs1') = AbsByte.split_bytes bs1 in
+          let (prov, bs1') = AbsByte.pvi_split_bytes bs1 in
             (* PNVI-ae-udi *)
           ( AbsByte.provs_of_bytes bs1
           , begin match extract_unspec bs1' with


### PR DESCRIPTION
The current implementation of `split_bytes` was not faithfully implementing what was described in the section "Reading pointer values from byte writes" of the N3005 draft. In my interpretation should return `ValidPtrProv` **only** when "a pointer value read is from a single pointer value write (and thus should retain its original provenance when read)". In all other cases such as mixed provenance or out-of-sequence offsets it should return `Prov_none` marked as `NotValidPtrProv` and trigger provenance recovery.

In particular, this PR addresses a few corner cases:

1. Several `Prov_none` values (with correct offsets)  followed by `Prove_some.` 
2. Mix of `Prov_symbolic` and `Prove_some` 
3. `Prov_some` followed by `Prov_device`
