### PR TITLE
CN: Adjust mucore pp output

### DIFF
--- a/backend/cn/check.ml
+++ b/backend/cn/check.ml
@@ -1053,23 +1053,26 @@ let add_trace_information labels annots =
   let open CF.Annot in
   let inlined_labels =
     List.filter_map (function Ainlined_label l -> Some l | _ -> None) annots in
-  let stmt_locs =
-    List.filter_map (function Astmt loc -> Some loc | _ -> None) annots in
-  let expr_locs =
-    List.filter_map (function Aexpr loc -> Some loc | _ -> None) annots in
+  let locs =
+    List.filter_map (function Aloc l -> Some l | _ -> None) annots in
+  let is_stmt = List.exists (function Astmt -> true | _ -> false) annots in
+  let is_expr = List.exists (function Aexpr -> true | _ -> false) annots in
   let@ () = match inlined_labels with
     | [] -> return ()
     | [(lloc,lsym,lannot)] ->
       add_label_to_trace (Some (lloc,lannot))
     | _ -> assert false
   in
-  let@ () = match stmt_locs with
-    | [] -> return ()
-    | l :: _ -> add_trace_item_to_trace (Stmt, l)
-  in
-  let@ () = match expr_locs with
-    | [] -> return ()
-    | l :: _ -> add_trace_item_to_trace (Context.Expr, l)
+  let@ () = match locs with
+    | [] ->
+      return ()
+    | l :: _ ->
+      if is_stmt then
+        add_trace_item_to_trace (Stmt, l)
+      else if is_expr then
+        add_trace_item_to_trace (Expr, l)
+      else
+        return ()
   in
   return ()
 

--- a/backend/cn/main.ml
+++ b/backend/cn/main.ml
@@ -26,7 +26,7 @@ let print_file filename file =
      Pp.print_file (filename ^ ".core") (CF.Pp_core.All.pp_file file);
   | MUCORE file ->
      Pp.print_file (filename ^ ".mucore")
-       (Pp_mucore.Basic.pp_file None file);
+       (Pp_mucore.pp_file file);
 
 
 module Log : sig
@@ -139,6 +139,7 @@ let main
       no_use_ity
       use_peval
       batch
+      no_inherit_loc
   =
   if json then begin
       if debug_level > 0 then
@@ -156,7 +157,7 @@ let main
     Solver.random_seed := random_seed;
     Solver.log_to_temp := solver_logging;
     Check.skip_and_only := (opt_comma_split skip, opt_comma_split only);
-  IndexTerms.use_vip := use_vip;
+    IndexTerms.use_vip := use_vip;
     Check.batch := batch;
     Diagnostics.diag_string := diag;
     WellTyped.use_ity := not no_use_ity
@@ -175,7 +176,7 @@ let main
   try
       let result =
         let open Resultat in
-         let@ prog5 = Core_to_mucore.normalise_file (markers_env, ail_prog) prog4 in
+         let@ prog5 = Core_to_mucore.normalise_file ~inherit_loc:(not(no_inherit_loc)) (markers_env, ail_prog) prog4 in
          (* let instrumentation = Core_to_mucore.collect_instrumentation prog5 in *)
          (* for constructor base type information, for now see prog5.mu_datatypes and prog5.mu_constructors *)
          print_log_file ("mucore", MUCORE prog5);
@@ -347,6 +348,10 @@ let use_peval =
   let doc = "(this switch should go away) run the Core partial evaluation phase" in
   Arg.(value & flag & info["use-peval"] ~doc)
 
+let no_inherit_loc =
+  let doc = "debugging: stop mucore terms inheriting location information from parents" in
+  Arg.(value & flag & info["no-inherit-loc"] ~doc)
+
 
 
 
@@ -379,6 +384,7 @@ let () =
       use_vip $
       no_use_ity $
       use_peval $
-      batch
+      batch $
+      no_inherit_loc
   in
   Stdlib.exit @@ Cmd.(eval (v (info "cn") check_t))

