### PR TITLE
[CN-Test-Gen] Add CLI flag for test generation

### DIFF
--- a/backend/cn/testGeneration.ml
+++ b/backend/cn/testGeneration.ml
@@ -1,0 +1,3 @@
+module CF = Cerb_frontend
+
+let main _output_dir _sigma _prog5 : unit = ()

--- a/backend/cn/testGeneration.mli
+++ b/backend/cn/testGeneration.mli
@@ -1,0 +1,7 @@
+module CF = Cerb_frontend
+
+val main
+  :  string
+  -> CF.GenTypes.genTypeCategory CF.AilSyntax.sigma
+  -> unit Mucore.mu_file
+  -> unit


### PR DESCRIPTION
I'd like to avoid conflicts every time `main.ml` changes, so this PR just adds the code that will call test generation.