### PR TITLE
CN: allow running CN on header files

### DIFF
--- a/backend/cn/main.ml
+++ b/backend/cn/main.ml
@@ -107,8 +107,10 @@ let opt_comma_split = function
 let check_input_file filename =
   if not (Sys.file_exists filename) then
     CF.Pp_errors.fatal ("file \""^filename^"\" does not exist")
-  else if not (String.equal (Filename.extension filename) ".c") then
-    CF.Pp_errors.fatal ("file \""^filename^"\" has wrong file extension")
+  else
+    let ext = String.equal (Filename.extension filename) in
+    if not (ext ".c" || ext ".h") then
+      CF.Pp_errors.fatal ("file \""^filename^"\" has wrong file extension")
 
 
 


### PR DESCRIPTION
Headers may contain CN specs, and although CN can't check them against particular implementations, it can still report some warnings/errors, e.g. about well-formedness.