### PR TITLE
Correctly build the release docker image

### DIFF
--- a/Dockerfile.deps
+++ b/Dockerfile.deps
@@ -1,18 +1,18 @@
-FROM ubuntu
+FROM ubuntu:22.04
+
 RUN apt-get update
 RUN apt-get upgrade -y
 RUN apt-get install -y opam libgmp-dev libmpfr-dev
-RUN mkdir /etc/sudoers.d/ && \
-  echo 'user1 ALL=(ALL:ALL) NOPASSWD:ALL' > /etc/sudoers.d/user1 && \
-  chmod 440 /etc/sudoers.d/user1 && \
-  chown root:root /etc/sudoers.d/user1 && \
-  adduser --disabled-password --gecos '' user1 && \
-  passwd -l user1 && \
-  chown -R user1:user1 /home/user1
-USER user1
-ENV HOME /home/user1
-WORKDIR /home/user1
+
+ENV OPAMCONFIRMLEVEL=unsafe-yes
 RUN opam init --disable-sandboxing
-RUN eval `opam env` && \
-  opam repository add rems https://github.com/rems-project/opam-repository.git && \
-  opam install -y ocamlfind ocamlbuild pprint yojson ppx_sexp_conv sexplib ppx_deriving cmdliner menhir z3 dune lem sha apron
+RUN opam install dune lem
+
+ADD . /opt/cerberus
+WORKDIR /opt/cerberus
+RUN opam install --deps-only  ./cerberus-lib.opam ./cn.opam
+RUN eval `opam env` \
+  && make install \
+  && make install_cn
+
+WORKDIR /opt

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,11 +1,7 @@
 FROM cerberus:deps
 
-COPY --chown=user1 . /home/opam/cerberus/
-RUN eval `opam env` && \
-  cd /home/opam/cerberus/ && \
-  make && \
-  make install
-COPY --chown=user1 docker_entry_point.sh /home/user1/
-RUN chmod +x docker_entry_point.sh
+RUN rm -rf /opt/cerberus
+COPY docker_entry_point.sh /opt/docker_entry_point.sh
+RUN chmod +x /opt/docker_entry_point.sh
 WORKDIR /data
-ENTRYPOINT ["/home/user1/docker_entry_point.sh"]
+ENTRYPOINT ["/opt/docker_entry_point.sh"]

--- a/Makefile_docker
+++ b/Makefile_docker
@@ -8,7 +8,7 @@ deps :
 
 release: deps
 	docker build --tag cerberus:release -f Dockerfile.release .
-	@echo 'for example: docker run --volume `PWD`:/data/ cerberus:release tests/tcc/00_assignment.c --pp=core'
+	@echo 'for example: docker run --volume `PWD`:/data/ cerberus:release cerberus tests/tcc/00_assignment.c --pp=core'
 
 dev-env: deps
 	docker build --tag cerberus:dev-env -f Dockerfile.dev-env .

--- a/docker_entry_point.sh
+++ b/docker_entry_point.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-eval `opam env` && cerberus $*
+eval `opam env` && $*


### PR DESCRIPTION
Fixes #259 

Simplifies running `opam` in docker, and improves the ergonomics of the docker image.

Building the image should be a part of the cerberus CI, but for that you need to set appropriate tokens.