### PR TITLE
Dune version consistent

### DIFF
--- a/cerberus.opam
+++ b/cerberus.opam
@@ -20,7 +20,7 @@ bug-reports: "https://github.com/rems-project/cerberus/issues"
 depends: [
   "cerberus-lib"
   "ocaml" {>= "4.12.0"}
-  "dune" {>= "3.8.0" & < "3.13.0"}
+  "dune" {(>= "3.8.0" & < "3.13.0") | (>= "3.15.0")}
   "sha" {>= "1.12"}
   "pprint" {>= "20180528"}
   "ppx_sexp_conv" {>= "v0.14.3" }


### PR DESCRIPTION
`cerberus-lib.opam` allows for `dune >= 3.15.0` so I made that the case for `cerberus.opam` as well. Otherwise `opam` takes the intersection of the two and force me to downgrade dune to `3.13.0`. Which I'd rather not do unless I absolutely have to.