--- a/backend/cn/pp_mucore.ml
+++ b/backend/cn/pp_mucore.ml
@@ -512,8 +512,8 @@ module Make (Config: CONFIG) = struct
                  Pp_core_ctype.pp_integer_ctype ity]
               | Ainlined_label (_, s, _) ->
                  [!^"inlined" ^^^ pp_symbol s]
-              | Astmt loc -> [!^"TODO(stmt)"]
-              | Aexpr loc -> [!^"TODO(expr)"]
+              | Astmt -> [!^"stmt"]
+              | Aexpr -> [!^"expr"]
 
   let pp_annots annots =
     Pp.flow_map (Pp.break 0) (fun annot -> !^"{-#" ^^ annot ^^ !^"#-}")

--- a/coq/CheriMemory/CoqAnnot.v
+++ b/coq/CheriMemory/CoqAnnot.v
@@ -68,8 +68,8 @@ Inductive annot : Type :=
   | Acerb: cerb_attribute -> annot
   | Avalue: value_annot -> annot
   | Ainlined_label: location_ocaml -> CoqSymbol.sym -> label_annot -> annot
-  | Astmt: location_ocaml -> annot
-  | Aexpr: location_ocaml -> annot.
+  | Astmt: annot
+  | Aexpr: annot.
 
 
 (*

--- a/frontend/model/annot.lem
+++ b/frontend/model/annot.lem
@@ -80,8 +80,8 @@ type annot =
   | Acerb of cerb_attribute
   | Avalue of value_annot
   | Ainlined_label of (Loc.t * Symbol.sym * label_annot)
-  | Astmt of Loc.t
-  | Aexpr of Loc.t
+  | Astmt (* Added for CN, to mark an Ail statement boundary *)
+  | Aexpr (* Added for CN, to mark an Ail expression boundary *)
 
 
 type identifier_item_kind =
@@ -122,12 +122,12 @@ let rec get_loc annots =
         get_loc annots'
     | (Avalue _ :: annots') ->
         get_loc annots'
-	| (Ainlined_label _ :: annots') ->
-	    get_loc annots'
-	| (Astmt _ :: annots') ->
-	    get_loc annots'
-	| (Aexpr _ :: annots') ->
-	    get_loc annots'
+    | (Ainlined_label _ :: annots') ->
+        get_loc annots'
+    | (Astmt :: annots') ->
+        get_loc annots'
+    | (Aexpr :: annots') ->
+        get_loc annots'
   end
 
 (* This is assuming there is only one Atypedef annot *)
@@ -188,11 +188,11 @@ let rec get_attrs annots =
     | (Avalue _ :: annots') ->
         get_attrs annots'
     | (Ainlined_label _ :: annots') ->
-	    get_attrs annots'
-	| (Astmt _ :: annots') ->
-	    get_attrs annots'
-	| (Aexpr _ :: annots') ->
-	    get_attrs annots'
+        get_attrs annots'
+    | (Astmt :: annots') ->
+        get_attrs annots'
+    | (Aexpr :: annots') ->
+        get_attrs annots'
   end
 
 
@@ -283,12 +283,12 @@ let rec get_uid annots =
         get_uid annots'
     | (Avalue _ :: annots') ->
         get_uid annots'
-	| (Ainlined_label _ :: annots') ->
-	    get_uid annots'
-	| (Astmt _ :: annots') ->
-	    get_uid annots'
-	| (Aexpr _ :: annots') ->
-	    get_uid annots'
+    | (Ainlined_label _ :: annots') ->
+        get_uid annots'
+    | (Astmt :: annots') ->
+        get_uid annots'
+    | (Aexpr :: annots') ->
+        get_uid annots'
   end
 
 

--- a/frontend/model/core_aux.lem
+++ b/frontend/model/core_aux.lem
@@ -2103,13 +2103,13 @@ let add_loc loc (Expr annot expr_) =
   end in
   Expr (update_annot pred (Aloc loc) annot) expr_
 
-val add_stmt_loc: Loc.t -> expr unit -> expr unit
-let add_stmt_loc loc (Expr annot expr_) =
-  Expr (Astmt loc :: annot) expr_
+val add_stmt: expr unit -> expr unit
+let add_stmt (Expr annot expr_) =
+  Expr (Astmt :: annot) expr_
 
-val add_expr_loc: Loc.t -> expr unit -> expr unit
-let add_expr_loc loc (Expr annot expr_) =
-  Expr (Aexpr loc :: annot) expr_
+val add_expr: expr unit -> expr unit
+let add_expr (Expr annot expr_) =
+  Expr (Aexpr :: annot) expr_
 
 
 val annotate_integer_type_pexpr : integerType -> pexpr -> pexpr

--- a/frontend/model/translation.lem
+++ b/frontend/model/translation.lem
@@ -1397,7 +1397,7 @@ let rec translate_expression is_used ctx variadic_env stdlib tagDefs a_expr =
     E.return (Caux.mk_pure_e (Caux.mk_specified_pe (Caux.mk_nullptr_pe result_ty)))
   else
     let A.AnnotatedExpression annot std_annots loc expr = a_expr in
-    (comb (comb (Caux.add_loc loc) (Caux.add_expr_loc loc))
+    (comb (comb (Caux.add_loc loc) Caux.add_expr)
           (if is_lvalue then (fun z -> z) else Caux.maybe_annotate_integer_type result_ty)) <$>
       match expr with
       | A.AilEunary A.Plus e ->
@@ -3364,7 +3364,7 @@ let rec translate_stmt stdlib tagDefs f env (A.AnnotatedStatement loc stmt_attrs
             "** TRANSLATING ** " ^
             Pp.stringFromAil_statement (A.AnnotatedStatement loc stmt_attrs stmt)
           ) in
-  (Caux.add_loc loc -| Caux.add_stmt_loc loc -| Caux.add_attrs stmt_attrs) <$>
+  (Caux.add_loc loc -| Caux.add_stmt -| Caux.add_attrs stmt_attrs) <$>
   match stmt with
     | A.AilSskip ->
         E.return Caux.mk_skip_e

--- a/memory/cheri-coq/impl_mem.ml
+++ b/memory/cheri-coq/impl_mem.ml
@@ -182,8 +182,8 @@ module CerbTagDefs = struct
     | Avalue va -> Avalue (toCoq_value_annot va)
     | Ainlined_label (l,s,la) ->
        Ainlined_label (toCoq_location l, toCoq_Symbol_sym s, toCoq_label_annot la)
-    | Astmt l -> Astmt (toCoq_location l)
-    | Aexpr l -> Aexpr (toCoq_location l)
+    | Astmt -> Astmt
+    | Aexpr -> Aexpr
 
   let toCoq_basicType: basicType -> CoqCtype.basicType = function
     | Integer ity -> Integer (toCoq_integerType ity)
@@ -769,8 +769,8 @@ module CHERIMorello : Memory = struct
                                     (fromCoq_location l,
                                      fromCoq_Symbol_sym s,
                                      fromCoq_label_annot la)
-  | Astmt loc -> Astmt (fromCoq_location loc)
-  | Aexpr loc -> Aexpr (fromCoq_location loc)
+  | Astmt -> Astmt
+  | Aexpr -> Aexpr
 
   let fromCoq_basicType: CoqCtype.basicType -> basicType = function
     | Integer ity -> Integer (fromCoq_integerType ity)

--- a/ocaml_frontend/pprinters/pp_core.ml
+++ b/ocaml_frontend/pprinters/pp_core.ml
@@ -610,9 +610,9 @@ let rec pp_expr expr =
                   acc
             | Ainlined_label s ->
                 acc
-            | Astmt _ ->
+            | Astmt ->
                 acc
-            | Aexpr _ ->
+            | Aexpr ->
                 acc
         ) doc annot
     end


### PR DESCRIPTION
These commits refactor the annotations related to locations and then output of that information in mucore pretty-printing to make it easier to see and debug locations.