### PR TITLE
CN + Exec: Run spec checks before decoration

### DIFF
--- a/backend/cn/main.ml
+++ b/backend/cn/main.ml
@@ -125,13 +125,6 @@ let check_input_file filename =
     if not (ext ".c" || ext ".h") then
       CF.Pp_errors.fatal ("file \""^filename^"\" has wrong file extension")
 
-let _maybe_executable_check ~with_ownership_checking ~filename ?output_filename ?output_dir ail_prog mu_file statement_locs =
-  Option.iter (fun output_filename ->
-      Cerb_colour.without_colour (fun () ->
-          Executable_spec.main ~with_ownership_checking filename ail_prog output_dir output_filename mu_file statement_locs)
-        ())
-    output_filename
-
 let main
       filename
       macros
@@ -208,11 +201,11 @@ let main
       let open Resultat in
       let@ prog5 = Core_to_mucore.normalise_file ~inherit_loc:(not(no_inherit_loc)) (markers_env, snd ail_prog) prog4 in
       print_log_file ("mucore", MUCORE prog5);
+      let paused = Typing.run_to_pause Context.empty (Check.check_decls_lemmata_fun_specs prog5) in
+      Result.iter_error handle_error (Typing.pause_to_result paused);
       begin match output_decorated with
-      | None -> 
-          let paused = Typing.run_to_pause Context.empty (Check.check_decls_lemmata_fun_specs prog5) in
-          Result.iter_error handle_error (Typing.pause_to_result paused);
-          Typing.run_from_pause (fun paused -> Check.check paused lemmata) paused
+      | None ->
+        Typing.run_from_pause (fun paused -> Check.check paused lemmata) paused
       | Some output_filename ->
           Cerb_colour.without_colour begin fun () ->
             Executable_spec.main ~with_ownership_checking filename ail_prog output_decorated_dir output_filename prog5 statement_locs;


### PR DESCRIPTION
Commit a18c9da798d6d6ea7b89813c7fa1faef050e0fc0 implemented this with a bug: the proof was running even after decoration. Hence, it was reverted in 2cbe6f3b989ddb4cc048f5ed39f79710dba437d8.

This commit should implement the behaviour correctly now. However, for a more robust solution, we should look into refactoring using subcommands.