### PR TITLE
CN: Use Base.List library instead of hand-rolling

### DIFF
--- a/backend/cn/argumentTypes.ml
+++ b/backend/cn/argumentTypes.ml
@@ -17,7 +17,7 @@ let mComputational (name, bound, info) t =
   Computational ((name, bound), info, t)
 
 let mComputationals t =
-  List.fold_right mComputational t
+  List.Old.fold_right mComputational t
 
 
 let rec subst i_subst (substitution: _ Subst.t) at =

--- a/backend/cn/baseTypes.ml
+++ b/backend/cn/baseTypes.ml
@@ -225,7 +225,7 @@ let normalise_to_range_bt bt z = match is_bits_bt bt with
   | _ -> failwith ("normalise_to_range: not bits type: " ^ Pp.plain (pp bt))
 
 let pick_integer_encoding_type z = match
-    List.Old.find_opt (fun k -> fits_range k z)
+    List.find ~f:(fun k -> fits_range k z)
         [(Signed, 32); (Unsigned, 64); (Signed, 64); (Unsigned, 128); (Signed, 128)]
   with
   | Some (sign, sz) -> Some (Bits (sign, sz))

--- a/backend/cn/baseTypes.ml
+++ b/backend/cn/baseTypes.ml
@@ -90,7 +90,7 @@ let rec contained : t -> t list =
   | Tuple bts -> bts @ containeds bts
   | Set bt -> bt :: contained bt
 
-and containeds bts = List.Old.concat_map contained bts
+and containeds bts = List.concat_map ~f:contained bts
 
 
 

--- a/backend/cn/baseTypes.ml
+++ b/backend/cn/baseTypes.ml
@@ -84,13 +84,13 @@ let rec contained : t -> t list =
   | CType -> []
   | Struct _ -> []
   | Datatype _ -> []
-  | Record ms -> let mts = List.map snd ms in mts @ containeds mts
+  | Record ms -> let mts = List.Old.map snd ms in mts @ containeds mts
   | Map (abt,rbt) -> abt :: rbt :: containeds [abt; rbt]
   | List bt -> bt :: contained bt
   | Tuple bts -> bts @ containeds bts
   | Set bt -> bt :: contained bt
 
-and containeds bts = List.concat_map contained bts
+and containeds bts = List.Old.concat_map contained bts
 
 
 
@@ -225,7 +225,7 @@ let normalise_to_range_bt bt z = match is_bits_bt bt with
   | _ -> failwith ("normalise_to_range: not bits type: " ^ Pp.plain (pp bt))
 
 let pick_integer_encoding_type z = match
-    List.find_opt (fun k -> fits_range k z)
+    List.Old.find_opt (fun k -> fits_range k z)
         [(Signed, 32); (Unsigned, 64); (Signed, 64); (Unsigned, 128); (Signed, 128)]
   with
   | Some (sign, sz) -> Some (Bits (sign, sz))

--- a/backend/cn/baseTypes.ml
+++ b/backend/cn/baseTypes.ml
@@ -84,7 +84,7 @@ let rec contained : t -> t list =
   | CType -> []
   | Struct _ -> []
   | Datatype _ -> []
-  | Record ms -> let mts = List.Old.map snd ms in mts @ containeds mts
+  | Record ms -> let mts = List.map ~f:snd ms in mts @ containeds mts
   | Map (abt,rbt) -> abt :: rbt :: containeds [abt; rbt]
   | List bt -> bt :: contained bt
   | Tuple bts -> bts @ containeds bts

--- a/backend/cn/builtins.ml
+++ b/backend/cn/builtins.ml
@@ -198,4 +198,4 @@ let apply_builtin_funs fsym args loc =
     return (Some t)
 
 let cn_builtin_fun_names =
-  List.Old.map (fun (str,sym,_) -> (str, sym)) builtin_funs
+  List.map ~f:(fun (str,sym,_) -> (str, sym)) builtin_funs

--- a/backend/cn/builtins.ml
+++ b/backend/cn/builtins.ml
@@ -191,7 +191,7 @@ let builtin_funs = max_min_bits @ [
 ]
 
 let apply_builtin_funs fsym args loc =
-  match List.Old.find_opt (fun (_, fsym', _) -> Sym.equal fsym fsym') builtin_funs with
+  match List.find ~f:(fun (_, fsym', _) -> Sym.equal fsym fsym') builtin_funs with
   | None -> return None
   | Some (_, _, mk) ->
     let@ t = mk args loc in

--- a/backend/cn/builtins.ml
+++ b/backend/cn/builtins.ml
@@ -9,28 +9,28 @@ open IndexTerms
 (* builtin function symbols *)
 let mk_arg0 mk args loc = match args with
   | [] -> return (mk loc)
-  | _ :: _ as xs -> fail {loc; msg = Number_arguments {has = List.Old.length xs; expect = 0}}
+  | _ :: _ as xs -> fail {loc; msg = Number_arguments {has = List.length xs; expect = 0}}
 
 let mk_arg1 mk args loc = match args with
   | [x] -> return (mk x loc)
-  | xs -> fail {loc; msg = Number_arguments {has = List.Old.length xs; expect = 1}}
+  | xs -> fail {loc; msg = Number_arguments {has = List.length xs; expect = 1}}
 
 let mk_arg2_err mk args loc = match args with
   | [x; y] -> mk (x, y) loc
-  | xs -> fail {loc; msg = Number_arguments {has = List.Old.length xs; expect = 2}}
+  | xs -> fail {loc; msg = Number_arguments {has = List.length xs; expect = 2}}
 
 let mk_arg2 mk = mk_arg2_err (fun tup loc-> return (mk tup loc))
 
 let mk_arg3_err mk args loc = match args with
   | [x; y; z] -> mk (x, y, z) loc
-  | xs -> fail {loc; msg = Number_arguments {has = List.Old.length xs; expect = 3}}
+  | xs -> fail {loc; msg = Number_arguments {has = List.length xs; expect = 3}}
 
 let mk_arg3 mk = mk_arg3_err (fun tup loc -> return (mk tup loc))
 
 
 let mk_arg5 mk args loc = match args with
   | [a;b;c;d;e] -> return (mk (a,b,c,d,e) loc)
-  | xs -> fail {loc; msg = Number_arguments {has = List.Old.length xs; expect = 5}}
+  | xs -> fail {loc; msg = Number_arguments {has = List.length xs; expect = 5}}
 
 
 let min_bits_def (sign, n) =

--- a/backend/cn/builtins.ml
+++ b/backend/cn/builtins.ml
@@ -9,28 +9,28 @@ open IndexTerms
 (* builtin function symbols *)
 let mk_arg0 mk args loc = match args with
   | [] -> return (mk loc)
-  | _ :: _ as xs -> fail {loc; msg = Number_arguments {has = List.length xs; expect = 0}}
+  | _ :: _ as xs -> fail {loc; msg = Number_arguments {has = List.Old.length xs; expect = 0}}
 
 let mk_arg1 mk args loc = match args with
   | [x] -> return (mk x loc)
-  | xs -> fail {loc; msg = Number_arguments {has = List.length xs; expect = 1}}
+  | xs -> fail {loc; msg = Number_arguments {has = List.Old.length xs; expect = 1}}
 
 let mk_arg2_err mk args loc = match args with
   | [x; y] -> mk (x, y) loc
-  | xs -> fail {loc; msg = Number_arguments {has = List.length xs; expect = 2}}
+  | xs -> fail {loc; msg = Number_arguments {has = List.Old.length xs; expect = 2}}
 
 let mk_arg2 mk = mk_arg2_err (fun tup loc-> return (mk tup loc))
 
 let mk_arg3_err mk args loc = match args with
   | [x; y; z] -> mk (x, y, z) loc
-  | xs -> fail {loc; msg = Number_arguments {has = List.length xs; expect = 3}}
+  | xs -> fail {loc; msg = Number_arguments {has = List.Old.length xs; expect = 3}}
 
 let mk_arg3 mk = mk_arg3_err (fun tup loc -> return (mk tup loc))
 
 
 let mk_arg5 mk args loc = match args with
   | [a;b;c;d;e] -> return (mk (a,b,c,d,e) loc)
-  | xs -> fail {loc; msg = Number_arguments {has = List.length xs; expect = 5}}
+  | xs -> fail {loc; msg = Number_arguments {has = List.Old.length xs; expect = 5}}
 
 
 let min_bits_def (sign, n) =
@@ -144,9 +144,9 @@ let addr_eq_def =
 let max_min_bits =
   let sizes = [8; 16; 32; 64] in
   let signs = [BT.Unsigned; Signed] in
-  List.fold_left
+  List.Old.fold_left
     (fun acc sign ->
-      List.fold_left
+      List.Old.fold_left
         (fun acc size -> max_bits_def (sign, size) :: min_bits_def (sign, size) :: acc)
         acc
         sizes)
@@ -191,11 +191,11 @@ let builtin_funs = max_min_bits @ [
 ]
 
 let apply_builtin_funs fsym args loc =
-  match List.find_opt (fun (_, fsym', _) -> Sym.equal fsym fsym') builtin_funs with
+  match List.Old.find_opt (fun (_, fsym', _) -> Sym.equal fsym fsym') builtin_funs with
   | None -> return None
   | Some (_, _, mk) ->
     let@ t = mk args loc in
     return (Some t)
 
 let cn_builtin_fun_names =
-  List.map (fun (str,sym,_) -> (str, sym)) builtin_funs
+  List.Old.map (fun (str,sym,_) -> (str, sym)) builtin_funs

--- a/backend/cn/cLogicalFuns.ml
+++ b/backend/cn/cLogicalFuns.ml
@@ -130,7 +130,7 @@ let rec add_pattern p v var_map =
       fail_n {loc; msg = Generic (Pp.item "getting expr from C syntax: cannot tuple-split val"
         (Pp.typ (IT.pp it) (Pp_mucore.Basic.pp_pattern p)))}
     end in
-    assert (List.Old.length vs == List.Old.length ps);
+    assert (List.length vs == List.length ps);
     ListM.fold_rightM (fun (p, v) var_map -> add_pattern p v var_map)
       (List.Old.combine ps vs) var_map
   | _ ->
@@ -383,7 +383,7 @@ let rec symb_exec_mu_expr ctxt state_vars expr =
     let@ arg_vs = ListM.mapM (symb_exec_mu_pexpr ctxt var_map) args in
     begin match Pmap.lookup sym ctxt.label_defs with
     | Some (M_Return _) ->
-      assert (List.Old.length args == 1);
+      assert (List.length args == 1);
       return (Call_Ret (List.Old.hd arg_vs))
     | _ ->
        fail_n {loc; msg = Generic Pp.(!^"function has goto-labels in control-flow")}

--- a/backend/cn/cLogicalFuns.ml
+++ b/backend/cn/cLogicalFuns.ml
@@ -436,7 +436,7 @@ let rec symb_exec_mu_expr ctxt state_vars expr =
       let wrap_int x = IT.wrapI_ (signed_int_ity, x) in
       if String.equal s "ctz_proxy"
       then rcval (wrap_int (IT.arith_unop Terms.BWCTZNoSMT (List.hd_exn args_its) loc) loc) state
-      else if List.Old.exists (String.equal s) ["ffs_proxy"; "ffsl_proxy"; "ffsll_proxy"]
+      else if List.exists ~f:(String.equal s) ["ffs_proxy"; "ffsl_proxy"; "ffsll_proxy"]
       then rcval (wrap_int (IT.arith_unop Terms.BWFFSNoSMT (List.hd_exn args_its) loc) loc) state
       else failwith ("unknown stdlib function: " ^ s)
     end else fail_fun_it "not a function with a pure/logical interpretation"

--- a/backend/cn/cLogicalFuns.ml
+++ b/backend/cn/cLogicalFuns.ml
@@ -132,7 +132,7 @@ let rec add_pattern p v var_map =
     end in
     assert (List.length vs == List.length ps);
     ListM.fold_rightM (fun (p, v) var_map -> add_pattern p v var_map)
-      (List.Old.combine ps vs) var_map
+      (List.zip_exn ps vs) var_map
   | _ ->
     fail_n {loc; msg = Generic (Pp.item "getting expr from C syntax: unsupported pattern"
         (Pp_mucore.Basic.pp_pattern p))}

--- a/backend/cn/cLogicalFuns.ml
+++ b/backend/cn/cLogicalFuns.ml
@@ -458,7 +458,7 @@ let rec filter_syms ss p =
   | M_CaseBase (None, _) -> p
   | M_CaseCtor (M_Ctuple, ps) ->
     let ps = List.map ~f:(filter_syms ss) ps in
-    if List.Old.for_all is_wild_pat ps
+    if List.for_all ~f:is_wild_pat ps
     then mk (M_CaseBase (None, CF.Core.BTy_unit))
     else mk (M_CaseCtor (M_Ctuple, ps))
   | _ -> p

--- a/backend/cn/cLogicalFuns.ml
+++ b/backend/cn/cLogicalFuns.ml
@@ -364,7 +364,7 @@ let rec symb_exec_mu_expr ctxt state_vars expr =
   | M_Eunseq exps ->
     let orig_expr = expr in
     let rec cont1 state exp_vals = function
-      | [] -> rcval (IT.tuple_ (List.Old.rev exp_vals) loc) state
+      | [] -> rcval (IT.tuple_ (List.rev exp_vals) loc) state
       | (exp :: exps) ->
         let@ r = symb_exec_mu_expr ctxt (state, var_map) exp in
         cont2 exp_vals exps r

--- a/backend/cn/cLogicalFuns.ml
+++ b/backend/cn/cLogicalFuns.ml
@@ -384,7 +384,7 @@ let rec symb_exec_mu_expr ctxt state_vars expr =
     begin match Pmap.lookup sym ctxt.label_defs with
     | Some (M_Return _) ->
       assert (List.length args == 1);
-      return (Call_Ret (List.Old.hd arg_vs))
+      return (Call_Ret (List.hd_exn arg_vs))
     | _ ->
        fail_n {loc; msg = Generic Pp.(!^"function has goto-labels in control-flow")}
     end
@@ -435,9 +435,9 @@ let rec symb_exec_mu_expr ctxt state_vars expr =
       let s = Option.get (Sym.has_id nm) in
       let wrap_int x = IT.wrapI_ (signed_int_ity, x) in
       if String.equal s "ctz_proxy"
-      then rcval (wrap_int (IT.arith_unop Terms.BWCTZNoSMT (List.Old.hd args_its) loc) loc) state
+      then rcval (wrap_int (IT.arith_unop Terms.BWCTZNoSMT (List.hd_exn args_its) loc) loc) state
       else if List.Old.exists (String.equal s) ["ffs_proxy"; "ffsl_proxy"; "ffsll_proxy"]
-      then rcval (wrap_int (IT.arith_unop Terms.BWFFSNoSMT (List.Old.hd args_its) loc) loc) state
+      then rcval (wrap_int (IT.arith_unop Terms.BWFFSNoSMT (List.hd_exn args_its) loc) loc) state
       else failwith ("unknown stdlib function: " ^ s)
     end else fail_fun_it "not a function with a pure/logical interpretation"
   | M_CN_progs _ ->

--- a/backend/cn/cLogicalFuns.ml
+++ b/backend/cn/cLogicalFuns.ml
@@ -457,7 +457,7 @@ let rec filter_syms ss p =
     if SymSet.mem s ss then p else mk (M_CaseBase (None, bt))
   | M_CaseBase (None, _) -> p
   | M_CaseCtor (M_Ctuple, ps) ->
-    let ps = List.Old.map (filter_syms ss) ps in
+    let ps = List.map ~f:(filter_syms ss) ps in
     if List.Old.for_all is_wild_pat ps
     then mk (M_CaseBase (None, CF.Core.BTy_unit))
     else mk (M_CaseCtor (M_Ctuple, ps))
@@ -485,7 +485,7 @@ let c_fun_to_it id_loc glob_context (id : Sym.t) fsym def
   let here = Locations.other __FUNCTION__ in
   let def_args = def.LogicalFunctions.args
     (* TODO - add location information to binders *)
-    |> List.Old.map (fun (s, bt) -> IndexTerms.sym_ (s, bt, here)) in
+    |> List.map ~f:(fun (s, bt) -> IndexTerms.sym_ (s, bt, here)) in
   Pp.debug 3 (lazy (Pp.item "cn_function converting C function to logical"
     (Pp.infix_arrow (Sym.pp fsym) (Sym.pp id))));
   match fn with

--- a/backend/cn/cStatements.ml
+++ b/backend/cn/cStatements.ml
@@ -19,7 +19,7 @@ let to_pre_cmp = function
   | Cerb_location.Loc_point p -> (2, [lex_to_cmp p], [])
   | Cerb_location.Loc_region (x, y, _) -> (3, [lex_to_cmp x; lex_to_cmp y], [])
   | Cerb_location.Loc_regions (xs, _) -> (4,
-        List.Old.map lex_to_cmp (List.Old.concat (List.Old.map (fun (x, y) -> [x; y]) xs)), [])
+        List.map ~f:lex_to_cmp (List.Old.concat (List.map ~f:(fun (x, y) -> [x; y]) xs)), [])
 
 let mk_cmp (x : t) = to_pre_cmp x
 
@@ -57,7 +57,7 @@ let expr_locs (expr : 'a expression) =
     | AilEcast (_, _, x) -> f ls (x :: exprs)
     | AilEcall (f_x, xs) -> f ls (f_x :: xs @ exprs)
     | AilEassert x -> f ls (x :: exprs)
-    | AilEgeneric (x, xs) -> f ls (x :: List.Old.map gen_expr xs @ exprs)
+    | AilEgeneric (x, xs) -> f ls (x :: List.map ~f:gen_expr xs @ exprs)
     | AilEarray (_, _, xs) -> f ls (List.Old.filter_map (fun x -> x) xs @ exprs)
     | AilEstruct (_, xs) -> f ls (List.Old.filter_map snd xs @ exprs)
     | AilEunion (_, _, opt_x) -> f ls (Option.to_list opt_x @ exprs)

--- a/backend/cn/cStatements.ml
+++ b/backend/cn/cStatements.ml
@@ -58,8 +58,8 @@ let expr_locs (expr : 'a expression) =
     | AilEcall (f_x, xs) -> f ls (f_x :: xs @ exprs)
     | AilEassert x -> f ls (x :: exprs)
     | AilEgeneric (x, xs) -> f ls (x :: List.map ~f:gen_expr xs @ exprs)
-    | AilEarray (_, _, xs) -> f ls (List.Old.filter_map (fun x -> x) xs @ exprs)
-    | AilEstruct (_, xs) -> f ls (List.Old.filter_map snd xs @ exprs)
+    | AilEarray (_, _, xs) -> f ls (List.filter_map ~f:(fun x -> x) xs @ exprs)
+    | AilEstruct (_, xs) -> f ls (List.filter_map ~f:snd xs @ exprs)
     | AilEunion (_, _, opt_x) -> f ls (Option.to_list opt_x @ exprs)
     | AilEcompound (_, _, x) -> f ls (x :: exprs)
     | AilEmemberof (x, _) -> f ls (x :: exprs)
@@ -101,7 +101,7 @@ let add_map_stmt (stmt : 'a statement) m =
     | AilSpar ss2 -> f (ss2 @ ss) m
     | AilSexpr e -> f ss (do_x l m e)
     | AilSreturn e -> f ss (do_x l m e)
-    | AilSdeclaration xs -> f ss (do_xs l m (List.Old.filter_map snd xs))
+    | AilSdeclaration xs -> f ss (do_xs l m (List.filter_map ~f:snd xs))
     | AilSreg_store (_, x) -> f ss (do_x l m x)
     | _ -> f ss m
     end

--- a/backend/cn/cStatements.ml
+++ b/backend/cn/cStatements.ml
@@ -19,7 +19,7 @@ let to_pre_cmp = function
   | Cerb_location.Loc_point p -> (2, [lex_to_cmp p], [])
   | Cerb_location.Loc_region (x, y, _) -> (3, [lex_to_cmp x; lex_to_cmp y], [])
   | Cerb_location.Loc_regions (xs, _) -> (4,
-        List.map lex_to_cmp (List.concat (List.map (fun (x, y) -> [x; y]) xs)), [])
+        List.Old.map lex_to_cmp (List.Old.concat (List.Old.map (fun (x, y) -> [x; y]) xs)), [])
 
 let mk_cmp (x : t) = to_pre_cmp x
 
@@ -57,9 +57,9 @@ let expr_locs (expr : 'a expression) =
     | AilEcast (_, _, x) -> f ls (x :: exprs)
     | AilEcall (f_x, xs) -> f ls (f_x :: xs @ exprs)
     | AilEassert x -> f ls (x :: exprs)
-    | AilEgeneric (x, xs) -> f ls (x :: List.map gen_expr xs @ exprs)
-    | AilEarray (_, _, xs) -> f ls (List.filter_map (fun x -> x) xs @ exprs)
-    | AilEstruct (_, xs) -> f ls (List.filter_map snd xs @ exprs)
+    | AilEgeneric (x, xs) -> f ls (x :: List.Old.map gen_expr xs @ exprs)
+    | AilEarray (_, _, xs) -> f ls (List.Old.filter_map (fun x -> x) xs @ exprs)
+    | AilEstruct (_, xs) -> f ls (List.Old.filter_map snd xs @ exprs)
     | AilEunion (_, _, opt_x) -> f ls (Option.to_list opt_x @ exprs)
     | AilEcompound (_, _, x) -> f ls (x :: exprs)
     | AilEmemberof (x, _) -> f ls (x :: exprs)
@@ -83,8 +83,8 @@ let add_map_stmt (stmt : 'a statement) m =
   let map stmt_loc m expr_loc = if LocMap.mem expr_loc m
     then m else LocMap.add expr_loc stmt_loc m
   in
-  let do_x stmt_loc m expr = List.fold_left (map stmt_loc) m (expr_locs expr) in
-  let do_xs stmt_loc m exprs = List.fold_left (do_x stmt_loc) m exprs in
+  let do_x stmt_loc m expr = List.Old.fold_left (map stmt_loc) m (expr_locs expr) in
+  let do_xs stmt_loc m exprs = List.Old.fold_left (do_x stmt_loc) m exprs in
   let rec f stmts m = match stmts with
     | [] -> m
     | (AnnotatedStatement (l, _, x) :: ss) ->
@@ -101,7 +101,7 @@ let add_map_stmt (stmt : 'a statement) m =
     | AilSpar ss2 -> f (ss2 @ ss) m
     | AilSexpr e -> f ss (do_x l m e)
     | AilSreturn e -> f ss (do_x l m e)
-    | AilSdeclaration xs -> f ss (do_xs l m (List.filter_map snd xs))
+    | AilSdeclaration xs -> f ss (do_xs l m (List.Old.filter_map snd xs))
     | AilSreg_store (_, x) -> f ss (do_x l m x)
     | _ -> f ss m
     end
@@ -109,7 +109,7 @@ let add_map_stmt (stmt : 'a statement) m =
   f [stmt] m
 
 let search (sigma : 'a sigma) =
-  List.fold_right (fun (_, (_, _, _, _, stmt)) m -> add_map_stmt stmt m)
+  List.Old.fold_right (fun (_, (_, _, _, _, stmt)) m -> add_map_stmt stmt m)
     sigma.function_definitions LocMap.empty
 
 

--- a/backend/cn/cStatements.ml
+++ b/backend/cn/cStatements.ml
@@ -19,7 +19,7 @@ let to_pre_cmp = function
   | Cerb_location.Loc_point p -> (2, [lex_to_cmp p], [])
   | Cerb_location.Loc_region (x, y, _) -> (3, [lex_to_cmp x; lex_to_cmp y], [])
   | Cerb_location.Loc_regions (xs, _) -> (4,
-        List.map ~f:lex_to_cmp (List.Old.concat (List.map ~f:(fun (x, y) -> [x; y]) xs)), [])
+        List.map ~f:lex_to_cmp (List.concat (List.map ~f:(fun (x, y) -> [x; y]) xs)), [])
 
 let mk_cmp (x : t) = to_pre_cmp x
 

--- a/backend/cn/check.ml
+++ b/backend/cn/check.ml
@@ -1901,7 +1901,7 @@ let check_c_functions funs =
       []
     | ss -> ss
   in
-  let strs_fsyms ss = SymSet.of_list (List.Old.concat_map str_fsyms ss) in
+  let strs_fsyms ss = SymSet.of_list (List.concat_map ~f:str_fsyms ss) in
   let skip = strs_fsyms (fst (! skip_and_only)) in
   let only = strs_fsyms (snd (! skip_and_only)) in
   let only_funs = match (snd (! skip_and_only)) with
@@ -2014,7 +2014,7 @@ let record_and_check_datatypes datatypes =
       let@ () =
         add_datatype s {
             dt_constrs = List.map ~f:fst cases;
-            dt_all_params = List.Old.concat_map snd cases
+            dt_all_params = List.concat_map ~f:snd cases
           }
       in
       ListM.iterM (fun (c,c_params) ->

--- a/backend/cn/check.ml
+++ b/backend/cn/check.ml
@@ -1258,7 +1258,7 @@ let rec check_expr labels (e : BT.t mu_expr) (k: IT.t -> unit m) : unit m =
         check_pexpr pe (fun arg ->
         let ret_s, ret = match prefix with
           | PrefSource (_loc, syms) ->
-             let syms = List.Old.rev syms in
+             let syms = List.rev syms in
              begin match syms with
              | (Symbol (_, _, SD_ObjectAddress str)) :: _ ->
                 IT.fresh_named Loc ("&" ^ str) loc
@@ -1451,7 +1451,7 @@ let rec check_expr labels (e : BT.t mu_expr) (k: IT.t -> unit m) : unit m =
           aux es' (v :: vs) (used :: prev_used))
        | [] ->
           (* let@ () = check_used_distinct loc prev_used in *)
-          k (tuple_ (List.Old.rev vs) loc)
+          k (tuple_ (List.rev vs) loc)
      in
      aux es [] []
   | M_CN_progs (_, cn_progs) ->

--- a/backend/cn/check.ml
+++ b/backend/cn/check.ml
@@ -1027,7 +1027,7 @@ let instantiate loc filter arg =
   let@ () = add_l arg_s (IT.bt arg_it) (loc, lazy (Sym.pp arg_s)) in
   let@ () = add_c loc (LC.t_ (eq__ arg_it arg loc)) in
   let@ constraints = get_cs () in
-  let extra_assumptions1 = List.Old.filter_map (function
+  let extra_assumptions1 = List.filter_map ~f:(function
         | Forall ((s, bt), t) when filter t -> Some ((s, bt), t)
         | _ -> None) (LCSet.elements constraints) in
   let extra_assumptions2, type_mismatch = List.Old.partition (fun ((_, bt), _) ->
@@ -1048,9 +1048,9 @@ let add_trace_information _labels annots =
   let open Where in
   let open CF.Annot in
   let inlined_labels =
-    List.Old.filter_map (function Ainlined_label l -> Some l | _ -> None) annots in
+    List.filter_map ~f:(function Ainlined_label l -> Some l | _ -> None) annots in
   let locs =
-    List.Old.filter_map (function Aloc l -> Some l | _ -> None) annots in
+    List.filter_map ~f:(function Aloc l -> Some l | _ -> None) annots in
   let is_stmt = List.Old.exists (function Astmt -> true | _ -> false) annots in
   let is_expr = List.Old.exists (function Aexpr -> true | _ -> false) annots in
   let@ () = match inlined_labels with

--- a/backend/cn/check.ml
+++ b/backend/cn/check.ml
@@ -967,7 +967,7 @@ let compute_used loc (prev_rs, prev_ix) (post_rs, _) =
   let post_ixs = IntSet.of_list (List.map ~f:snd post_rs) in
   (* restore previous resources that have disappeared from the context, since they
      might participate in a race *)
-  let all_rs = post_rs @ List.Old.filter (fun (_, i) -> not (IntSet.mem i post_ixs)) prev_rs in
+  let all_rs = post_rs @ List.filter ~f:(fun (_, i) -> not (IntSet.mem i post_ixs)) prev_rs in
   ListM.fold_leftM (fun (rs, ws) (r, i) ->
     let@ h = res_history loc i in
     if h.last_written_id >= prev_ix
@@ -1895,7 +1895,7 @@ let wf_check_and_record_functions mu_funs mu_call_sigs =
 
 let check_c_functions funs =
   let matches_str s fsym = String.equal s (Sym.pp_string fsym) in
-  let str_fsyms s = match List.Old.filter (matches_str s) (List.map ~f:fst funs) with
+  let str_fsyms s = match List.filter ~f:(matches_str s) (List.map ~f:fst funs) with
     | [] ->
       Pp.warn_noloc (!^"function" ^^^ !^s ^^^ !^"not found");
       []
@@ -1906,9 +1906,9 @@ let check_c_functions funs =
   let only = strs_fsyms (snd (! skip_and_only)) in
   let only_funs = match (snd (! skip_and_only)) with
     | [] -> funs
-    | _ss -> List.Old.filter (fun (fsym, _) -> SymSet.mem fsym only) funs
+    | _ss -> List.filter ~f:(fun (fsym, _) -> SymSet.mem fsym only) funs
   in
-  let selected_funs = List.Old.filter (fun (fsym, _) -> not (SymSet.mem fsym skip)) only_funs in
+  let selected_funs = List.filter ~f:(fun (fsym, _) -> not (SymSet.mem fsym skip)) only_funs in
   let number_entries = List.length selected_funs in
   match !batch with
   | false ->

--- a/backend/cn/check.ml
+++ b/backend/cn/check.ml
@@ -177,7 +177,7 @@ and check_struct (loc : loc)
                  (member_values : (Id.t * Sctypes.t * mem_value) list) : IT.t m =
   let@ layout = get_struct_decl loc tag in
   let member_types = Memory.member_types layout in
-  assert (List.Old.for_all2 (fun (id,ct) (id',ct',_mv') -> Id.equal id id' && Sctypes.equal ct ct')
+  assert (List.for_all2_exn ~f:(fun (id,ct) (id',ct',_mv') -> Id.equal id id' && Sctypes.equal ct ct')
             member_types member_values);
   let@ member_its =
     ListM.mapM (fun (member, sct, mv) ->

--- a/backend/cn/check.ml
+++ b/backend/cn/check.ml
@@ -84,7 +84,7 @@ let rec check_and_match_pattern (M_Pattern (loc, _, bty, pattern)) it =
                check_and_match_pattern p ith
              ) pats
          in
-         return (List.Old.concat all_as)
+         return (List.concat all_as)
       | M_Carray, _ ->
          Cerb_debug.error "todo: array patterns"
       | _ ->
@@ -994,7 +994,7 @@ let _check_used_distinct loc used =
           (RE.pp r ^^^ break 1 ^^^ render_upd h ^^^ break 1 ^^^ render_upd h2))})
     end
   in
-  let@ w_map = check_ws IntMap.empty (List.Old.concat (List.map ~f:snd used)) in
+  let@ w_map = check_ws IntMap.empty (List.concat (List.map ~f:snd used)) in
   let check_rd (r, h, i) = match IntMap.find_opt i w_map with
     | None -> return ()
     | Some h2 ->
@@ -1002,7 +1002,7 @@ let _check_used_distinct loc used =
       fail (fun _ -> {loc; msg = Generic (Pp.item "undefined behaviour: concurrent read & update"
         (RE.pp r ^^^ break 1 ^^^ render_read h ^^^ break 1 ^^^ render_upd h2))})
   in
-  ListM.iterM check_rd (List.Old.concat (List.map ~f:fst used))
+  ListM.iterM check_rd (List.concat (List.map ~f:fst used))
 
 (*type labels = (AT.lt * label_kind) SymMap.t*)
 

--- a/backend/cn/check.ml
+++ b/backend/cn/check.ml
@@ -256,7 +256,7 @@ let rec check_value (loc : loc) (M_V (expect,v)) : IT.t m =
      let@ _ = get_fun_decl loc sym in
      return (IT.sym_ (sym, Loc, loc))
   | M_Vlist (_item_cbt, vals) ->
-     let item_bt = bt_of_value (List.Old.hd vals) in
+     let item_bt = bt_of_value (List.hd_exn vals) in
      let@ () = WellTyped.ensure_base_type loc ~expect (List item_bt) in
      let@ () = ListM.iterM (fun i -> ensure_base_type loc ~expect:item_bt (bt_of_value i)) vals in
      let@ values = ListM.mapM (check_value loc) vals in

--- a/backend/cn/check.ml
+++ b/backend/cn/check.ml
@@ -467,7 +467,7 @@ let rec check_pexpr (pe : BT.t mu_pexpr) (k : IT.t -> unit m) : unit m =
         let@ () = check_against_core_bt loc (!^ "checking Cnil") item_cbt item_bt in
         k (nil_ ~item_bt loc)
      | M_Cnil _item_bt, _ ->
-        fail (fun _ -> {loc; msg = Number_arguments {has = List.Old.length pes; expect=0}})
+        fail (fun _ -> {loc; msg = Number_arguments {has = List.length pes; expect=0}})
      | M_Ccons, [pe1; pe2] ->
         let@ () = ensure_base_type loc ~expect (List (bt_of_pexpr pe1)) in
         let@ () = ensure_base_type loc ~expect (bt_of_pexpr pe2) in
@@ -475,7 +475,7 @@ let rec check_pexpr (pe : BT.t mu_pexpr) (k : IT.t -> unit m) : unit m =
         check_pexpr pe2 (fun vt2 ->
         k (cons_ (vt1, vt2) loc)))
      | M_Ccons, _ ->
-        fail (fun _ -> {loc; msg = Number_arguments {has = List.Old.length pes; expect = 2}})
+        fail (fun _ -> {loc; msg = Number_arguments {has = List.length pes; expect = 2}})
      end
   | M_PEbitwise_unop (unop, pe1) ->
      let@ _ = ensure_bitvector_type loc ~expect in
@@ -591,8 +591,8 @@ let rec check_pexpr (pe : BT.t mu_pexpr) (k : IT.t -> unit m) : unit m =
      in
      let expect_args = Mucore.mu_fun_param_types fun_id in
      let@ () =
-       let has = List.Old.length args in
-       let expect = List.Old.length expect_args in
+       let has = List.length args in
+       let expect = List.length expect_args in
        if expect = has then return ()
        else fail (fun _ -> {loc; msg = Number_arguments {has; expect}})
      in
@@ -892,7 +892,7 @@ end = struct
            k ftyp
         | _ ->
            let expect = count_computational original_ftyp in
-           let has = List.Old.length original_args in
+           let has = List.length original_args in
            fail (fun _ -> {loc; msg = Number_arguments {expect; has}})
       in
       fun args ftyp k -> aux [] args ftyp k
@@ -1035,7 +1035,7 @@ let instantiate loc filter arg =
   let extra_assumptions = List.map ~f:(fun ((s, _), t) ->
         LC.t_ (IT.subst (IT.make_subst [(s, arg_it)]) t)) extra_assumptions2
   in
-  if List.Old.length extra_assumptions == 0 then Pp.warn loc (!^ "nothing instantiated")
+  if List.length extra_assumptions == 0 then Pp.warn loc (!^ "nothing instantiated")
   else ();
   List.Old.iteri (fun i ((_, bt), _) -> if i < 2
     then Pp.warn loc (!^ "did not instantiate on basetype mismatch:" ^^^
@@ -1511,7 +1511,7 @@ let rec check_expr labels (e : BT.t mu_expr) (k: IT.t -> unit m) : unit m =
                return ()
             | M_CN_unfold (f, args) ->
                let@ def = get_logical_function_def loc f in
-               let has_args, expect_args = List.Old.length args, List.Old.length def.args in
+               let has_args, expect_args = List.length args, List.length def.args in
                let@ () = WellTyped.ensure_same_argument_number loc `General has_args ~expect:expect_args in
                let@ args =
                  ListM.map2M (fun has_arg (_, def_arg_bt) ->
@@ -1791,7 +1791,7 @@ let record_and_check_logical_functions funs =
       ) funs
   in
 
-  let n_funs = List.Old.length funs in
+  let n_funs = List.length funs in
 
   (* Add all recursive functions (without their actual bodies), so that they
      can depend on themselves and each other. *)
@@ -1820,7 +1820,7 @@ let record_and_check_resource_predicates preds =
   in
   ListM.iteriM (fun i (name, def) ->
       debug 2 (lazy (headline ("checking welltypedness of resource pred" ^
-          Pp.of_total i (List.Old.length preds) ^ ": " ^ Sym.pp_string name)));
+          Pp.of_total i (List.length preds) ^ ": " ^ Sym.pp_string name)));
       let@ def = WellTyped.WRPD.welltyped def in
       (* add simplified def to the context *)
       add_resource_predicate name def
@@ -1860,7 +1860,7 @@ let register_fun_syms mu_file =
 
 
 let wf_check_and_record_functions mu_funs mu_call_sigs =
-  let n_syms = List.Old.length (Pmap.bindings_list mu_funs) in
+  let n_syms = List.length (Pmap.bindings_list mu_funs) in
   let welltyped_ping i fsym =
     debug 2 (lazy (headline ("checking welltypedness of procedure" ^
         Pp.of_total i n_syms ^ ": " ^ Sym.pp_string fsym)))
@@ -1909,7 +1909,7 @@ let check_c_functions funs =
     | _ss -> List.Old.filter (fun (fsym, _) -> SymSet.mem fsym only) funs
   in
   let selected_funs = List.Old.filter (fun (fsym, _) -> not (SymSet.mem fsym skip)) only_funs in
-  let number_entries = List.Old.length selected_funs in
+  let number_entries = List.length selected_funs in
   match !batch with
   | false ->
      let@ _ =

--- a/backend/cn/check.ml
+++ b/backend/cn/check.ml
@@ -289,7 +289,7 @@ let eq_value_with f expr = match f expr with
   | Some y -> return (Some (expr, y))
   | None -> begin
     let@ group = value_eq_group None expr in
-    match List.Old.find_opt (fun t -> Option.is_some (f t)) (EqTable.ITSet.elements group) with
+    match List.find ~f:(fun t -> Option.is_some (f t)) (EqTable.ITSet.elements group) with
     | Some x ->
       let y = Option.get (f x) in
       return (Some (x, y))

--- a/backend/cn/check.ml
+++ b/backend/cn/check.ml
@@ -1030,7 +1030,7 @@ let instantiate loc filter arg =
   let extra_assumptions1 = List.filter_map ~f:(function
         | Forall ((s, bt), t) when filter t -> Some ((s, bt), t)
         | _ -> None) (LCSet.elements constraints) in
-  let extra_assumptions2, type_mismatch = List.Old.partition (fun ((_, bt), _) ->
+  let extra_assumptions2, type_mismatch = List.partition_tf ~f:(fun ((_, bt), _) ->
         BT.equal bt (IT.bt arg_it)) extra_assumptions1 in
   let extra_assumptions = List.map ~f:(fun ((s, _), t) ->
         LC.t_ (IT.subst (IT.make_subst [(s, arg_it)]) t)) extra_assumptions2
@@ -1786,7 +1786,7 @@ let check_tagdefs tagDefs =
 let record_and_check_logical_functions funs =
 
   let recursive, _nonrecursive =
-    List.Old.partition (fun (_, def) ->
+    List.partition_tf ~f:(fun (_, def) ->
         LogicalFunctions.is_recursive def
       ) funs
   in

--- a/backend/cn/check.ml
+++ b/backend/cn/check.ml
@@ -617,7 +617,7 @@ let rec check_pexpr (pe : BT.t mu_pexpr) (k : IT.t -> unit m) : unit m =
          ) member_types xs
      in
      check_pexprs (List.map ~f:snd xs) (fun vs ->
-     let members = List.Old.map2 (fun (nm, _) v -> (nm, v)) xs vs in
+     let members = List.map2_exn ~f:(fun (nm, _) v -> (nm, v)) xs vs in
      k (struct_ (tag, members) loc))
   | M_PEunion _ ->
      Cerb_debug.error "todo: PEunion"

--- a/backend/cn/check.ml
+++ b/backend/cn/check.ml
@@ -1051,8 +1051,8 @@ let add_trace_information _labels annots =
     List.filter_map ~f:(function Ainlined_label l -> Some l | _ -> None) annots in
   let locs =
     List.filter_map ~f:(function Aloc l -> Some l | _ -> None) annots in
-  let is_stmt = List.Old.exists (function Astmt -> true | _ -> false) annots in
-  let is_expr = List.Old.exists (function Aexpr -> true | _ -> false) annots in
+  let is_stmt = List.exists ~f:(function Astmt -> true | _ -> false) annots in
+  let is_expr = List.exists ~f:(function Aexpr -> true | _ -> false) annots in
   let@ () = match inlined_labels with
     | [] -> return ()
     | [(lloc,_lsym,lannot)] ->
@@ -1500,8 +1500,8 @@ let rec check_expr labels (e : BT.t mu_expr) (k: IT.t -> unit m) : unit m =
                in
                let@ it = WellTyped.WIT.infer it in
                let@ (original_rs, _) = all_resources_tagged loc in
-               (* let verbose = List.Old.exists (Id.is_str "verbose") attrs in *)
-               let quiet = List.Old.exists (Id.is_str "quiet") attrs in
+               (* let verbose = List.exists ~f:(Id.is_str "verbose") attrs in *)
+               let quiet = List.exists ~f:(Id.is_str "quiet") attrs in
                let@ () = add_movable_index loc (predicate_name, it) in
                let@ (upd_rs, _) = all_resources_tagged loc in
                if (List.Old.equal Int.equal (List.map ~f:snd original_rs) (List.map ~f:snd upd_rs)

--- a/backend/cn/cn_internal_to_ail.ml
+++ b/backend/cn/cn_internal_to_ail.ml
@@ -70,12 +70,12 @@ let members_equal ms ms' =
   (if (List.length ms == 0) then true else (
   let (ids, cn_bts) = List.unzip  ms in
   let (ids', cn_bts') = List.unzip  ms' in
-  let ctypes_eq = List.Old.map2 (fun cn_bt cn_bt'->
+  let ctypes_eq = List.map2_exn ~f:(fun cn_bt cn_bt'->
     let bt = cn_base_type_to_bt cn_bt in
     let bt' = cn_base_type_to_bt cn_bt' in
     BT.equal bt bt') cn_bts cn_bts' in
   let ctypes_eq = List.Old.fold_left (&&) true ctypes_eq in
-  let ids_eq = List.Old.map2 Id.equal ids ids' in
+  let ids_eq = List.map2_exn ~f:Id.equal ids ids' in
   let ids_eq = List.Old.fold_left (&&) true ids_eq in
   ctypes_eq && ids_eq))
 

--- a/backend/cn/cn_internal_to_ail.ml
+++ b/backend/cn/cn_internal_to_ail.ml
@@ -1081,7 +1081,7 @@ let rec cn_to_ail_expr_aux_internal
                         | dt :: _ ->
                           let (b1, s1, e1) = cn_to_ail_expr_aux_internal const_prop pred_name dts globals term PassBack in
                           let build_case (constr_sym, members_with_types) = 
-                            let cases' = List.Old.filter_map (expand_datatype constr_sym) cases in 
+                            let cases' = List.filter_map ~f:(expand_datatype constr_sym) cases in 
                             let suffix = "_" ^ (string_of_int count) in
                             let lc_sym = generate_sym_with_suffix ~suffix:"" ~lowercase:true constr_sym in 
                             let count_sym = generate_sym_with_suffix ~suffix ~lowercase:true constr_sym in 

--- a/backend/cn/cn_internal_to_ail.ml
+++ b/backend/cn/cn_internal_to_ail.ml
@@ -1068,7 +1068,7 @@ let rec cn_to_ail_expr_aux_internal
               
               let cases = List.map ~f:(simplify_leading_variable term) cases in
 
-              if List.Old.for_all leading_wildcard cases then
+              if List.for_all ~f:leading_wildcard cases then
                 let cases = List.map ~f:(fun (ps, e) -> (List.Old.tl ps, e)) cases in
                 let (bindings', stats') = translate count vs cases in 
                 (bindings', stats')

--- a/backend/cn/cn_internal_to_ail.ml
+++ b/backend/cn/cn_internal_to_ail.ml
@@ -803,7 +803,7 @@ let rec cn_to_ail_expr_aux_internal
     let (b, s) = ([res_binding], [alloc_stat]) in
     
     let (bs, ss, assign_stats) = list_split_three (List.map ~f:generate_ail_stat ms) in
-    dest d (List.Old.concat bs @ b, List.Old.concat ss @ s @ assign_stats, mk_expr res_ident)
+    dest d (List.concat bs @ b, List.concat ss @ s @ assign_stats, mk_expr res_ident)
 
   | RecordMember (t, m) ->
     (* Currently assuming records only exist  *)
@@ -875,7 +875,7 @@ let rec cn_to_ail_expr_aux_internal
     let (b, s) = ([res_binding], [alloc_stat]) in
     
     let (bs, ss, assign_stats) = list_split_three (List.map ~f:generate_ail_stat ms) in
-    dest d (List.Old.concat bs @ b, List.Old.concat ss @ s @ assign_stats, mk_expr res_ident)
+    dest d (List.concat bs @ b, List.concat ss @ s @ assign_stats, mk_expr res_ident)
 
   | RecordUpdate ((t1, m), t2) -> failwith "TODO6"
 
@@ -924,7 +924,7 @@ let rec cn_to_ail_expr_aux_internal
     let tag_member_ptr = A.(AilEmemberofptr (mk_expr res_ident, Id.id "tag")) in
     let tag_assign = A.(AilSexpr (mk_expr (AilEassign (mk_expr tag_member_ptr, mk_expr (AilEident uc_constr_sym))))) in
 
-    dest d ((List.Old.concat bs) @ [res_binding], [ail_decl; tag_assign] @ (List.Old.concat ss) @ constr_allocation_stat @ assign_stats, mk_expr res_ident)
+    dest d ((List.concat bs) @ [res_binding], [ail_decl; tag_assign] @ (List.concat ss) @ constr_allocation_stat @ assign_stats, mk_expr res_ident)
 
 
   | MemberShift (it, tag, member) -> 
@@ -995,7 +995,7 @@ let rec cn_to_ail_expr_aux_internal
       let f = (mk_expr A.(AilEident sym)) in
       let ail_expr_ = A.AilEcall (f, es) in 
       let error_msg_update_stats_ = generate_error_msg_info_update_stats ~cn_source_loc_opt:(Some loc) () in
-      dest d (List.Old.concat bs, List.Old.concat ss @ error_msg_update_stats_, mk_expr ail_expr_)
+      dest d (List.concat bs, List.concat ss @ error_msg_update_stats_, mk_expr ail_expr_)
       
   | Let ((var, t1), body) -> 
     let (b1, s1, e1) = cn_to_ail_expr_aux_internal const_prop pred_name dts globals t1 PassBack in
@@ -1684,7 +1684,7 @@ let cn_to_ail_resource_internal ?(is_pre=true) ?(is_toplevel=true) sym dts globa
         let error_msg_update_stats_ = generate_error_msg_info_update_stats ~cn_source_loc_opt:(Some loc) () in
         let fcall = A.(AilEcall (mk_expr (AilEident pname), e :: es @ [mk_expr (AilEident enum_sym)])) in
         let binding = create_binding sym (bt_to_ail_ctype ~pred_sym:(Some pname) bt) in
-        (mk_expr fcall, binding :: (List.Old.concat bs), List.Old.concat ss @ error_msg_update_stats_, None)
+        (mk_expr fcall, binding :: (List.concat bs), List.concat ss @ error_msg_update_stats_, None)
     in
     let s_decl = match rm_ctype ctype with 
       | C.Void -> A.(AilSexpr rhs)
@@ -1774,7 +1774,7 @@ let cn_to_ail_resource_internal ?(is_pre=true) ?(is_toplevel=true) sym dts globa
         let (bs, ss, es) = list_split_three (List.map ~f:(fun it -> cn_to_ail_expr_internal dts globals it PassBack) q.iargs) in
         let error_msg_update_stats_ = generate_error_msg_info_update_stats ~cn_source_loc_opt:(Some loc) () in
         let fcall = A.(AilEcall (mk_expr (AilEident pname), (mk_expr (AilEident ptr_add_sym)) :: es @ [mk_expr (AilEident enum_sym)])) in
-        (mk_expr fcall, List.Old.concat bs, List.Old.concat ss @ error_msg_update_stats_, None)
+        (mk_expr fcall, List.concat bs, List.concat ss @ error_msg_update_stats_, None)
     in
 
     let typedef_name = get_typedef_string (bt_to_ail_ctype i_bt) in 
@@ -2108,7 +2108,7 @@ let cn_to_ail_cnprog_internal dts globals cn_prog =
 let cn_to_ail_statements dts globals (loc, cn_progs) = 
   let bs_and_ss = List.map ~f:(fun prog -> cn_to_ail_cnprog_internal dts globals prog) cn_progs in 
   let (bs, ss) = List.Old.split bs_and_ss in 
-  (loc, (List.Old.concat bs, List.Old.concat ss))
+  (loc, (List.concat bs, List.concat ss))
 
 let prepend_to_precondition ail_executable_spec (b1, s1) = 
   let (b2, s2) = ail_executable_spec.pre in

--- a/backend/cn/cn_internal_to_ail.ml
+++ b/backend/cn/cn_internal_to_ail.ml
@@ -1069,7 +1069,7 @@ let rec cn_to_ail_expr_aux_internal
               let cases = List.map ~f:(simplify_leading_variable term) cases in
 
               if List.for_all ~f:leading_wildcard cases then
-                let cases = List.map ~f:(fun (ps, e) -> (List.Old.tl ps, e)) cases in
+                let cases = List.map ~f:(fun (ps, e) -> (List.tl_exn ps, e)) cases in
                 let (bindings', stats') = translate count vs cases in 
                 (bindings', stats')
               else

--- a/backend/cn/cn_internal_to_ail.ml
+++ b/backend/cn/cn_internal_to_ail.ml
@@ -68,8 +68,8 @@ end
 let members_equal ms ms' = 
   if ((List.length ms) != (List.length ms')) then false else
   (if (List.length ms == 0) then true else (
-  let (ids, cn_bts) = List.Old.split ms in
-  let (ids', cn_bts') = List.Old.split ms' in
+  let (ids, cn_bts) = List.unzip  ms in
+  let (ids', cn_bts') = List.unzip  ms' in
   let ctypes_eq = List.Old.map2 (fun cn_bt cn_bt'->
     let bt = cn_base_type_to_bt cn_bt in
     let bt' = cn_base_type_to_bt cn_bt' in
@@ -615,7 +615,7 @@ let generate_ownership_function with_ownership_checking ctype =
   let param2_sym = Sym.fresh_pretty "owned_enum" in
   let param1 = (param1_sym, bt_to_ail_ctype BT.Loc) in
   let param2 = (param2_sym, mk_ctype (C.(Basic (Integer (Enum (Sym.fresh_pretty "OWNERSHIP")))))) in
-  let (param_syms, param_types) = List.Old.split [param1; param2] in
+  let (param_syms, param_types) = List.unzip  [param1; param2] in
   let param_types = List.map ~f:(fun t -> (empty_qualifiers, t, false)) param_types in
   let ownership_fcall_maybe = 
   if with_ownership_checking then 
@@ -1090,7 +1090,7 @@ let rec cn_to_ail_expr_aux_internal
                             let constr_binding = create_binding count_sym (mk_ctype C.(Pointer (empty_qualifiers, (mk_ctype C.(Struct lc_sym))))) in
                             let constructor_var_assign = mk_stmt A.(AilSdeclaration [(count_sym, Some (mk_expr rhs_memberof))]) in
 
-                            let (ids, ts) = List.Old.split (List.Old.rev members_with_types) in
+                            let (ids, ts) = List.unzip  (List.Old.rev members_with_types) in
                             let bts = List.map ~f:cn_base_type_to_bt ts in
                             let new_constr_it = IT.IT (Sym count_sym, BT.Struct lc_sym, Cerb_location.unknown) in
                             let vars' = List.map ~f:(fun id -> T.StructMember (new_constr_it, id)) ids in
@@ -1311,7 +1311,7 @@ let generate_datatype_default_function (cn_datatype : cn_datatype) =
   let rec get_constrs_and_ms = function 
   | [] -> failwith "Datatype default generation failure: datatype has no constructors"
   | ((_, members) as x) :: xs -> 
-    let (ids, basetypes) = List.Old.split members in 
+    let (ids, basetypes) = List.unzip  members in 
     if List.Old.mem BT.equal (Datatype cn_sym) (List.map ~f:cn_base_type_to_bt basetypes) then 
       get_constrs_and_ms xs 
     else 
@@ -1895,7 +1895,7 @@ let cn_to_ail_function_internal (fn_sym, (lf_def : LogicalFunctions.definition))
   in
   let ail_record_opt = generate_record_opt fn_sym lf_def.return_bt in
   let params = List.map ~f:(fun (sym, bt) -> (sym, (bt_to_ail_ctype bt))) lf_def.args in
-  let (param_syms, param_types) = List.Old.split params in
+  let (param_syms, param_types) = List.unzip  params in
   let param_types = List.map ~f:(fun t -> (empty_qualifiers, t, false)) param_types in
   let matched_cn_functions = List.filter ~f:(fun (cn_fun : (A.ail_identifier, C.ctype) Cn.cn_function) -> Sym.equal cn_fun.cn_func_name fn_sym) cn_functions in
   (* Unsafe - check if list has an element *)
@@ -1976,7 +1976,7 @@ let cn_to_ail_predicate_internal (pred_sym, (rp_def : ResourcePredicates.definit
   let params = List.map ~f:(fun (sym, bt) -> (sym, (bt_to_ail_ctype bt))) ((rp_def.pointer, BT.Loc) :: rp_def.iargs) in
   let enum_param_sym = Sym.fresh_pretty "owned_enum" in
   let params = params @ [(enum_param_sym, mk_ctype (C.(Basic (Integer (Enum (Sym.fresh_pretty "OWNERSHIP"))))))] in
-  let (param_syms, param_types) = List.Old.split params in
+  let (param_syms, param_types) = List.unzip  params in
   let param_types = List.map ~f:(fun t -> (empty_qualifiers, t, false)) param_types in
   (* Generating function declaration *)
   let decl = (pred_sym, (rp_def.loc, empty_attributes, A.(Decl_function (false, (empty_qualifiers, ret_type), param_types, false, false, false)))) in
@@ -2107,7 +2107,7 @@ let cn_to_ail_cnprog_internal dts globals cn_prog =
 
 let cn_to_ail_statements dts globals (loc, cn_progs) = 
   let bs_and_ss = List.map ~f:(fun prog -> cn_to_ail_cnprog_internal dts globals prog) cn_progs in 
-  let (bs, ss) = List.Old.split bs_and_ss in 
+  let (bs, ss) = List.unzip  bs_and_ss in 
   (loc, (List.concat bs, List.concat ss))
 
 let prepend_to_precondition ail_executable_spec (b1, s1) = 

--- a/backend/cn/cn_internal_to_ail.ml
+++ b/backend/cn/cn_internal_to_ail.ml
@@ -823,7 +823,7 @@ let rec cn_to_ail_expr_aux_internal
     let struct_tag = match IT.bt struct_term with | BT.Struct tag -> tag | _ -> failwith "Cannot do StructUpdate on non-struct term" in 
     let tag_defs = Pmap.bindings_list (CF.Tags.tagDefs ()) in 
     let matching_tag_defs = List.Old.filter (fun (sym, (_, def)) -> Sym.equal struct_tag sym) tag_defs in 
-    let (_, (_, tag_def)) = if List.Old.is_empty matching_tag_defs then failwith "Struct not found in tagDefs" else List.Old.nth matching_tag_defs 0 in 
+    let (_, (_, tag_def)) = if List.Old.is_empty matching_tag_defs then failwith "Struct not found in tagDefs" else List.nth_exn matching_tag_defs 0 in 
     (match tag_def with 
       | C.StructDef (members, _) -> 
         let (b1, s1, e1) = cn_to_ail_expr_aux_internal const_prop pred_name dts globals struct_term PassBack in
@@ -1394,7 +1394,7 @@ let generate_struct_equality_function ?(is_record=false) dts ((sym, (loc, attrs,
         let args = List.map ~f:(fun cast_sym -> mk_expr (AilEmemberofptr (mk_expr (AilEident cast_sym), id))) cast_param_syms in 
         (* List length of args guaranteed to be 2 by construction *)
         assert(List.length args == 2);
-        let equality_fn_call = get_equality_fn_call bt (List.Old.nth args 0) (List.Old.nth args 1) dts in 
+        let equality_fn_call = get_equality_fn_call bt (List.nth_exn args 0) (List.nth_exn args 1) dts in 
         mk_expr equality_fn_call
       in
       let member_equality_exprs = List.map ~f:generate_member_equality members in 
@@ -1540,7 +1540,7 @@ let generate_record_equality_function dts (sym, (members: BT.member_types)) =
       let args = List.map ~f:(fun cast_sym -> mk_expr (AilEmemberofptr (mk_expr (AilEident cast_sym), id))) cast_param_syms in 
       (* List length of args guaranteed to be 2 by construction *)
       assert(List.length args == 2);
-      let equality_fn_call = get_equality_fn_call bt (List.Old.nth args 0) (List.Old.nth args 1) dts in 
+      let equality_fn_call = get_equality_fn_call bt (List.nth_exn args 0) (List.nth_exn args 1) dts in 
       mk_expr equality_fn_call
     in
     let member_equality_exprs = List.map ~f:generate_member_equality members in 
@@ -1899,7 +1899,7 @@ let cn_to_ail_function_internal (fn_sym, (lf_def : LogicalFunctions.definition))
   let param_types = List.map ~f:(fun t -> (empty_qualifiers, t, false)) param_types in
   let matched_cn_functions = List.Old.filter (fun (cn_fun : (A.ail_identifier, C.ctype) Cn.cn_function) -> Sym.equal cn_fun.cn_func_name fn_sym) cn_functions in
   (* Unsafe - check if list has an element *)
-  let loc = (List.Old.nth matched_cn_functions 0).cn_func_magic_loc in 
+  let loc = (List.nth_exn matched_cn_functions 0).cn_func_magic_loc in 
   (* Generating function declaration *)
   let decl = (fn_sym, (lf_def.loc, empty_attributes, A.(Decl_function (false, (empty_qualifiers, ret_type), param_types, false, false, false)))) in
   (* Generating function definition *)
@@ -1985,7 +1985,7 @@ let cn_to_ail_predicate_internal (pred_sym, (rp_def : ResourcePredicates.definit
 
   let matched_cn_preds = List.Old.filter (fun (cn_pred : (A.ail_identifier, C.ctype) Cn.cn_predicate) -> Sym.equal cn_pred.cn_pred_name pred_sym) cn_preds in
   (* Unsafe - check if list has an element *)
-  let loc = (List.Old.nth matched_cn_preds 0).cn_pred_magic_loc in 
+  let loc = (List.nth_exn matched_cn_preds 0).cn_pred_magic_loc in 
   (((loc, decl), def), ail_record_opt)
 
 let rec cn_to_ail_predicates_internal pred_def_list dts globals preds cn_preds = 

--- a/backend/cn/cn_internal_to_ail.ml
+++ b/backend/cn/cn_internal_to_ail.ml
@@ -1090,7 +1090,7 @@ let rec cn_to_ail_expr_aux_internal
                             let constr_binding = create_binding count_sym (mk_ctype C.(Pointer (empty_qualifiers, (mk_ctype C.(Struct lc_sym))))) in
                             let constructor_var_assign = mk_stmt A.(AilSdeclaration [(count_sym, Some (mk_expr rhs_memberof))]) in
 
-                            let (ids, ts) = List.unzip  (List.Old.rev members_with_types) in
+                            let (ids, ts) = List.unzip  (List.rev members_with_types) in
                             let bts = List.map ~f:cn_base_type_to_bt ts in
                             let new_constr_it = IT.IT (Sym count_sym, BT.Struct lc_sym, Cerb_location.unknown) in
                             let vars' = List.map ~f:(fun id -> T.StructMember (new_constr_it, id)) ids in

--- a/backend/cn/cn_internal_to_ail.ml
+++ b/backend/cn/cn_internal_to_ail.ml
@@ -66,8 +66,8 @@ end
 
 
 let members_equal ms ms' = 
-  if ((List.Old.length ms) != (List.Old.length ms')) then false else
-  (if (List.Old.length ms == 0) then true else (
+  if ((List.length ms) != (List.length ms')) then false else
+  (if (List.length ms == 0) then true else (
   let (ids, cn_bts) = List.Old.split ms in
   let (ids', cn_bts') = List.Old.split ms' in
   let ctypes_eq = List.Old.map2 (fun cn_bt cn_bt'->
@@ -174,7 +174,7 @@ let generate_record_sym sym members =
       sym''
     | None ->   
       let map_bindings = RecordMap.bindings !records in
-      (* Printf.printf "Record table size: %d\n" (List.Old.length map_bindings); *)
+      (* Printf.printf "Record table size: %d\n" (List.length map_bindings); *)
       let eq_members_bindings = List.Old.filter (fun (k, v) -> members_equal k members) map_bindings in
       match eq_members_bindings with 
       | [] -> 
@@ -886,7 +886,7 @@ let rec cn_to_ail_expr_aux_internal
         | [] -> failwith "Datatype not found" (* Not found *)
         | dt :: dts' ->
           let matching_cases = List.Old.filter (fun (c_sym, members) -> Sym.equal c_sym constr_sym) dt.cn_dt_cases in
-          if List.Old.length matching_cases != 0 then
+          if List.length matching_cases != 0 then
             let (_, members) = List.Old.hd matching_cases in
             (dt, members)
           else 
@@ -1393,7 +1393,7 @@ let generate_struct_equality_function ?(is_record=false) dts ((sym, (loc, attrs,
         let bt = BT.of_sct Memory.is_signed_integer_type Memory.size_of_integer_type sct in 
         let args = List.map ~f:(fun cast_sym -> mk_expr (AilEmemberofptr (mk_expr (AilEident cast_sym), id))) cast_param_syms in 
         (* List length of args guaranteed to be 2 by construction *)
-        assert(List.Old.length args == 2);
+        assert(List.length args == 2);
         let equality_fn_call = get_equality_fn_call bt (List.Old.nth args 0) (List.Old.nth args 1) dts in 
         mk_expr equality_fn_call
       in
@@ -1539,7 +1539,7 @@ let generate_record_equality_function dts (sym, (members: BT.member_types)) =
     let generate_member_equality (id, bt) = 
       let args = List.map ~f:(fun cast_sym -> mk_expr (AilEmemberofptr (mk_expr (AilEident cast_sym), id))) cast_param_syms in 
       (* List length of args guaranteed to be 2 by construction *)
-      assert(List.Old.length args == 2);
+      assert(List.length args == 2);
       let equality_fn_call = get_equality_fn_call bt (List.Old.nth args 0) (List.Old.nth args 1) dts in 
       mk_expr equality_fn_call
     in

--- a/backend/cn/cn_internal_to_ail.ml
+++ b/backend/cn/cn_internal_to_ail.ml
@@ -36,11 +36,11 @@ let rec cn_base_type_to_bt = function
   | CN_struct tag -> BT.Struct tag
   | CN_datatype tag -> BT.Datatype tag
   | CN_record ms -> 
-    let ms' = List.map (fun (id, bt) -> (id, cn_base_type_to_bt bt)) ms in
+    let ms' = List.Old.map (fun (id, bt) -> (id, cn_base_type_to_bt bt)) ms in
     BT.Record ms'
   | CN_map (type1, type2) -> BT.Map (cn_base_type_to_bt type1, cn_base_type_to_bt type2)
   | CN_list typ -> cn_base_type_to_bt typ
-  | CN_tuple ts -> BT.Tuple (List.map cn_base_type_to_bt ts)
+  | CN_tuple ts -> BT.Tuple (List.Old.map cn_base_type_to_bt ts)
   | CN_set typ -> cn_base_type_to_bt typ
   | CN_user_type_name _ -> failwith "TODO CN_user_type_name"
   | CN_c_typedef_name _ -> failwith "TODO CN_c_typedef_name"
@@ -66,17 +66,17 @@ end
 
 
 let members_equal ms ms' = 
-  if ((List.length ms) != (List.length ms')) then false else
-  (if (List.length ms == 0) then true else (
-  let (ids, cn_bts) = List.split ms in
-  let (ids', cn_bts') = List.split ms' in
-  let ctypes_eq = List.map2 (fun cn_bt cn_bt'->
+  if ((List.Old.length ms) != (List.Old.length ms')) then false else
+  (if (List.Old.length ms == 0) then true else (
+  let (ids, cn_bts) = List.Old.split ms in
+  let (ids', cn_bts') = List.Old.split ms' in
+  let ctypes_eq = List.Old.map2 (fun cn_bt cn_bt'->
     let bt = cn_base_type_to_bt cn_bt in
     let bt' = cn_base_type_to_bt cn_bt' in
     BT.equal bt bt') cn_bts cn_bts' in
-  let ctypes_eq = List.fold_left (&&) true ctypes_eq in
-  let ids_eq = List.map2 Id.equal ids ids' in
-  let ids_eq = List.fold_left (&&) true ids_eq in
+  let ctypes_eq = List.Old.fold_left (&&) true ctypes_eq in
+  let ids_eq = List.Old.map2 Id.equal ids ids' in
+  let ids_eq = List.Old.fold_left (&&) true ids_eq in
   ctypes_eq && ids_eq))
 
 module SymKey = struct
@@ -148,11 +148,11 @@ let rec bt_to_cn_base_type = function
 | BT.Struct tag -> CN_struct tag
 | BT.Datatype tag -> CN_datatype tag
 | BT.Record member_types -> 
-  let ms = List.map (fun (id, bt) -> (id, bt_to_cn_base_type bt)) member_types in
+  let ms = List.Old.map (fun (id, bt) -> (id, bt_to_cn_base_type bt)) member_types in
   CN_record ms
 | BT.Map (bt1, bt2) -> CN_map (bt_to_cn_base_type bt1, bt_to_cn_base_type bt2)
 | BT.List bt -> CN_list (bt_to_cn_base_type bt)
-| BT.Tuple bts -> CN_tuple (List.map bt_to_cn_base_type bts)
+| BT.Tuple bts -> CN_tuple (List.Old.map bt_to_cn_base_type bts)
 | BT.Set bt -> CN_set (bt_to_cn_base_type bt)
 
 
@@ -174,8 +174,8 @@ let generate_record_sym sym members =
       sym''
     | None ->   
       let map_bindings = RecordMap.bindings !records in
-      (* Printf.printf "Record table size: %d\n" (List.length map_bindings); *)
-      let eq_members_bindings = List.filter (fun (k, v) -> members_equal k members) map_bindings in
+      (* Printf.printf "Record table size: %d\n" (List.Old.length map_bindings); *)
+      let eq_members_bindings = List.Old.filter (fun (k, v) -> members_equal k members) map_bindings in
       match eq_members_bindings with 
       | [] -> 
         (* First time reaching record of this type - add to map *)
@@ -209,7 +209,7 @@ let rec cn_to_ail_base_type ?(pred_sym=None) cn_typ =
    | CN_tuple ts -> 
       (* Printf.printf "Entered CN_tuple case\n"; *)
       let some_id = create_id_from_sym (Sym.fresh_pretty "some_sym") in
-      let members = List.map (fun t -> (some_id, t)) ts in
+      let members = List.Old.map (fun t -> (some_id, t)) ts in
       let sym = generate_record_sym pred_sym members in
       Struct sym
    | CN_set bt -> generate_ail_array bt
@@ -373,7 +373,7 @@ let add_conversion_fn ?sct ail_expr_ bt =
           A.[ail_expr_; AilEident (Sym.fresh_pretty cntype_conversion_fn_str); converted_num_elements]
         | _ -> [ail_expr_]  
         ) in 
-      A.(AilEcall (mk_expr (AilEident (Sym.fresh_pretty conversion_fn_str)), List.map mk_expr args))
+      A.(AilEcall (mk_expr (AilEident (Sym.fresh_pretty conversion_fn_str)), List.Old.map mk_expr args))
     | None -> ail_expr_
 
 let get_equality_fn_call bt e1 e2 dts  =
@@ -506,13 +506,13 @@ let gen_bool_while_loop sym bt start_expr while_cond ?(if_cond_opt=None) (bs, ss
 
   let loop_body = match if_cond_opt with 
     | Some if_cond_expr -> 
-      List.map mk_stmt [A.(AilSif (wrap_with_convert_from_cn_bool if_cond_expr, mk_stmt (AilSblock ([], List.map mk_stmt (ss @ [b_assign; incr_stat]))), mk_stmt (AilSblock ([], [mk_stmt AilSskip])))); incr_stat]
+      List.Old.map mk_stmt [A.(AilSif (wrap_with_convert_from_cn_bool if_cond_expr, mk_stmt (AilSblock ([], List.Old.map mk_stmt (ss @ [b_assign; incr_stat]))), mk_stmt (AilSblock ([], [mk_stmt AilSskip])))); incr_stat]
     | None -> 
-      List.map mk_stmt (ss @ [b_assign; incr_stat])
+      List.Old.map mk_stmt (ss @ [b_assign; incr_stat])
   in
   let while_loop = A.(AilSwhile (while_cond_with_conversion, mk_stmt (AilSblock (bs, loop_body)), 0)) in
 
-  let block = A.(AilSblock ([incr_var_binding], List.map mk_stmt [start_decl; while_loop])) in
+  let block = A.(AilSblock ([incr_var_binding], List.Old.map mk_stmt [start_decl; while_loop])) in
   ([b_binding], [b_decl; block], mk_expr b_ident)
 
 
@@ -615,13 +615,13 @@ let generate_ownership_function with_ownership_checking ctype =
   let param2_sym = Sym.fresh_pretty "owned_enum" in
   let param1 = (param1_sym, bt_to_ail_ctype BT.Loc) in
   let param2 = (param2_sym, mk_ctype (C.(Basic (Integer (Enum (Sym.fresh_pretty "OWNERSHIP")))))) in
-  let (param_syms, param_types) = List.split [param1; param2] in
-  let param_types = List.map (fun t -> (empty_qualifiers, t, false)) param_types in
+  let (param_syms, param_types) = List.Old.split [param1; param2] in
+  let param_types = List.Old.map (fun t -> (empty_qualifiers, t, false)) param_types in
   let ownership_fcall_maybe = 
   if with_ownership_checking then 
     (let ownership_fn_sym = Sym.fresh_pretty "cn_check_ownership" in 
     let ownership_fn_args = A.[AilEident param2_sym; AilEident generic_c_ptr_sym; AilEsizeof (empty_qualifiers, ctype)] in
-    [A.(AilSexpr (mk_expr (AilEcall (mk_expr (AilEident ownership_fn_sym), List.map mk_expr ownership_fn_args))))])
+    [A.(AilSexpr (mk_expr (AilEcall (mk_expr (AilEident ownership_fn_sym), List.Old.map mk_expr ownership_fn_args))))])
   else  
     []
   in
@@ -637,7 +637,7 @@ let generate_ownership_function with_ownership_checking ctype =
   (* Generating function declaration *)
   let decl = (fn_sym, (Cerb_location.unknown, empty_attributes, A.(Decl_function (false, (empty_qualifiers, ret_type), param_types, false, false, false)))) in
   (* Generating function definition *)
-  let def = (fn_sym, (Cerb_location.unknown, 0, empty_attributes, param_syms, mk_stmt A.(AilSblock (generic_c_ptr_bs, List.map mk_stmt (generic_c_ptr_ss @ ownership_fcall_maybe @ [return_stmt]))))) in
+  let def = (fn_sym, (Cerb_location.unknown, 0, empty_attributes, param_syms, mk_stmt A.(AilSblock (generic_c_ptr_bs, List.Old.map mk_stmt (generic_c_ptr_ss @ ownership_fcall_maybe @ [return_stmt]))))) in
   (decl, def)
 
 let is_sym_obj_address sym = match Sym.symbol_description sym with 
@@ -802,8 +802,8 @@ let rec cn_to_ail_expr_aux_internal
     
     let (b, s) = ([res_binding], [alloc_stat]) in
     
-    let (bs, ss, assign_stats) = list_split_three (List.map generate_ail_stat ms) in
-    dest d (List.concat bs @ b, List.concat ss @ s @ assign_stats, mk_expr res_ident)
+    let (bs, ss, assign_stats) = list_split_three (List.Old.map generate_ail_stat ms) in
+    dest d (List.Old.concat bs @ b, List.Old.concat ss @ s @ assign_stats, mk_expr res_ident)
 
   | RecordMember (t, m) ->
     (* Currently assuming records only exist  *)
@@ -822,8 +822,8 @@ let rec cn_to_ail_expr_aux_internal
   | StructUpdate ((struct_term, m), new_val) ->
     let struct_tag = match IT.bt struct_term with | BT.Struct tag -> tag | _ -> failwith "Cannot do StructUpdate on non-struct term" in 
     let tag_defs = Pmap.bindings_list (CF.Tags.tagDefs ()) in 
-    let matching_tag_defs = List.filter (fun (sym, (_, def)) -> Sym.equal struct_tag sym) tag_defs in 
-    let (_, (_, tag_def)) = if List.is_empty matching_tag_defs then failwith "Struct not found in tagDefs" else List.nth matching_tag_defs 0 in 
+    let matching_tag_defs = List.Old.filter (fun (sym, (_, def)) -> Sym.equal struct_tag sym) tag_defs in 
+    let (_, (_, tag_def)) = if List.Old.is_empty matching_tag_defs then failwith "Struct not found in tagDefs" else List.Old.nth matching_tag_defs 0 in 
     (match tag_def with 
       | C.StructDef (members, _) -> 
         let (b1, s1, e1) = cn_to_ail_expr_aux_internal const_prop pred_name dts globals struct_term PassBack in
@@ -843,7 +843,7 @@ let rec cn_to_ail_expr_aux_internal
           in
           A.(AilSexpr (mk_expr (AilEassign (lhs_memberof_expr_, rhs))))
         in 
-        let member_assignments = List.map (generate_member_assignment m) members in 
+        let member_assignments = List.Old.map (generate_member_assignment m) members in 
 
         dest d (b1 @ b2 @ [res_binding], s1 @ s2 @ (res_decl :: member_assignments), res_ident)
       | UnionDef _ -> failwith "Can't apply StructUpdate to a C union")
@@ -863,7 +863,7 @@ let rec cn_to_ail_expr_aux_internal
       (b, s, assign_stat)
     in
 
-    let transformed_ms = List.map (fun (id, it) -> (id, bt_to_cn_base_type (IT.bt it))) ms in
+    let transformed_ms = List.Old.map (fun (id, it) -> (id, bt_to_cn_base_type (IT.bt it))) ms in
 
     let sym_name = generate_record_sym pred_name transformed_ms in
     let ctype_ = C.(Pointer (empty_qualifiers, (mk_ctype (Struct sym_name)))) in
@@ -874,8 +874,8 @@ let rec cn_to_ail_expr_aux_internal
     
     let (b, s) = ([res_binding], [alloc_stat]) in
     
-    let (bs, ss, assign_stats) = list_split_three (List.map generate_ail_stat ms) in
-    dest d (List.concat bs @ b, List.concat ss @ s @ assign_stats, mk_expr res_ident)
+    let (bs, ss, assign_stats) = list_split_three (List.Old.map generate_ail_stat ms) in
+    dest d (List.Old.concat bs @ b, List.Old.concat ss @ s @ assign_stats, mk_expr res_ident)
 
   | RecordUpdate ((t1, m), t2) -> failwith "TODO6"
 
@@ -885,9 +885,9 @@ let rec cn_to_ail_expr_aux_internal
       match dts with 
         | [] -> failwith "Datatype not found" (* Not found *)
         | dt :: dts' ->
-          let matching_cases = List.filter (fun (c_sym, members) -> Sym.equal c_sym constr_sym) dt.cn_dt_cases in
-          if List.length matching_cases != 0 then
-            let (_, members) = List.hd matching_cases in
+          let matching_cases = List.Old.filter (fun (c_sym, members) -> Sym.equal c_sym constr_sym) dt.cn_dt_cases in
+          if List.Old.length matching_cases != 0 then
+            let (_, members) = List.Old.hd matching_cases in
             (dt, members)
           else 
             find_dt_from_constructor constr_sym dts'
@@ -917,14 +917,14 @@ let rec cn_to_ail_expr_aux_internal
     in
 
     let constr_alloc_call = A.(AilEcall (mk_expr (AilEident alloc_sym), [mk_expr (AilEsizeof (empty_qualifiers, mk_ctype C.(Struct lc_constr_sym)))])) in
-    let constr_allocation_stat = if List.is_empty ms then [] else [A.(AilSexpr (mk_expr (AilEassign (mk_expr e_', mk_expr constr_alloc_call))))] in
-    let (bs, ss, assign_stats) = list_split_three (List.map generate_ail_stat ms) in
+    let constr_allocation_stat = if List.Old.is_empty ms then [] else [A.(AilSexpr (mk_expr (AilEassign (mk_expr e_', mk_expr constr_alloc_call))))] in
+    let (bs, ss, assign_stats) = list_split_three (List.Old.map generate_ail_stat ms) in
 
     let uc_constr_sym = generate_sym_with_suffix ~suffix:"" ~uppercase:true sym in
     let tag_member_ptr = A.(AilEmemberofptr (mk_expr res_ident, Id.id "tag")) in
     let tag_assign = A.(AilSexpr (mk_expr (AilEassign (mk_expr tag_member_ptr, mk_expr (AilEident uc_constr_sym))))) in
 
-    dest d ((List.concat bs) @ [res_binding], [ail_decl; tag_assign] @ (List.concat ss) @ constr_allocation_stat @ assign_stats, mk_expr res_ident)
+    dest d ((List.Old.concat bs) @ [res_binding], [ail_decl; tag_assign] @ (List.Old.concat ss) @ constr_allocation_stat @ assign_stats, mk_expr res_ident)
 
 
   | MemberShift (it, tag, member) -> 
@@ -990,12 +990,12 @@ let rec cn_to_ail_expr_aux_internal
 
   | MapDef ((sym, bt), t) -> failwith "TODO21"
   | Apply (sym, ts) ->
-      let bs_ss_es = List.map (fun e -> cn_to_ail_expr_aux_internal const_prop pred_name dts globals e PassBack) ts in
+      let bs_ss_es = List.Old.map (fun e -> cn_to_ail_expr_aux_internal const_prop pred_name dts globals e PassBack) ts in
       let (bs, ss, es) = list_split_three bs_ss_es in 
       let f = (mk_expr A.(AilEident sym)) in
       let ail_expr_ = A.AilEcall (f, es) in 
       let error_msg_update_stats_ = generate_error_msg_info_update_stats ~cn_source_loc_opt:(Some loc) () in
-      dest d (List.concat bs, List.concat ss @ error_msg_update_stats_, mk_expr ail_expr_)
+      dest d (List.Old.concat bs, List.Old.concat ss @ error_msg_update_stats_, mk_expr ail_expr_)
       
   | Let ((var, t1), body) -> 
     let (b1, s1, e1) = cn_to_ail_expr_aux_internal const_prop pred_name dts globals t1 PassBack in
@@ -1029,7 +1029,7 @@ let rec cn_to_ail_expr_aux_internal
         | T.(Pat (PWild, p_bt, p_loc) as pat) :: ps' -> Some (pat :: ps', e)
         | T.(Pat (PConstructor (c_nm, members), _, _)) :: ps' ->
           if Sym.equal_sym c c_nm then
-            let member_patterns = List.map snd members in
+            let member_patterns = List.Old.map snd members in
             Some (member_patterns @ ps', e)
           else
             None
@@ -1066,22 +1066,22 @@ let rec cn_to_ail_expr_aux_internal
 
             | term :: vs -> 
               
-              let cases = List.map (simplify_leading_variable term) cases in
+              let cases = List.Old.map (simplify_leading_variable term) cases in
 
-              if List.for_all leading_wildcard cases then
-                let cases = List.map (fun (ps, e) -> (List.tl ps, e)) cases in
+              if List.Old.for_all leading_wildcard cases then
+                let cases = List.Old.map (fun (ps, e) -> (List.Old.tl ps, e)) cases in
                 let (bindings', stats') = translate count vs cases in 
                 (bindings', stats')
               else
                 match IT.bt term with
                   | BT.Datatype sym -> 
-                      let cn_dt = List.filter (fun dt -> Sym.equal sym dt.cn_dt_name) dts in 
+                      let cn_dt = List.Old.filter (fun dt -> Sym.equal sym dt.cn_dt_name) dts in 
                       (match cn_dt with 
                         | [] -> failwith "Datatype not found"
                         | dt :: _ ->
                           let (b1, s1, e1) = cn_to_ail_expr_aux_internal const_prop pred_name dts globals term PassBack in
                           let build_case (constr_sym, members_with_types) = 
-                            let cases' = List.filter_map (expand_datatype constr_sym) cases in 
+                            let cases' = List.Old.filter_map (expand_datatype constr_sym) cases in 
                             let suffix = "_" ^ (string_of_int count) in
                             let lc_sym = generate_sym_with_suffix ~suffix:"" ~lowercase:true constr_sym in 
                             let count_sym = generate_sym_with_suffix ~suffix ~lowercase:true constr_sym in 
@@ -1090,22 +1090,22 @@ let rec cn_to_ail_expr_aux_internal
                             let constr_binding = create_binding count_sym (mk_ctype C.(Pointer (empty_qualifiers, (mk_ctype C.(Struct lc_sym))))) in
                             let constructor_var_assign = mk_stmt A.(AilSdeclaration [(count_sym, Some (mk_expr rhs_memberof))]) in
 
-                            let (ids, ts) = List.split (List.rev members_with_types) in
-                            let bts = List.map cn_base_type_to_bt ts in
+                            let (ids, ts) = List.Old.split (List.Old.rev members_with_types) in
+                            let bts = List.Old.map cn_base_type_to_bt ts in
                             let new_constr_it = IT.IT (Sym count_sym, BT.Struct lc_sym, Cerb_location.unknown) in
-                            let vars' = List.map (fun id -> T.StructMember (new_constr_it, id)) ids in
-                            let terms' = List.map (fun (var', bt') -> T.IT (var', bt', Cerb_location.unknown)) (List.combine vars' bts) in
+                            let vars' = List.Old.map (fun id -> T.StructMember (new_constr_it, id)) ids in
+                            let terms' = List.Old.map (fun (var', bt') -> T.IT (var', bt', Cerb_location.unknown)) (List.Old.combine vars' bts) in
 
                             let (bindings, member_stats) = translate (count + 1) (terms' @ vs) cases' in
                             (* TODO: Check *)
-                            let stat_block = A.AilSblock (constr_binding :: bindings, constructor_var_assign :: (List.map mk_stmt member_stats)) in
+                            let stat_block = A.AilSblock (constr_binding :: bindings, constructor_var_assign :: (List.Old.map mk_stmt member_stats)) in
                             let tag_sym = generate_sym_with_suffix ~suffix:"" ~uppercase:true constr_sym in
                             let attribute : CF.Annot.attribute = {attr_ns = None; attr_id = create_id_from_sym tag_sym; attr_args = []} in
                             let ail_case = A.(AilScase (Nat_big_num.zero (* placeholder *), mk_stmt stat_block)) in
                             A.(AnnotatedStatement (Cerb_location.unknown, CF.Annot.Attrs [attribute], ail_case))
                           in 
                           let e1_transformed = transform_switch_expr e1 in
-                          let ail_case_stmts = List.map build_case dt.cn_dt_cases in
+                          let ail_case_stmts = List.Old.map build_case dt.cn_dt_cases in
                           let switch = A.(AilSswitch (mk_expr e1_transformed, mk_stmt (AilSblock ([], ail_case_stmts)))) in
                           (b1, s1 @ [switch])
                       )
@@ -1127,7 +1127,7 @@ let rec cn_to_ail_expr_aux_internal
             | PassBack -> failwith "TODO translate_real 2"
       in 
 
-      let ps' = List.map (fun (p, t) -> ([p], t)) ps in
+      let ps' = List.Old.map (fun (p, t) -> ([p], t)) ps in
       translate_real [t] ps' d
 
   | Cast (bt, t) -> 
@@ -1166,9 +1166,9 @@ let create_member (ctype, id) =
 
 
 let generate_tag_definition dt_members = 
-  let ail_dt_members = List.map (fun (id, cn_type) -> (cn_to_ail_base_type cn_type, id)) dt_members in
+  let ail_dt_members = List.Old.map (fun (id, cn_type) -> (cn_to_ail_base_type cn_type, id)) dt_members in
   (* TODO: Check if something called tag already exists *)
-  let members = List.map create_member ail_dt_members in
+  let members = List.Old.map create_member ail_dt_members in
   C.(StructDef (members, None))
 
 let generate_struct_definition ?(lc=true) (constructor, members) = 
@@ -1181,24 +1181,24 @@ let generate_struct_definition ?(lc=true) (constructor, members) =
 
 
 let cn_to_ail_pred_records map_bindings = 
-  let flipped_bindings = List.map (fun (ms, sym) -> (sym, ms)) map_bindings in
-  List.map generate_struct_definition flipped_bindings
+  let flipped_bindings = List.Old.map (fun (ms, sym) -> (sym, ms)) map_bindings in
+  List.Old.map generate_struct_definition flipped_bindings
 
 
 
 let cn_to_ail_datatype ?(first=false) (cn_datatype : cn_datatype) =
   let enum_sym = generate_sym_with_suffix cn_datatype.cn_dt_name in
-  let constructor_syms = List.map fst cn_datatype.cn_dt_cases in
+  let constructor_syms = List.Old.map fst cn_datatype.cn_dt_cases in
   let generate_enum_member sym = 
     let doc = CF.Pp_ail.pp_id sym in
     let str = CF.Pp_utils.to_plain_string doc in 
     let str = String.uppercase_ascii str in
     Id.id str
   in
-  let enum_member_syms = List.map generate_enum_member constructor_syms in
+  let enum_member_syms = List.Old.map generate_enum_member constructor_syms in
   let attr : CF.Annot.attribute = {attr_ns = None; attr_id = Id.id "enum"; attr_args = []} in
   let attrs = CF.Annot.Attrs [attr] in
-  let enum_members = List.map (fun sym -> (sym, (empty_attributes, None, empty_qualifiers, mk_ctype C.Void))) enum_member_syms in
+  let enum_members = List.Old.map (fun sym -> (sym, (empty_attributes, None, empty_qualifiers, mk_ctype C.Void))) enum_member_syms in
   let enum_tag_definition = C.(UnionDef enum_members) in
   let enum = (enum_sym, (Cerb_location.unknown, attrs, enum_tag_definition)) in
   let cntype_sym = Sym.fresh_pretty "cntype" in
@@ -1209,7 +1209,7 @@ let cn_to_ail_datatype ?(first=false) (cn_datatype : cn_datatype) =
       (create_member (mk_ctype cntype_pointer, Id.id "cntype"))]
   in
   
-  let structs = List.map (fun c -> generate_struct_definition c) cn_datatype.cn_dt_cases in
+  let structs = List.Old.map (fun c -> generate_struct_definition c) cn_datatype.cn_dt_cases in
   let structs = if first then 
     let generic_dt_struct = 
       (generic_cn_dt_sym, (Cerb_location.unknown, empty_attributes, C.(StructDef (extra_members (C.(Basic (Integer (Signed Int_)))), None))))
@@ -1221,7 +1221,7 @@ let cn_to_ail_datatype ?(first=false) (cn_datatype : cn_datatype) =
     structs
   in
   let union_sym = generate_sym_with_suffix ~suffix:"_union" cn_datatype.cn_dt_name in
-  let union_def_members = List.map (fun sym -> 
+  let union_def_members = List.Old.map (fun sym -> 
     let lc_sym = Sym.fresh_pretty (String.lowercase_ascii (Sym.pp_string sym)) in
     create_member (mk_ctype C.(Pointer (empty_qualifiers, (mk_ctype (Struct lc_sym)))), create_id_from_sym ~lowercase:true sym)) constructor_syms in
   let union_def = C.(UnionDef union_def_members) in
@@ -1274,10 +1274,10 @@ let generate_datatype_equality_function (cn_datatype : cn_datatype) =
         let lc_constr_sym = generate_sym_with_suffix ~suffix:"" ~lowercase:true constructor in
         let constr_id = create_id_from_sym ~lowercase:true constructor in 
         let constr_struct_type = mk_ctype C.(Pointer (empty_qualifiers, mk_ctype (Struct lc_constr_sym))) in
-        let bindings = List.map (fun sym -> create_binding sym constr_struct_type) constr_syms in 
-        let memberof_ptr_es = List.map (fun sym -> mk_expr A.(AilEmemberofptr (mk_expr (AilEident sym), Id.id "u"))) param_syms in
-        let decls = List.map (fun (constr_sym, e) -> A.(AilSdeclaration [(constr_sym, Some (mk_expr (AilEmemberof (e, constr_id))))])) (List.combine constr_syms memberof_ptr_es) in
-        (bindings, List.map mk_stmt decls)
+        let bindings = List.Old.map (fun sym -> create_binding sym constr_struct_type) constr_syms in 
+        let memberof_ptr_es = List.Old.map (fun sym -> mk_expr A.(AilEmemberofptr (mk_expr (AilEident sym), Id.id "u"))) param_syms in
+        let decls = List.Old.map (fun (constr_sym, e) -> A.(AilSdeclaration [(constr_sym, Some (mk_expr (AilEmemberof (e, constr_id))))])) (List.Old.combine constr_syms memberof_ptr_es) in
+        (bindings, List.Old.map mk_stmt decls)
     in
     let equality_expr = generate_equality_expr members x_constr_sym y_constr_sym in
     let (_, _, e) = cn_to_ail_expr_internal [] [] equality_expr PassBack in
@@ -1285,7 +1285,7 @@ let generate_datatype_equality_function (cn_datatype : cn_datatype) =
     let ail_case = A.(AilScase (Nat_big_num.zero, mk_stmt (AilSblock (bs, ss @ [return_stat])))) in 
     A.(AnnotatedStatement (Cerb_location.unknown, CF.Annot.Attrs [attribute], ail_case))
   in
-  let switch_stmt = A.(AilSswitch (mk_expr (AilEmemberofptr (mk_expr (AilEident param1_sym), id_tag)), mk_stmt (AilSblock ([], List.map create_case cn_datatype.cn_dt_cases)))) in
+  let switch_stmt = A.(AilSswitch (mk_expr (AilEmemberofptr (mk_expr (AilEident param1_sym), id_tag)), mk_stmt (AilSblock ([], List.Old.map create_case cn_datatype.cn_dt_cases)))) in
   let tag_if_stmt = A.(AilSif (mk_expr tag_check_cond, mk_stmt return_false, mk_stmt switch_stmt)) in
   let ret_type = bt_to_ail_ctype BT.Bool in
   (* Generating function declaration *)
@@ -1311,8 +1311,8 @@ let generate_datatype_default_function (cn_datatype : cn_datatype) =
   let rec get_constrs_and_ms = function 
   | [] -> failwith "Datatype default generation failure: datatype has no constructors"
   | ((_, members) as x) :: xs -> 
-    let (ids, basetypes) = List.split members in 
-    if List.mem BT.equal (Datatype cn_sym) (List.map cn_base_type_to_bt basetypes) then 
+    let (ids, basetypes) = List.Old.split members in 
+    if List.Old.mem BT.equal (Datatype cn_sym) (List.Old.map cn_base_type_to_bt basetypes) then 
       get_constrs_and_ms xs 
     else 
       x
@@ -1344,7 +1344,7 @@ let generate_datatype_default_function (cn_datatype : cn_datatype) =
   let res_u = A.(AilEmemberofptr (res_ident, Id.id "u")) in 
   let res_u_constr = mk_expr (AilEmemberof (mk_expr res_u, create_id_from_sym lc_constr_sym)) in 
   let constr_alloc_assign_ = A.(AilSexpr (mk_expr (AilEassign (res_u_constr, generate_alloc_assign (mk_ctype C.(Struct lc_constr_sym)))))) in 
-  let member_assign_info = List.map (fun (id, cn_bt) -> 
+  let member_assign_info = List.Old.map (fun (id, cn_bt) -> 
     let bt = cn_base_type_to_bt cn_bt in
     let member_ctype_str_opt = get_underscored_typedef_string_from_bt bt in 
     let default_fun_str = match member_ctype_str_opt with 
@@ -1356,7 +1356,7 @@ let generate_datatype_default_function (cn_datatype : cn_datatype) =
     let fcall = A.(AilEcall (mk_expr (AilEident (Sym.fresh_pretty default_fun_str)), [])) in 
     (id, mk_expr fcall)
     ) members in 
-  let member_assign_stats = List.map (fun (id, rhs) -> A.(AilSexpr (mk_expr (AilEassign (mk_expr (AilEmemberofptr (res_u_constr, id)), rhs))))) member_assign_info in 
+  let member_assign_stats = List.Old.map (fun (id, rhs) -> A.(AilSexpr (mk_expr (AilEassign (mk_expr (AilEmemberofptr (res_u_constr, id)), rhs))))) member_assign_info in 
   
   (* Function body *)
   let return_stmt = A.(AilSreturn res_ident) in 
@@ -1364,7 +1364,7 @@ let generate_datatype_default_function (cn_datatype : cn_datatype) =
   (* Generating function declaration *)
   let decl = (fn_sym, (Cerb_location.unknown, empty_attributes, A.(Decl_function (false, (empty_qualifiers, ret_type), [], false, false, false)))) in
   (* Generating function definition *)
-  let def = (fn_sym, (Cerb_location.unknown, 0, empty_attributes, [], mk_stmt A.(AilSblock ([res_binding], (mk_stmt res_decl) :: res_tag_assign_stat :: (List.map mk_stmt (constr_alloc_assign_ :: member_assign_stats @ [return_stmt])))))) in
+  let def = (fn_sym, (Cerb_location.unknown, 0, empty_attributes, [], mk_stmt A.(AilSblock ([res_binding], (mk_stmt res_decl) :: res_tag_assign_stat :: (List.Old.map mk_stmt (constr_alloc_assign_ :: member_assign_stats @ [return_stmt])))))) in
   [(decl, def)]
 
 (* STRUCTS *)
@@ -1376,9 +1376,9 @@ let generate_struct_equality_function ?(is_record=false) dts ((sym, (loc, attrs,
       let fn_sym = Sym.fresh_pretty ("struct_" ^ (Sym.pp_string cn_sym) ^ "_equality") in
       let param_syms = [Sym.fresh_pretty "x"; Sym.fresh_pretty "y"] in 
       let param_type = (empty_qualifiers, mk_ctype (C.Pointer (empty_qualifiers, mk_ctype Void)), false) in
-      let cast_param_syms = List.map (fun sym -> generate_sym_with_suffix ~suffix:"_cast" sym) param_syms in 
-      let cast_bindings = List.map (fun sym -> create_binding sym cn_struct_ptr_ctype) cast_param_syms in 
-      let cast_assignments = List.map (fun (cast_sym, sym) -> A.(AilSdeclaration [cast_sym, Some (mk_expr (AilEcast (empty_qualifiers, cn_struct_ptr_ctype, (mk_expr (AilEident sym)))))])) (List.combine cast_param_syms param_syms) in 
+      let cast_param_syms = List.Old.map (fun sym -> generate_sym_with_suffix ~suffix:"_cast" sym) param_syms in 
+      let cast_bindings = List.Old.map (fun sym -> create_binding sym cn_struct_ptr_ctype) cast_param_syms in 
+      let cast_assignments = List.Old.map (fun (cast_sym, sym) -> A.(AilSdeclaration [cast_sym, Some (mk_expr (AilEcast (empty_qualifiers, cn_struct_ptr_ctype, (mk_expr (AilEident sym)))))])) (List.Old.combine cast_param_syms param_syms) in 
       (* Function body *)
       let generate_member_equality (id, (_, _, _, ctype)) = 
         let _doc = (CF.Pp_ail.pp_ctype ~executable_spec:true empty_qualifiers ctype) in 
@@ -1391,15 +1391,15 @@ let generate_struct_equality_function ?(is_record=false) dts ((sym, (loc, attrs,
             failwith "Bad sctype"
         in
         let bt = BT.of_sct Memory.is_signed_integer_type Memory.size_of_integer_type sct in 
-        let args = List.map (fun cast_sym -> mk_expr (AilEmemberofptr (mk_expr (AilEident cast_sym), id))) cast_param_syms in 
+        let args = List.Old.map (fun cast_sym -> mk_expr (AilEmemberofptr (mk_expr (AilEident cast_sym), id))) cast_param_syms in 
         (* List length of args guaranteed to be 2 by construction *)
-        assert(List.length args == 2);
-        let equality_fn_call = get_equality_fn_call bt (List.nth args 0) (List.nth args 1) dts in 
+        assert(List.Old.length args == 2);
+        let equality_fn_call = get_equality_fn_call bt (List.Old.nth args 0) (List.Old.nth args 1) dts in 
         mk_expr equality_fn_call
       in
-      let member_equality_exprs = List.map generate_member_equality members in 
+      let member_equality_exprs = List.Old.map generate_member_equality members in 
       let cn_bool_and_sym = Sym.fresh_pretty "cn_bool_and" in
-      let ail_and_binop = List.fold_left (fun e1 e2 -> mk_expr (A.(AilEcall (mk_expr (AilEident cn_bool_and_sym), [e1; e2])))) (mk_expr (add_conversion_fn true_const BT.Bool)) member_equality_exprs in
+      let ail_and_binop = List.Old.fold_left (fun e1 e2 -> mk_expr (A.(AilEcall (mk_expr (AilEident cn_bool_and_sym), [e1; e2])))) (mk_expr (add_conversion_fn true_const BT.Bool)) member_equality_exprs in
       (* let rec remove_true_const ail_binop = match rm_expr ail_binop with 
         | A.(AilEbinary (e1, And, e2)) -> (match rm_expr e1 with 
             | A.AilEconst (ConstantInteger (IConstant (_, Decimal, Some B))) -> e2
@@ -1412,7 +1412,7 @@ let generate_struct_equality_function ?(is_record=false) dts ((sym, (loc, attrs,
       (* Generating function declaration *)
       let decl = (fn_sym, (Cerb_location.unknown, empty_attributes, A.(Decl_function (false, (empty_qualifiers, ret_type), [param_type; param_type], false, false, false)))) in
       (* Generating function definition *)
-      let def = (fn_sym, (Cerb_location.unknown, 0, empty_attributes, param_syms, mk_stmt A.(AilSblock (cast_bindings, List.map mk_stmt (cast_assignments @ [return_stmt]))))) in
+      let def = (fn_sym, (Cerb_location.unknown, 0, empty_attributes, param_syms, mk_stmt A.(AilSblock (cast_bindings, List.Old.map mk_stmt (cast_assignments @ [return_stmt]))))) in
       [(decl, def)]
   | C.UnionDef _ -> []
 
@@ -1448,13 +1448,13 @@ let generate_struct_default_function ?(is_record=false) dts ((sym, (loc, attrs, 
       let fcall = A.(AilEcall (mk_expr (AilEident (Sym.fresh_pretty default_fun_str)), [])) in 
       A.(AilSexpr (mk_expr (AilEassign (mk_expr lhs, mk_expr fcall))))
     in
-    let member_default_assigns = List.map generate_member_default_assign members in 
+    let member_default_assigns = List.Old.map generate_member_default_assign members in 
     let return_stmt = A.(AilSreturn (mk_expr ret_ident)) in 
     let ret_type = cn_struct_ptr_ctype in
     (* Generating function declaration *)
     let decl = (fn_sym, (Cerb_location.unknown, empty_attributes, A.(Decl_function (false, (empty_qualifiers, ret_type), [], false, false, false)))) in
     (* Generating function definition *)
-    let def = (fn_sym, (Cerb_location.unknown, 0, empty_attributes, [], mk_stmt A.(AilSblock ([ret_binding], List.map mk_stmt (ret_decl :: member_default_assigns @ [return_stmt]))))) in
+    let def = (fn_sym, (Cerb_location.unknown, 0, empty_attributes, [], mk_stmt A.(AilSblock ([ret_binding], List.Old.map mk_stmt (ret_decl :: member_default_assigns @ [return_stmt]))))) in
     [(decl, def)]
   | C.UnionDef _ -> []
 
@@ -1467,8 +1467,8 @@ let generate_struct_map_get ?(is_record=false) dts ((sym, (loc, attrs, tag_def))
     let param1_sym = Sym.fresh_pretty "m" in 
     let param2_sym = Sym.fresh_pretty "key" in 
     let param_syms = [param1_sym; param2_sym] in 
-    let param_types = List.map bt_to_ail_ctype [BT.Map (Integer, Struct cn_sym); BT.Integer] in 
-    let param_types = List.map (fun ctype -> (empty_qualifiers, ctype, false)) param_types in 
+    let param_types = List.Old.map bt_to_ail_ctype [BT.Map (Integer, Struct cn_sym); BT.Integer] in 
+    let param_types = List.Old.map (fun ctype -> (empty_qualifiers, ctype, false)) param_types in 
     let fn_sym = Sym.fresh_pretty fn_str in
     let ret_sym = Sym.fresh_pretty "ret" in 
     let ret_binding = create_binding ret_sym void_ptr_type in 
@@ -1486,7 +1486,7 @@ let generate_struct_map_get ?(is_record=false) dts ((sym, (loc, attrs, tag_def))
     (* Generating function declaration *)
     let decl = (fn_sym, (Cerb_location.unknown, empty_attributes, A.(Decl_function (false, (empty_qualifiers, ret_type), param_types, false, false, false)))) in
     (* Generating function definition *)
-    let def = (fn_sym, (Cerb_location.unknown, 0, empty_attributes, param_syms, mk_stmt A.(AilSblock ([ret_binding], List.map mk_stmt ([ret_decl; if_stmt]))))) in
+    let def = (fn_sym, (Cerb_location.unknown, 0, empty_attributes, param_syms, mk_stmt A.(AilSblock ([ret_binding], List.Old.map mk_stmt ([ret_decl; if_stmt]))))) in
     [(decl, def)]
   | C.UnionDef _ -> []
 
@@ -1514,13 +1514,13 @@ let generate_struct_conversion_function ((sym, (loc, attrs, tag_def)) : (A.ail_i
       let lhs = A.(AilEmemberofptr (mk_expr (AilEident res_sym), id)) in 
       A.(AilSexpr (mk_expr (AilEassign (mk_expr lhs, mk_expr rhs))))
     in
-    let member_assignments = List.map generate_member_assignment members in 
+    let member_assignments = List.Old.map generate_member_assignment members in 
     let return_stmt = A.(AilSreturn (mk_expr (AilEident res_sym))) in 
     let ret_type = (bt_to_ail_ctype (BT.Struct sym)) in
     (* Generating function declaration *)
     let decl = (fn_sym, (Cerb_location.unknown, empty_attributes, A.(Decl_function (false, (empty_qualifiers, ret_type), [param_type], false, false, false)))) in
     (* Generating function definition *)
-    let def = (fn_sym, (Cerb_location.unknown, 0, empty_attributes, [param_sym], mk_stmt A.(AilSblock ([res_binding], List.map mk_stmt (res_assign :: member_assignments @ [return_stmt]))))) in
+    let def = (fn_sym, (Cerb_location.unknown, 0, empty_attributes, [param_sym], mk_stmt A.(AilSblock ([res_binding], List.Old.map mk_stmt (res_assign :: member_assignments @ [return_stmt]))))) in
     [(decl, def)]
   | C.UnionDef _ -> []
 
@@ -1532,20 +1532,20 @@ let generate_record_equality_function dts (sym, (members: BT.member_types)) =
     let fn_sym = Sym.fresh_pretty ("struct_" ^ (Sym.pp_string cn_sym) ^ "_equality") in
     let param_syms = [Sym.fresh_pretty "x"; Sym.fresh_pretty "y"] in 
     let param_type = (empty_qualifiers, mk_ctype (C.Pointer (empty_qualifiers, mk_ctype Void)), false) in
-    let cast_param_syms = List.map (fun sym -> generate_sym_with_suffix ~suffix:"_cast" sym) param_syms in 
-    let cast_bindings = List.map (fun sym -> create_binding sym cn_struct_ptr_ctype) cast_param_syms in 
-    let cast_assignments = List.map (fun (cast_sym, sym) -> A.(AilSdeclaration [cast_sym, Some (mk_expr (AilEcast (empty_qualifiers, cn_struct_ptr_ctype, (mk_expr (AilEident sym)))))])) (List.combine cast_param_syms param_syms) in 
+    let cast_param_syms = List.Old.map (fun sym -> generate_sym_with_suffix ~suffix:"_cast" sym) param_syms in 
+    let cast_bindings = List.Old.map (fun sym -> create_binding sym cn_struct_ptr_ctype) cast_param_syms in 
+    let cast_assignments = List.Old.map (fun (cast_sym, sym) -> A.(AilSdeclaration [cast_sym, Some (mk_expr (AilEcast (empty_qualifiers, cn_struct_ptr_ctype, (mk_expr (AilEident sym)))))])) (List.Old.combine cast_param_syms param_syms) in 
     (* Function body *)
     let generate_member_equality (id, bt) = 
-      let args = List.map (fun cast_sym -> mk_expr (AilEmemberofptr (mk_expr (AilEident cast_sym), id))) cast_param_syms in 
+      let args = List.Old.map (fun cast_sym -> mk_expr (AilEmemberofptr (mk_expr (AilEident cast_sym), id))) cast_param_syms in 
       (* List length of args guaranteed to be 2 by construction *)
-      assert(List.length args == 2);
-      let equality_fn_call = get_equality_fn_call bt (List.nth args 0) (List.nth args 1) dts in 
+      assert(List.Old.length args == 2);
+      let equality_fn_call = get_equality_fn_call bt (List.Old.nth args 0) (List.Old.nth args 1) dts in 
       mk_expr equality_fn_call
     in
-    let member_equality_exprs = List.map generate_member_equality members in 
+    let member_equality_exprs = List.Old.map generate_member_equality members in 
     let cn_bool_and_sym = Sym.fresh_pretty "cn_bool_and" in
-    let ail_and_binop = List.fold_left (fun e1 e2 -> mk_expr (A.(AilEcall (mk_expr (AilEident cn_bool_and_sym), [e1; e2])))) (mk_expr (add_conversion_fn true_const BT.Bool)) member_equality_exprs in
+    let ail_and_binop = List.Old.fold_left (fun e1 e2 -> mk_expr (A.(AilEcall (mk_expr (AilEident cn_bool_and_sym), [e1; e2])))) (mk_expr (add_conversion_fn true_const BT.Bool)) member_equality_exprs in
     (* let rec remove_true_const ail_binop = match rm_expr ail_binop with 
       | A.(AilEbinary (e1, And, e2)) -> (match rm_expr e1 with 
           | A.AilEconst (ConstantInteger (IConstant (_, Decimal, Some B))) -> e2
@@ -1558,7 +1558,7 @@ let generate_record_equality_function dts (sym, (members: BT.member_types)) =
     (* Generating function declaration *)
     let decl = (fn_sym, (Cerb_location.unknown, empty_attributes, A.(Decl_function (false, (empty_qualifiers, ret_type), [param_type; param_type], false, false, false)))) in
     (* Generating function definition *)
-    let def = (fn_sym, (Cerb_location.unknown, 0, empty_attributes, param_syms, mk_stmt A.(AilSblock (cast_bindings, List.map mk_stmt (cast_assignments @ [return_stmt]))))) in
+    let def = (fn_sym, (Cerb_location.unknown, 0, empty_attributes, param_syms, mk_stmt A.(AilSblock (cast_bindings, List.Old.map mk_stmt (cast_assignments @ [return_stmt]))))) in
     [(decl, def)]
 
 let generate_record_default_function dts (sym, (members: BT.member_types)) =
@@ -1585,13 +1585,13 @@ let generate_record_default_function dts (sym, (members: BT.member_types)) =
       let fcall = A.(AilEcall (mk_expr (AilEident (Sym.fresh_pretty default_fun_str)), [])) in 
       A.(AilSexpr (mk_expr (AilEassign (mk_expr lhs, mk_expr fcall))))
     in
-    let member_default_assigns = List.map generate_member_default_assign members in 
+    let member_default_assigns = List.Old.map generate_member_default_assign members in 
     let return_stmt = A.(AilSreturn (mk_expr ret_ident)) in 
     let ret_type = cn_struct_ptr_ctype in
     (* Generating function declaration *)
     let decl = (fn_sym, (Cerb_location.unknown, empty_attributes, A.(Decl_function (false, (empty_qualifiers, ret_type), [], false, false, false)))) in
     (* Generating function definition *)
-    let def = (fn_sym, (Cerb_location.unknown, 0, empty_attributes, [], mk_stmt A.(AilSblock ([ret_binding], List.map mk_stmt (ret_decl :: member_default_assigns @ [return_stmt]))))) in
+    let def = (fn_sym, (Cerb_location.unknown, 0, empty_attributes, [], mk_stmt A.(AilSblock ([ret_binding], List.Old.map mk_stmt (ret_decl :: member_default_assigns @ [return_stmt]))))) in
     [(decl, def)]
 
 let generate_record_map_get dts (sym, (members: BT.member_types)) = 
@@ -1602,8 +1602,8 @@ let generate_record_map_get dts (sym, (members: BT.member_types)) =
     let param1_sym = Sym.fresh_pretty "m" in 
     let param2_sym = Sym.fresh_pretty "key" in 
     let param_syms = [param1_sym; param2_sym] in 
-    let param_types = List.map bt_to_ail_ctype [BT.Map (Integer, Struct cn_sym); BT.Integer] in 
-    let param_types = List.map (fun ctype -> (empty_qualifiers, ctype, false)) param_types in 
+    let param_types = List.Old.map bt_to_ail_ctype [BT.Map (Integer, Struct cn_sym); BT.Integer] in 
+    let param_types = List.Old.map (fun ctype -> (empty_qualifiers, ctype, false)) param_types in 
     let fn_sym = Sym.fresh_pretty fn_str in
     let ret_sym = Sym.fresh_pretty "ret" in 
     let ret_binding = create_binding ret_sym void_ptr_type in 
@@ -1621,14 +1621,14 @@ let generate_record_map_get dts (sym, (members: BT.member_types)) =
     (* Generating function declaration *)
     let decl = (fn_sym, (Cerb_location.unknown, empty_attributes, A.(Decl_function (false, (empty_qualifiers, ret_type), param_types, false, false, false)))) in
     (* Generating function definition *)
-    let def = (fn_sym, (Cerb_location.unknown, 0, empty_attributes, param_syms, mk_stmt A.(AilSblock ([ret_binding], List.map mk_stmt ([ret_decl; if_stmt]))))) in
+    let def = (fn_sym, (Cerb_location.unknown, 0, empty_attributes, param_syms, mk_stmt A.(AilSblock ([ret_binding], List.Old.map mk_stmt ([ret_decl; if_stmt]))))) in
     [(decl, def)]
 
 
 let cn_to_ail_struct ((sym, (loc, attrs, tag_def)) : (A.ail_identifier * (Cerb_location.t * CF.Annot.attributes * C.tag_definition))) = match tag_def with 
   | C.StructDef (members, opt) -> 
     let cn_struct_sym = generate_sym_with_suffix ~suffix:"_cn" sym in
-    let new_members = List.map (fun (id, (attrs, alignment, qualifiers, ctype)) -> 
+    let new_members = List.Old.map (fun (id, (attrs, alignment, qualifiers, ctype)) -> 
       let sct_opt = Sctypes.of_ctype ctype in 
       let sct = match sct_opt with | Some t -> t | None -> failwith "Bad sctype" in
       let bt = BT.of_sct Memory.is_signed_integer_type Memory.size_of_integer_type sct in 
@@ -1643,7 +1643,7 @@ let cn_to_ail_resource_internal ?(is_pre=true) ?(is_toplevel=true) sym dts globa
   let calculate_return_type = function 
   | ResourceTypes.Owned (sct, _) -> (Sctypes.to_ctype sct, BT.of_sct Memory.is_signed_integer_type Memory.size_of_integer_type sct)
   | PName pname -> 
-    let matching_preds = List.filter (fun (pred_sym', def) -> Sym.equal pname pred_sym') preds in
+    let matching_preds = List.Old.filter (fun (pred_sym', def) -> Sym.equal pname pred_sym') preds in
     let (pred_sym', pred_def') = match matching_preds with 
       | [] -> failwith "Predicate not found"
       | p :: _ -> p
@@ -1680,11 +1680,11 @@ let cn_to_ail_resource_internal ?(is_pre=true) ?(is_toplevel=true) sym dts globa
         let binding = create_binding sym (bt_to_ail_ctype bt) in
         (e', binding :: bs', ss', Some (Sctypes.to_ctype sct))
       | PName pname -> 
-        let (bs, ss, es) = list_split_three (List.map (fun it -> cn_to_ail_expr_internal dts globals it PassBack) p.iargs) in
+        let (bs, ss, es) = list_split_three (List.Old.map (fun it -> cn_to_ail_expr_internal dts globals it PassBack) p.iargs) in
         let error_msg_update_stats_ = generate_error_msg_info_update_stats ~cn_source_loc_opt:(Some loc) () in
         let fcall = A.(AilEcall (mk_expr (AilEident pname), e :: es @ [mk_expr (AilEident enum_sym)])) in
         let binding = create_binding sym (bt_to_ail_ctype ~pred_sym:(Some pname) bt) in
-        (mk_expr fcall, binding :: (List.concat bs), List.concat ss @ error_msg_update_stats_, None)
+        (mk_expr fcall, binding :: (List.Old.concat bs), List.Old.concat ss @ error_msg_update_stats_, None)
     in
     let s_decl = match rm_ctype ctype with 
       | C.Void -> A.(AilSexpr rhs)
@@ -1771,10 +1771,10 @@ let cn_to_ail_resource_internal ?(is_pre=true) ?(is_toplevel=true) sym dts globa
         let (bs', ss', e') = cn_to_ail_expr_internal dts globals fn_call_it PassBack in
         (e', bs', ss', Some (Sctypes.to_ctype sct))
       | PName pname -> 
-        let (bs, ss, es) = list_split_three (List.map (fun it -> cn_to_ail_expr_internal dts globals it PassBack) q.iargs) in
+        let (bs, ss, es) = list_split_three (List.Old.map (fun it -> cn_to_ail_expr_internal dts globals it PassBack) q.iargs) in
         let error_msg_update_stats_ = generate_error_msg_info_update_stats ~cn_source_loc_opt:(Some loc) () in
         let fcall = A.(AilEcall (mk_expr (AilEident pname), (mk_expr (AilEident ptr_add_sym)) :: es @ [mk_expr (AilEident enum_sym)])) in
-        (mk_expr fcall, List.concat bs, List.concat ss @ error_msg_update_stats_, None)
+        (mk_expr fcall, List.Old.concat bs, List.Old.concat ss @ error_msg_update_stats_, None)
     in
 
     let typedef_name = get_typedef_string (bt_to_ail_ctype i_bt) in 
@@ -1786,9 +1786,9 @@ let cn_to_ail_resource_internal ?(is_pre=true) ?(is_toplevel=true) sym dts globa
     let (bs', ss') = match rm_ctype return_ctype with 
       | C.Void -> 
         let void_pred_call = A.(AilSexpr rhs) in
-        let if_stat = A.(AilSif (wrap_with_convert_from_cn_bool if_cond_expr, mk_stmt (AilSblock ([ptr_add_binding], List.map mk_stmt [ptr_add_stat; void_pred_call])), mk_stmt (AilSblock ([], [mk_stmt AilSskip])))) in 
-        let while_loop = A.(AilSwhile (wrap_with_convert_from_cn_bool while_cond_expr, mk_stmt (AilSblock ([], List.map mk_stmt [if_stat; increment_stat])), 0)) in
-        let ail_block = A.(AilSblock ([], List.map mk_stmt ([start_assign; while_loop]))) in
+        let if_stat = A.(AilSif (wrap_with_convert_from_cn_bool if_cond_expr, mk_stmt (AilSblock ([ptr_add_binding], List.Old.map mk_stmt [ptr_add_stat; void_pred_call])), mk_stmt (AilSblock ([], [mk_stmt AilSskip])))) in 
+        let while_loop = A.(AilSwhile (wrap_with_convert_from_cn_bool while_cond_expr, mk_stmt (AilSblock ([], List.Old.map mk_stmt [if_stat; increment_stat])), 0)) in
+        let ail_block = A.(AilSblock ([], List.Old.map mk_stmt ([start_assign; while_loop]))) in
         ([], [ail_block])
       | _ -> 
         (* TODO: Change to mostly use index terms rather than Ail directly - avoids duplication between these functions and cn_internal_to_ail *)
@@ -1802,10 +1802,10 @@ let cn_to_ail_resource_internal ?(is_pre=true) ?(is_toplevel=true) sym dts globa
           | None -> ""
         in
         let i_expr = if i_bt == BT.Integer then i_ident_expr else A.(AilEcall (mk_expr (AilEident (Sym.fresh_pretty ("cast_" ^ i_bt_str ^ "_to_cn_integer"))), [mk_expr i_ident_expr])) in
-        let map_set_expr_ = A.(AilEcall (mk_expr (AilEident (Sym.fresh_pretty "cn_map_set")), (List.map mk_expr [AilEident sym; i_expr]) @ [rhs])) in
-        let if_stat = A.(AilSif (wrap_with_convert_from_cn_bool if_cond_expr, mk_stmt (AilSblock (ptr_add_binding :: b4, List.map mk_stmt (s4 @ [ptr_add_stat; (AilSexpr (mk_expr map_set_expr_))]))), mk_stmt (AilSblock ([], [mk_stmt AilSskip])))) in 
-        let while_loop = A.(AilSwhile (wrap_with_convert_from_cn_bool while_cond_expr, mk_stmt A.(AilSblock ([], List.map mk_stmt [if_stat; increment_stat])), 0)) in
-        let ail_block = A.(AilSblock ([], List.map mk_stmt ([start_assign; while_loop]))) in
+        let map_set_expr_ = A.(AilEcall (mk_expr (AilEident (Sym.fresh_pretty "cn_map_set")), (List.Old.map mk_expr [AilEident sym; i_expr]) @ [rhs])) in
+        let if_stat = A.(AilSif (wrap_with_convert_from_cn_bool if_cond_expr, mk_stmt (AilSblock (ptr_add_binding :: b4, List.Old.map mk_stmt (s4 @ [ptr_add_stat; (AilSexpr (mk_expr map_set_expr_))]))), mk_stmt (AilSblock ([], [mk_stmt AilSskip])))) in 
+        let while_loop = A.(AilSwhile (wrap_with_convert_from_cn_bool while_cond_expr, mk_stmt A.(AilSblock ([], List.Old.map mk_stmt [if_stat; increment_stat])), 0)) in
+        let ail_block = A.(AilSblock ([], List.Old.map mk_stmt ([start_assign; while_loop]))) in
         ([sym_binding], [sym_decl; ail_block])
     in
 
@@ -1870,11 +1870,11 @@ let cn_to_ail_logical_constraint_internal : type a. (_ Cn.cn_datatype) list -> (
     
 let rec generate_record_opt pred_sym = function
   | BT.Record members ->
-    let members' = List.map (fun (id, bt) -> (id, bt_to_cn_base_type bt)) members in
+    let members' = List.Old.map (fun (id, bt) -> (id, bt_to_cn_base_type bt)) members in
     let record_sym = generate_sym_with_suffix ~suffix:"_record" pred_sym in
     Some (generate_struct_definition ~lc:false (record_sym, members'))
   | BT.Tuple ts ->
-    let members = List.map (fun t -> (create_id_from_sym (Sym.fresh ()), t)) ts in
+    let members = List.Old.map (fun t -> (create_id_from_sym (Sym.fresh ()), t)) ts in
     generate_record_opt pred_sym (BT.Record members)
   | _ -> None
 
@@ -1890,16 +1890,16 @@ let cn_to_ail_function_internal (fn_sym, (lf_def : LogicalFunctions.definition))
     | Def it
     | Rec_Def it ->
       let (bs, ss) = cn_to_ail_expr_internal_with_pred_name (Some fn_sym) cn_datatypes [] it Return in
-      (bs, Some (List.map mk_stmt ss))
+      (bs, Some (List.Old.map mk_stmt ss))
     | Uninterp -> ([], None)
   in
   let ail_record_opt = generate_record_opt fn_sym lf_def.return_bt in
-  let params = List.map (fun (sym, bt) -> (sym, (bt_to_ail_ctype bt))) lf_def.args in
-  let (param_syms, param_types) = List.split params in
-  let param_types = List.map (fun t -> (empty_qualifiers, t, false)) param_types in
-  let matched_cn_functions = List.filter (fun (cn_fun : (A.ail_identifier, C.ctype) Cn.cn_function) -> Sym.equal cn_fun.cn_func_name fn_sym) cn_functions in
+  let params = List.Old.map (fun (sym, bt) -> (sym, (bt_to_ail_ctype bt))) lf_def.args in
+  let (param_syms, param_types) = List.Old.split params in
+  let param_types = List.Old.map (fun t -> (empty_qualifiers, t, false)) param_types in
+  let matched_cn_functions = List.Old.filter (fun (cn_fun : (A.ail_identifier, C.ctype) Cn.cn_function) -> Sym.equal cn_fun.cn_func_name fn_sym) cn_functions in
   (* Unsafe - check if list has an element *)
-  let loc = (List.nth matched_cn_functions 0).cn_func_magic_loc in 
+  let loc = (List.Old.nth matched_cn_functions 0).cn_func_magic_loc in 
   (* Generating function declaration *)
   let decl = (fn_sym, (lf_def.loc, empty_attributes, A.(Decl_function (false, (empty_qualifiers, ret_type), param_types, false, false, false)))) in
   (* Generating function definition *)
@@ -1961,7 +1961,7 @@ let cn_to_ail_predicate_internal (pred_sym, (rp_def : ResourcePredicates.definit
             let (b1, s1, e) = cn_to_ail_expr_internal_with_pred_name (Some pred_sym) dts [] c.guard PassBack in
             let (bs'', ss'') = clause_translate cs in
             let conversion_from_cn_bool = A.(AilEcall (mk_expr (AilEident (Sym.fresh_pretty "convert_from_cn_bool")), [e])) in
-            let ail_if_stat = A.(AilSif (mk_expr conversion_from_cn_bool, mk_stmt (AilSblock (bs, List.map mk_stmt ss)), mk_stmt (AilSblock (bs'', List.map mk_stmt ss'')))) in
+            let ail_if_stat = A.(AilSif (mk_expr conversion_from_cn_bool, mk_stmt (AilSblock (bs, List.Old.map mk_stmt ss)), mk_stmt (AilSblock (bs'', List.Old.map mk_stmt ss'')))) in
             ([], [ail_if_stat])
   in
 
@@ -1970,22 +1970,22 @@ let cn_to_ail_predicate_internal (pred_sym, (rp_def : ResourcePredicates.definit
     | None -> ([], [])
   in
 
-  let pred_body = List.map mk_stmt ss in
+  let pred_body = List.Old.map mk_stmt ss in
 
   let ail_record_opt = generate_record_opt pred_sym rp_def.oarg_bt in
-  let params = List.map (fun (sym, bt) -> (sym, (bt_to_ail_ctype bt))) ((rp_def.pointer, BT.Loc) :: rp_def.iargs) in
+  let params = List.Old.map (fun (sym, bt) -> (sym, (bt_to_ail_ctype bt))) ((rp_def.pointer, BT.Loc) :: rp_def.iargs) in
   let enum_param_sym = Sym.fresh_pretty "owned_enum" in
   let params = params @ [(enum_param_sym, mk_ctype (C.(Basic (Integer (Enum (Sym.fresh_pretty "OWNERSHIP"))))))] in
-  let (param_syms, param_types) = List.split params in
-  let param_types = List.map (fun t -> (empty_qualifiers, t, false)) param_types in
+  let (param_syms, param_types) = List.Old.split params in
+  let param_types = List.Old.map (fun t -> (empty_qualifiers, t, false)) param_types in
   (* Generating function declaration *)
   let decl = (pred_sym, (rp_def.loc, empty_attributes, A.(Decl_function (false, (empty_qualifiers, ret_type), param_types, false, false, false)))) in
   (* Generating function definition *)
   let def = (pred_sym, (rp_def.loc, 0, empty_attributes, param_syms, mk_stmt A.(AilSblock (bs, pred_body)))) in
 
-  let matched_cn_preds = List.filter (fun (cn_pred : (A.ail_identifier, C.ctype) Cn.cn_predicate) -> Sym.equal cn_pred.cn_pred_name pred_sym) cn_preds in
+  let matched_cn_preds = List.Old.filter (fun (cn_pred : (A.ail_identifier, C.ctype) Cn.cn_predicate) -> Sym.equal cn_pred.cn_pred_name pred_sym) cn_preds in
   (* Unsafe - check if list has an element *)
-  let loc = (List.nth matched_cn_preds 0).cn_pred_magic_loc in 
+  let loc = (List.Old.nth matched_cn_preds 0).cn_pred_magic_loc in 
   (((loc, decl), def), ail_record_opt)
 
 let rec cn_to_ail_predicates_internal pred_def_list dts globals preds cn_preds = 
@@ -2034,7 +2034,7 @@ let rec cn_to_ail_post_aux_internal dts globals preds = function
 
 let cn_to_ail_post_internal dts globals preds (RT.Computational (bound, oinfo, t)) = 
   let (bs, ss) = cn_to_ail_post_aux_internal dts globals preds t in 
-  (bs, List.map mk_stmt ss)
+  (bs, List.Old.map mk_stmt ss)
 
 (* TODO: Add destination passing *)
 let cn_to_ail_cnstatement_internal : type a. (_ Cn.cn_datatype) list -> (C.union_tag * C.ctype) list -> a dest -> Cnprog.cn_statement -> (a * bool)
@@ -2106,9 +2106,9 @@ let cn_to_ail_cnprog_internal dts globals cn_prog =
   (bs, ss)
 
 let cn_to_ail_statements dts globals (loc, cn_progs) = 
-  let bs_and_ss = List.map (fun prog -> cn_to_ail_cnprog_internal dts globals prog) cn_progs in 
-  let (bs, ss) = List.split bs_and_ss in 
-  (loc, (List.concat bs, List.concat ss))
+  let bs_and_ss = List.Old.map (fun prog -> cn_to_ail_cnprog_internal dts globals prog) cn_progs in 
+  let (bs, ss) = List.Old.split bs_and_ss in 
+  (loc, (List.Old.concat bs, List.Old.concat ss))
 
 let prepend_to_precondition ail_executable_spec (b1, s1) = 
   let (b2, s2) = ail_executable_spec.pre in
@@ -2156,7 +2156,7 @@ let rec cn_to_ail_lat_internal_2 with_ownership_checking dts globals preds c_ret
         | (loc, s) :: ss ->
           let loc_equality x y = 
             String.equal (Cerb_location.location_to_string x) (Cerb_location.location_to_string y) in 
-          if (List.mem loc_equality loc locs) then 
+          if (List.Old.mem loc_equality loc locs) then 
             remove_duplicates locs ss
           else 
             (loc, s) :: (remove_duplicates (loc :: locs) ss))
@@ -2180,7 +2180,7 @@ let rec cn_to_ail_lat_internal_2 with_ownership_checking dts globals preds c_ret
         ([return_cn_binding], [mk_stmt return_cn_decl])
     in
     let stats = remove_duplicates [] stats in
-    let ail_statements = List.map (fun stat_pair -> cn_to_ail_statements dts globals stat_pair) stats in 
+    let ail_statements = List.Old.map (fun stat_pair -> cn_to_ail_statements dts globals stat_pair) stats in 
     let (post_bs, post_ss) = cn_to_ail_post_internal dts globals preds post in 
     let ownership_stat_ = if with_ownership_checking then 
       (let cn_stack_depth_decr_stat_ = mk_stmt (A.AilSexpr (mk_expr (AilEcall (mk_expr (AilEident OE.cn_stack_depth_decr_sym), [])))) in 

--- a/backend/cn/cn_internal_to_ail.ml
+++ b/backend/cn/cn_internal_to_ail.ml
@@ -175,7 +175,7 @@ let generate_record_sym sym members =
     | None ->   
       let map_bindings = RecordMap.bindings !records in
       (* Printf.printf "Record table size: %d\n" (List.length map_bindings); *)
-      let eq_members_bindings = List.Old.filter (fun (k, v) -> members_equal k members) map_bindings in
+      let eq_members_bindings = List.filter ~f:(fun (k, v) -> members_equal k members) map_bindings in
       match eq_members_bindings with 
       | [] -> 
         (* First time reaching record of this type - add to map *)
@@ -822,7 +822,7 @@ let rec cn_to_ail_expr_aux_internal
   | StructUpdate ((struct_term, m), new_val) ->
     let struct_tag = match IT.bt struct_term with | BT.Struct tag -> tag | _ -> failwith "Cannot do StructUpdate on non-struct term" in 
     let tag_defs = Pmap.bindings_list (CF.Tags.tagDefs ()) in 
-    let matching_tag_defs = List.Old.filter (fun (sym, (_, def)) -> Sym.equal struct_tag sym) tag_defs in 
+    let matching_tag_defs = List.filter ~f:(fun (sym, (_, def)) -> Sym.equal struct_tag sym) tag_defs in 
     let (_, (_, tag_def)) = if List.Old.is_empty matching_tag_defs then failwith "Struct not found in tagDefs" else List.nth_exn matching_tag_defs 0 in 
     (match tag_def with 
       | C.StructDef (members, _) -> 
@@ -885,9 +885,9 @@ let rec cn_to_ail_expr_aux_internal
       match dts with 
         | [] -> failwith "Datatype not found" (* Not found *)
         | dt :: dts' ->
-          let matching_cases = List.Old.filter (fun (c_sym, members) -> Sym.equal c_sym constr_sym) dt.cn_dt_cases in
+          let matching_cases = List.filter ~f:(fun (c_sym, members) -> Sym.equal c_sym constr_sym) dt.cn_dt_cases in
           if List.length matching_cases != 0 then
-            let (_, members) = List.Old.hd matching_cases in
+            let (_, members) = List.hd_exn matching_cases in
             (dt, members)
           else 
             find_dt_from_constructor constr_sym dts'
@@ -1075,7 +1075,7 @@ let rec cn_to_ail_expr_aux_internal
               else
                 match IT.bt term with
                   | BT.Datatype sym -> 
-                      let cn_dt = List.Old.filter (fun dt -> Sym.equal sym dt.cn_dt_name) dts in 
+                      let cn_dt = List.filter ~f:(fun dt -> Sym.equal sym dt.cn_dt_name) dts in 
                       (match cn_dt with 
                         | [] -> failwith "Datatype not found"
                         | dt :: _ ->
@@ -1643,7 +1643,7 @@ let cn_to_ail_resource_internal ?(is_pre=true) ?(is_toplevel=true) sym dts globa
   let calculate_return_type = function 
   | ResourceTypes.Owned (sct, _) -> (Sctypes.to_ctype sct, BT.of_sct Memory.is_signed_integer_type Memory.size_of_integer_type sct)
   | PName pname -> 
-    let matching_preds = List.Old.filter (fun (pred_sym', def) -> Sym.equal pname pred_sym') preds in
+    let matching_preds = List.filter ~f:(fun (pred_sym', def) -> Sym.equal pname pred_sym') preds in
     let (pred_sym', pred_def') = match matching_preds with 
       | [] -> failwith "Predicate not found"
       | p :: _ -> p
@@ -1897,7 +1897,7 @@ let cn_to_ail_function_internal (fn_sym, (lf_def : LogicalFunctions.definition))
   let params = List.map ~f:(fun (sym, bt) -> (sym, (bt_to_ail_ctype bt))) lf_def.args in
   let (param_syms, param_types) = List.Old.split params in
   let param_types = List.map ~f:(fun t -> (empty_qualifiers, t, false)) param_types in
-  let matched_cn_functions = List.Old.filter (fun (cn_fun : (A.ail_identifier, C.ctype) Cn.cn_function) -> Sym.equal cn_fun.cn_func_name fn_sym) cn_functions in
+  let matched_cn_functions = List.filter ~f:(fun (cn_fun : (A.ail_identifier, C.ctype) Cn.cn_function) -> Sym.equal cn_fun.cn_func_name fn_sym) cn_functions in
   (* Unsafe - check if list has an element *)
   let loc = (List.nth_exn matched_cn_functions 0).cn_func_magic_loc in 
   (* Generating function declaration *)
@@ -1983,7 +1983,7 @@ let cn_to_ail_predicate_internal (pred_sym, (rp_def : ResourcePredicates.definit
   (* Generating function definition *)
   let def = (pred_sym, (rp_def.loc, 0, empty_attributes, param_syms, mk_stmt A.(AilSblock (bs, pred_body)))) in
 
-  let matched_cn_preds = List.Old.filter (fun (cn_pred : (A.ail_identifier, C.ctype) Cn.cn_predicate) -> Sym.equal cn_pred.cn_pred_name pred_sym) cn_preds in
+  let matched_cn_preds = List.filter ~f:(fun (cn_pred : (A.ail_identifier, C.ctype) Cn.cn_predicate) -> Sym.equal cn_pred.cn_pred_name pred_sym) cn_preds in
   (* Unsafe - check if list has an element *)
   let loc = (List.nth_exn matched_cn_preds 0).cn_pred_magic_loc in 
   (((loc, decl), def), ail_record_opt)

--- a/backend/cn/cn_internal_to_ail.ml
+++ b/backend/cn/cn_internal_to_ail.ml
@@ -1094,7 +1094,7 @@ let rec cn_to_ail_expr_aux_internal
                             let bts = List.map ~f:cn_base_type_to_bt ts in
                             let new_constr_it = IT.IT (Sym count_sym, BT.Struct lc_sym, Cerb_location.unknown) in
                             let vars' = List.map ~f:(fun id -> T.StructMember (new_constr_it, id)) ids in
-                            let terms' = List.map ~f:(fun (var', bt') -> T.IT (var', bt', Cerb_location.unknown)) (List.Old.combine vars' bts) in
+                            let terms' = List.map ~f:(fun (var', bt') -> T.IT (var', bt', Cerb_location.unknown)) (List.zip_exn vars' bts) in
 
                             let (bindings, member_stats) = translate (count + 1) (terms' @ vs) cases' in
                             (* TODO: Check *)
@@ -1276,7 +1276,7 @@ let generate_datatype_equality_function (cn_datatype : cn_datatype) =
         let constr_struct_type = mk_ctype C.(Pointer (empty_qualifiers, mk_ctype (Struct lc_constr_sym))) in
         let bindings = List.map ~f:(fun sym -> create_binding sym constr_struct_type) constr_syms in 
         let memberof_ptr_es = List.map ~f:(fun sym -> mk_expr A.(AilEmemberofptr (mk_expr (AilEident sym), Id.id "u"))) param_syms in
-        let decls = List.map ~f:(fun (constr_sym, e) -> A.(AilSdeclaration [(constr_sym, Some (mk_expr (AilEmemberof (e, constr_id))))])) (List.Old.combine constr_syms memberof_ptr_es) in
+        let decls = List.map ~f:(fun (constr_sym, e) -> A.(AilSdeclaration [(constr_sym, Some (mk_expr (AilEmemberof (e, constr_id))))])) (List.zip_exn constr_syms memberof_ptr_es) in
         (bindings, List.map ~f:mk_stmt decls)
     in
     let equality_expr = generate_equality_expr members x_constr_sym y_constr_sym in
@@ -1378,7 +1378,7 @@ let generate_struct_equality_function ?(is_record=false) dts ((sym, (loc, attrs,
       let param_type = (empty_qualifiers, mk_ctype (C.Pointer (empty_qualifiers, mk_ctype Void)), false) in
       let cast_param_syms = List.map ~f:(fun sym -> generate_sym_with_suffix ~suffix:"_cast" sym) param_syms in 
       let cast_bindings = List.map ~f:(fun sym -> create_binding sym cn_struct_ptr_ctype) cast_param_syms in 
-      let cast_assignments = List.map ~f:(fun (cast_sym, sym) -> A.(AilSdeclaration [cast_sym, Some (mk_expr (AilEcast (empty_qualifiers, cn_struct_ptr_ctype, (mk_expr (AilEident sym)))))])) (List.Old.combine cast_param_syms param_syms) in 
+      let cast_assignments = List.map ~f:(fun (cast_sym, sym) -> A.(AilSdeclaration [cast_sym, Some (mk_expr (AilEcast (empty_qualifiers, cn_struct_ptr_ctype, (mk_expr (AilEident sym)))))])) (List.zip_exn cast_param_syms param_syms) in 
       (* Function body *)
       let generate_member_equality (id, (_, _, _, ctype)) = 
         let _doc = (CF.Pp_ail.pp_ctype ~executable_spec:true empty_qualifiers ctype) in 
@@ -1534,7 +1534,7 @@ let generate_record_equality_function dts (sym, (members: BT.member_types)) =
     let param_type = (empty_qualifiers, mk_ctype (C.Pointer (empty_qualifiers, mk_ctype Void)), false) in
     let cast_param_syms = List.map ~f:(fun sym -> generate_sym_with_suffix ~suffix:"_cast" sym) param_syms in 
     let cast_bindings = List.map ~f:(fun sym -> create_binding sym cn_struct_ptr_ctype) cast_param_syms in 
-    let cast_assignments = List.map ~f:(fun (cast_sym, sym) -> A.(AilSdeclaration [cast_sym, Some (mk_expr (AilEcast (empty_qualifiers, cn_struct_ptr_ctype, (mk_expr (AilEident sym)))))])) (List.Old.combine cast_param_syms param_syms) in 
+    let cast_assignments = List.map ~f:(fun (cast_sym, sym) -> A.(AilSdeclaration [cast_sym, Some (mk_expr (AilEcast (empty_qualifiers, cn_struct_ptr_ctype, (mk_expr (AilEident sym)))))])) (List.zip_exn cast_param_syms param_syms) in 
     (* Function body *)
     let generate_member_equality (id, bt) = 
       let args = List.map ~f:(fun cast_sym -> mk_expr (AilEmemberofptr (mk_expr (AilEident cast_sym), id))) cast_param_syms in 

--- a/backend/cn/cnprog.ml
+++ b/backend/cn/cnprog.ml
@@ -60,10 +60,10 @@ let rec subst substitution = function
            M_CN_extract (attrs, to_extract, IT.subst substitution it)
        | M_CN_unfold (fsym, args) ->
           (* fsym is a function symbol *)
-          M_CN_unfold (fsym, List.Old.map (IT.subst substitution) args)
+          M_CN_unfold (fsym, List.map ~f:(IT.subst substitution) args)
        | M_CN_apply (fsym, args) ->
           (* fsym is a lemma symbol *)
-          M_CN_apply (fsym, List.Old.map (IT.subst substitution) args)
+          M_CN_apply (fsym, List.map ~f:(IT.subst substitution) args)
        | M_CN_assert lc ->
           M_CN_assert (LC.subst substitution lc)
        | M_CN_inline nms ->
@@ -121,16 +121,16 @@ let dtree_of_cn_statement = function
      Dnode (pp_ctor "Split_case", [LC.dtree lc])
   | M_CN_extract (attrs, to_extract, it) ->
      Dnode (pp_ctor "Extract",
-            [Dnode (pp_ctor "Attrs", List.Old.map (fun s -> Dleaf (Id.pp s)) attrs);
+            [Dnode (pp_ctor "Attrs", List.map ~f:(fun s -> Dleaf (Id.pp s)) attrs);
                 dtree_of_to_extract to_extract; IT.dtree it])
   | M_CN_unfold (s, args) ->
-     Dnode (pp_ctor "Unfold", Dleaf (Sym.pp s) :: List.Old.map IT.dtree args)
+     Dnode (pp_ctor "Unfold", Dleaf (Sym.pp s) :: List.map ~f:IT.dtree args)
   | M_CN_apply (s, args) ->
-     Dnode (pp_ctor "Apply", Dleaf (Sym.pp s) :: List.Old.map IT.dtree args)
+     Dnode (pp_ctor "Apply", Dleaf (Sym.pp s) :: List.map ~f:IT.dtree args)
   | M_CN_assert lc ->
      Dnode (pp_ctor "Assert", [LC.dtree lc])
   | M_CN_inline nms ->
-     Dnode (pp_ctor "Inline", List.Old.map (fun nm -> Dleaf (Sym.pp nm)) nms)
+     Dnode (pp_ctor "Inline", List.map ~f:(fun nm -> Dleaf (Sym.pp nm)) nms)
   | M_CN_print it ->
      Dnode (pp_ctor "Print", [IT.dtree it])
 

--- a/backend/cn/cnprog.ml
+++ b/backend/cn/cnprog.ml
@@ -60,10 +60,10 @@ let rec subst substitution = function
            M_CN_extract (attrs, to_extract, IT.subst substitution it)
        | M_CN_unfold (fsym, args) ->
           (* fsym is a function symbol *)
-          M_CN_unfold (fsym, List.map (IT.subst substitution) args)
+          M_CN_unfold (fsym, List.Old.map (IT.subst substitution) args)
        | M_CN_apply (fsym, args) ->
           (* fsym is a lemma symbol *)
-          M_CN_apply (fsym, List.map (IT.subst substitution) args)
+          M_CN_apply (fsym, List.Old.map (IT.subst substitution) args)
        | M_CN_assert lc ->
           M_CN_assert (LC.subst substitution lc)
        | M_CN_inline nms ->
@@ -121,16 +121,16 @@ let dtree_of_cn_statement = function
      Dnode (pp_ctor "Split_case", [LC.dtree lc])
   | M_CN_extract (attrs, to_extract, it) ->
      Dnode (pp_ctor "Extract",
-            [Dnode (pp_ctor "Attrs", List.map (fun s -> Dleaf (Id.pp s)) attrs);
+            [Dnode (pp_ctor "Attrs", List.Old.map (fun s -> Dleaf (Id.pp s)) attrs);
                 dtree_of_to_extract to_extract; IT.dtree it])
   | M_CN_unfold (s, args) ->
-     Dnode (pp_ctor "Unfold", Dleaf (Sym.pp s) :: List.map IT.dtree args)
+     Dnode (pp_ctor "Unfold", Dleaf (Sym.pp s) :: List.Old.map IT.dtree args)
   | M_CN_apply (s, args) ->
-     Dnode (pp_ctor "Apply", Dleaf (Sym.pp s) :: List.map IT.dtree args)
+     Dnode (pp_ctor "Apply", Dleaf (Sym.pp s) :: List.Old.map IT.dtree args)
   | M_CN_assert lc ->
      Dnode (pp_ctor "Assert", [LC.dtree lc])
   | M_CN_inline nms ->
-     Dnode (pp_ctor "Inline", List.map (fun nm -> Dleaf (Sym.pp nm)) nms)
+     Dnode (pp_ctor "Inline", List.Old.map (fun nm -> Dleaf (Sym.pp nm)) nms)
   | M_CN_print it ->
      Dnode (pp_ctor "Print", [IT.dtree it])
 

--- a/backend/cn/compile.ml
+++ b/backend/cn/compile.ml
@@ -1178,9 +1178,9 @@ let translate_cn_function env (def: cn_function) =
   let env' =
     List.Old.fold_left (fun acc (sym, bt) -> add_logical sym bt acc
       ) env args in
-  let is_rec = List.Old.exists (fun id -> String.equal (Id.s id) "rec") def.cn_func_attrs in
-  let coq_unfold = List.Old.exists (fun id -> String.equal (Id.s id) "coq_unfold") def.cn_func_attrs in
-  let@ () = ListM.iterM (fun id -> if List.Old.exists (String.equal (Id.s id)) known_attrs
+  let is_rec = List.exists ~f:(fun id -> String.equal (Id.s id) "rec") def.cn_func_attrs in
+  let coq_unfold = List.exists ~f:(fun id -> String.equal (Id.s id) "coq_unfold") def.cn_func_attrs in
+  let@ () = ListM.iterM (fun id -> if List.exists ~f:(String.equal (Id.s id)) known_attrs
     then return ()
     else fail {loc = def.cn_func_loc; msg = Generic (Pp.item "Unknown attribute" (Id.pp id))}
   ) def.cn_func_attrs in

--- a/backend/cn/compile.ml
+++ b/backend/cn/compile.ml
@@ -206,7 +206,7 @@ let rec free_in_expr (CNExpr (_loc, expr_)) =
   | CNExpr_memberupdates (e, updates) ->
      free_in_exprs (e :: List.map ~f:snd updates)
   | CNExpr_arrayindexupdates (e, updates) ->
-     free_in_exprs (e :: List.Old.concat_map (fun (e1, e2) -> [e1; e2]) updates)
+     free_in_exprs (e :: List.concat_map ~f:(fun (e1, e2) -> [e1; e2]) updates)
   | CNExpr_binop (_binop, e1, e2) ->
      free_in_exprs [e1; e2]
   | CNExpr_sizeof _ ->
@@ -394,7 +394,7 @@ let add_datatype_info env (dt : cn_datatype) =
                              ^^^ !^"within datatype definition.")}
   in
   let@ all_params = ListM.fold_leftM add_param StringMap.empty
-    (List.Old.concat_map snd dt.cn_dt_cases) in
+    (List.concat_map ~f:snd dt.cn_dt_cases) in
   let add_constr env (cname, params) =
     let c_params =
       List.map ~f:(fun (nm, ty) ->

--- a/backend/cn/compile.ml
+++ b/backend/cn/compile.ml
@@ -1358,7 +1358,7 @@ let translate_cn_clauses env clauses =
       end clauses'
   in
   let@ xs = self [] clauses in
-  return (List.Old.rev xs)
+  return (List.rev xs)
 
 let translate_option_cn_clauses env = function
   | Some clauses ->

--- a/backend/cn/compile.ml
+++ b/backend/cn/compile.ml
@@ -695,7 +695,7 @@ module EffectfulTranslation = struct
             return (IT ((Sym sym), bTy, loc))
         | CNExpr_list es ->
             let@ es = ListM.mapM self es in
-            let item_bt = basetype (List.Old.hd es) in
+            let item_bt = basetype (List.hd_exn es) in
             let  (_, nil_pos, _) =
               (* parser should ensure loc is a region *)
               Option.get @@ Locations.get_region loc in
@@ -882,7 +882,7 @@ module EffectfulTranslation = struct
                  return (pat, body)
                ) ms
            in
-           let rbt = IT.basetype (snd (List.Old.hd ms)) in
+           let rbt = IT.basetype (snd (List.hd_exn ms)) in
            return (IT (Match (x, ms), rbt, loc))
         | CNExpr_let (s, e, body) ->
             let@ e = self e in

--- a/backend/cn/context.ml
+++ b/backend/cn/context.ml
@@ -1,5 +1,4 @@
 open Pp
-open List
 
 module BT = BaseTypes
 module LS = LogicalSorts
@@ -74,7 +73,7 @@ let empty =
 
 
 
-let get_rs (ctxt : t) = List.map fst (fst ctxt.resources)
+let get_rs (ctxt : t) = List.Old.map fst (fst ctxt.resources)
 
 let pp_basetype_or_value = function
   | BaseType bt -> BaseTypes.pp bt
@@ -219,7 +218,7 @@ let res_written loc id reason (ix, m) =
 (* used during unfold, clone one history to a list of new ids *)
 let clone_history id ids m =
   let h = res_map_history m id in
-  List.fold_right (fun id2 m -> set_map_history id2 h m) ids m
+  List.Old.fold_right (fun id2 m -> set_map_history id2 h m) ids m
 
 
 let json (ctxt : t) : Yojson.Safe.t =
@@ -230,19 +229,19 @@ let json (ctxt : t) : Yojson.Safe.t =
   in
 
   let computational  =
-    List.map (fun (sym, (binding, _)) ->
+    List.Old.map (fun (sym, (binding, _)) ->
         `Assoc [("name", Sym.json sym);
                 ("type", basetype_or_value binding)]
       ) (SymMap.bindings ctxt.computational)
   in
   let logical =
-    List.map (fun (sym, (binding, _)) ->
+    List.Old.map (fun (sym, (binding, _)) ->
         `Assoc [("name", Sym.json sym);
                 ("type", basetype_or_value binding)]
       ) (SymMap.bindings ctxt.logical)
   in
-  let resources = List.map RE.json (get_rs ctxt) in
-  let constraints = List.map LC.json (LCSet.elements ctxt.constraints) in
+  let resources = List.Old.map RE.json (get_rs ctxt) in
+  let constraints = List.Old.map LC.json (LCSet.elements ctxt.constraints) in
   let json_record =
     `Assoc [("computational", `List computational);
             ("logical", `List logical);

--- a/backend/cn/context.ml
+++ b/backend/cn/context.ml
@@ -73,7 +73,7 @@ let empty =
 
 
 
-let get_rs (ctxt : t) = List.Old.map fst (fst ctxt.resources)
+let get_rs (ctxt : t) = List.map ~f:fst (fst ctxt.resources)
 
 let pp_basetype_or_value = function
   | BaseType bt -> BaseTypes.pp bt
@@ -229,19 +229,19 @@ let json (ctxt : t) : Yojson.Safe.t =
   in
 
   let computational  =
-    List.Old.map (fun (sym, (binding, _)) ->
+    List.map ~f:(fun (sym, (binding, _)) ->
         `Assoc [("name", Sym.json sym);
                 ("type", basetype_or_value binding)]
       ) (SymMap.bindings ctxt.computational)
   in
   let logical =
-    List.Old.map (fun (sym, (binding, _)) ->
+    List.map ~f:(fun (sym, (binding, _)) ->
         `Assoc [("name", Sym.json sym);
                 ("type", basetype_or_value binding)]
       ) (SymMap.bindings ctxt.logical)
   in
-  let resources = List.Old.map RE.json (get_rs ctxt) in
-  let constraints = List.Old.map LC.json (LCSet.elements ctxt.constraints) in
+  let resources = List.map ~f:RE.json (get_rs ctxt) in
+  let constraints = List.map ~f:LC.json (LCSet.elements ctxt.constraints) in
   let json_record =
     `Assoc [("computational", `List computational);
             ("logical", `List logical);

--- a/backend/cn/coreTypeChecks.ml
+++ b/backend/cn/coreTypeChecks.ml
@@ -37,7 +37,7 @@ let check_against_core_bt fail_op core_bt cn_bt =
     | BTy_object ot, bt -> check_object_type (ot, bt)
     | BTy_loaded ot, bt -> check_object_type (ot, bt)
     | BTy_list cbt, BT.List bt -> check_core_base_type (cbt, bt)
-    | BTy_tuple cbts, BT.Tuple bts when List.Old.length bts == List.Old.length bts ->
+    | BTy_tuple cbts, BT.Tuple bts when List.length bts == List.length bts ->
         let@ _ = ListM.map2M (Tools.curry check_core_base_type) cbts bts in
         return ()
     | BTy_storable, _ -> fail_op (Pp.string "unsupported: BTy_storable")

--- a/backend/cn/coreTypeChecks.ml
+++ b/backend/cn/coreTypeChecks.ml
@@ -37,7 +37,7 @@ let check_against_core_bt fail_op core_bt cn_bt =
     | BTy_object ot, bt -> check_object_type (ot, bt)
     | BTy_loaded ot, bt -> check_object_type (ot, bt)
     | BTy_list cbt, BT.List bt -> check_core_base_type (cbt, bt)
-    | BTy_tuple cbts, BT.Tuple bts when List.length bts == List.length bts ->
+    | BTy_tuple cbts, BT.Tuple bts when List.Old.length bts == List.Old.length bts ->
         let@ _ = ListM.map2M (Tools.curry check_core_base_type) cbts bts in
         return ()
     | BTy_storable, _ -> fail_op (Pp.string "unsupported: BTy_storable")

--- a/backend/cn/core_to_mucore.ml
+++ b/backend/cn/core_to_mucore.ml
@@ -164,7 +164,7 @@ let rec core_to_mu__pattern ~inherit_loc loc (Pattern (annots, pat_)) =
      | Ccons -> wrap (M_CaseCtor (M_Ccons, pats))
      | Ctuple -> wrap (M_CaseCtor (M_Ctuple, pats))
      | Carray -> wrap (M_CaseCtor (M_Carray, pats))
-     | Cspecified -> List.Old.hd pats
+     | Cspecified -> List.hd_exn pats
      | _ -> assert_error loc (!^"core_to_mucore: unsupported pattern")
 
 
@@ -289,7 +289,7 @@ let rec n_pexpr ~inherit_loc loc (Pexpr (annots, bty, pe)) : mu_pexpr =
      | Core.Carray, _ ->
         annotate (M_PEctor (M_Carray, List.map ~f:(n_pexpr loc) args))
      | Core.Cspecified, _ ->
-        n_pexpr loc (List.Old.hd args)
+        n_pexpr loc (List.hd_exn args)
      | Core.Civsizeof, [ct_expr] ->
         annotate (M_PEapply_fun (M_F_size_of, [n_pexpr loc ct_expr]))
      | Core.Civsizeof, _ ->

--- a/backend/cn/core_to_mucore.ml
+++ b/backend/cn/core_to_mucore.ml
@@ -433,7 +433,7 @@ let rec n_pexpr ~inherit_loc loc (Pexpr (annots, bty, pe)) : mu_pexpr =
        Pexpr (annots2, _, PEctor (Ctuple, [Pexpr (_, _, PEsym sym2);
                                            Pexpr (_, _, PEsym sym2')]))
        (* pairwise disjoint *)
-       when (List.Old.length (List.Old.sort_uniq Sym.compare [sym; sym'; sym2; sym2']) = 4) ->
+       when (List.length (List.Old.sort_uniq Sym.compare [sym; sym'; sym2; sym2']) = 4) ->
         let e'' = Core_peval.subst_sym_pexpr2 sym
                    (get_loc annots2, `SYM sym2) e'' in
         let e'' = Core_peval.subst_sym_pexpr2 sym'
@@ -679,7 +679,7 @@ let n_memop ~inherit_loc loc memop pexprs =
      let err =
        !^(show_n_memop memop)
        ^^^ !^"applied to"
-       ^^^ Print.int (List.Old.length pexprs1)
+       ^^^ Print.int (List.length pexprs1)
        ^^^ !^"arguments"
      in
      assert_error loc err
@@ -726,7 +726,7 @@ let rec n_expr ~inherit_loc (loc : Loc.t) ((env, old_states), desugaring_things)
        Pexpr (annots2, _, PEctor (Ctuple, [Pexpr (_, _, PEsym sym2);
                                            Pexpr (_, _, PEsym sym2')]))
        (* pairwise disjoint *)
-       when (List.Old.length (List.Old.sort_uniq Sym.compare [sym; sym'; sym2; sym2']) = 4) ->
+       when (List.length (List.Old.sort_uniq Sym.compare [sym; sym'; sym2; sym2']) = 4) ->
         let e2 = Core_peval.subst_sym_expr2 sym
                    (get_loc annots2, `SYM sym2) e2 in
         let e2 = Core_peval.subst_sym_expr2 sym'

--- a/backend/cn/core_to_mucore.ml
+++ b/backend/cn/core_to_mucore.ml
@@ -98,7 +98,7 @@ let convert_core_bt_for_list loc =
     | BTy_unit -> BT.Unit
     | BTy_boolean -> BT.Bool
     | BTy_list bt -> BT.List (bt_of_core_base_type bt)
-    | BTy_tuple bts -> BT.Tuple (List.Old.map bt_of_core_base_type bts)
+    | BTy_tuple bts -> BT.Tuple (List.map ~f:bt_of_core_base_type bts)
     | BTy_ctype -> BT.CType
     | cbt -> assert_error loc (Print.item "convert_core_bt_for_list"
         (Pp_mucore.pp_core_base_type cbt))
@@ -177,9 +177,9 @@ let rec n_ov loc ov =
    | OVpointer pv ->
       M_OVpointer pv
    | OVarray is ->
-      M_OVarray (List.Old.map (n_lv loc) is)
+      M_OVarray (List.map ~f:(n_lv loc) is)
    | OVstruct (sym1, is) ->
-      M_OVstruct (sym1, List.Old.map (fun (id,ct,mv) -> (id,convert_ct loc ct,mv)) is)
+      M_OVstruct (sym1, List.map ~f:(fun (id,ct,mv) -> (id,convert_ct loc ct,mv)) is)
    | OVunion (sym1, id1, mv) ->
       M_OVunion (sym1, id1, mv)
   in
@@ -201,8 +201,8 @@ and n_val loc v =
    | Vtrue -> M_Vtrue
    | Vfalse -> M_Vfalse
    | Vctype ct -> M_Vctype ct
-   | Vlist (cbt, vs) -> M_Vlist (cbt, List.Old.map (n_val loc) vs)
-   | Vtuple vs -> M_Vtuple (List.Old.map (n_val loc) vs)
+   | Vlist (cbt, vs) -> M_Vlist (cbt, List.map ~f:(n_val loc) vs)
+   | Vtuple vs -> M_Vtuple (List.map ~f:(n_val loc) vs)
   in
   M_V ((),v)
 
@@ -232,7 +232,7 @@ let rec n_pexpr ~inherit_loc loc (Pexpr (annots, bty, pe)) : mu_pexpr =
   | PEval v ->
      annotate (M_PEval (n_val loc v))
   | PEconstrained l ->
-     let l = List.Old.map (fun (c, e) -> (c, n_pexpr loc e)) l in
+     let l = List.map ~f:(fun (c, e) -> (c, n_pexpr loc e)) l in
      annotate (M_PEconstrained l)
   | PEundef(l, u) ->
      annotate (M_PEundef (l, u))
@@ -281,13 +281,13 @@ let rec n_pexpr ~inherit_loc loc (Pexpr (annots, bty, pe)) : mu_pexpr =
      | Core.Civfromfloat, _ ->
         argnum_err ()
      | Core.Cnil bt1, _ ->
-        annotate (M_PEctor (M_Cnil bt1, List.Old.map (n_pexpr loc) args))
+        annotate (M_PEctor (M_Cnil bt1, List.map ~f:(n_pexpr loc) args))
      | Core.Ccons, _ ->
-        annotate (M_PEctor (M_Ccons, List.Old.map (n_pexpr loc) args))
+        annotate (M_PEctor (M_Ccons, List.map ~f:(n_pexpr loc) args))
      | Core.Ctuple, _ ->
-        annotate (M_PEctor (M_Ctuple, List.Old.map (n_pexpr loc) args))
+        annotate (M_PEctor (M_Ctuple, List.map ~f:(n_pexpr loc) args))
      | Core.Carray, _ ->
-        annotate (M_PEctor (M_Carray, List.Old.map (n_pexpr loc) args))
+        annotate (M_PEctor (M_Carray, List.map ~f:(n_pexpr loc) args))
      | Core.Cspecified, _ ->
         n_pexpr loc (List.Old.hd args)
      | Core.Civsizeof, [ct_expr] ->
@@ -331,7 +331,7 @@ let rec n_pexpr ~inherit_loc loc (Pexpr (annots, bty, pe)) : mu_pexpr =
      let e'' = n_pexpr loc e'' in
      annotate (M_PEop(binop1, e', e''))
   | PEstruct(sym1, fields) ->
-     let fields = List.Old.map (fun (m, e) -> (m, n_pexpr loc e)) fields in
+     let fields = List.map ~f:(fun (m, e) -> (m, n_pexpr loc e)) fields in
      annotate (M_PEstruct(sym1, fields))
   | PEunion(sym1, id1, e') ->
      let e' = n_pexpr loc e' in
@@ -401,7 +401,7 @@ let rec n_pexpr ~inherit_loc loc (Pexpr (annots, bty, pe)) : mu_pexpr =
      | Sym (Symbol (_, _, SD_Id fun_id)), args ->
         begin match List.Old.assoc_opt String.equal fun_id function_ids with
         | Some fun_id ->
-           let args = List.Old.map (n_pexpr loc) args in
+           let args = List.map ~f:(n_pexpr loc) args in
            annotate (M_PEapply_fun (fun_id, args))
         | None ->
            assert_error loc (!^"PEcall (SD_Id) not inlined: " ^^^ !^ fun_id ^^ Print.colon ^^^
@@ -784,10 +784,10 @@ let rec n_expr ~inherit_loc (loc : Loc.t) ((env, old_states), desugaring_things)
           return (M_Pexpr (loc, annots, bty, (M_PEval (M_V ((), M_Vfunction_addr sym)))))
        | _ -> return @@ n_pexpr e2
      in
-     let es = List.Old.map n_pexpr es in
+     let es = List.map ~f:n_pexpr es in
      return (wrap (M_Eccall(ct1, e2, es)))
   | Eproc(_a, name, es) ->
-     let es = List.Old.map n_pexpr es in
+     let es = List.map ~f:n_pexpr es in
      begin match name, es with
      | Impl (BuiltinFunction "ctz"), [arg1] ->
        return (wrap_pure (M_PEbitwise_unop (M_BW_CTZ, arg1)))
@@ -864,7 +864,7 @@ let rec n_expr ~inherit_loc (loc : Loc.t) ((env, old_states), desugaring_things)
   | Esave((_sym1,_bt1), _syms_typs_pes, _e) ->
      assert_error loc !^"core_anormalisation: Esave"
   | Erun(_a, sym1, pes) ->
-     let pes = List.Old.map n_pexpr pes in
+     let pes = List.map ~f:n_pexpr pes in
      return (wrap (M_Erun(sym1, pes)))
   | Epar _es ->
      assert_error loc !^"core_anormalisation: Epar"
@@ -1127,14 +1127,14 @@ let fetch_typedef d_st _loc sym =
 
 
 let dtree_of_inv conds =
-  Dnode (pp_ctor "LoopInvariantAnnotation", List.Old.map CF.Cn_ocaml.PpAil.dtree_of_cn_condition conds)
+  Dnode (pp_ctor "LoopInvariantAnnotation", List.map ~f:CF.Cn_ocaml.PpAil.dtree_of_cn_condition conds)
 let dtree_of_requires conds =
-  Dnode (pp_ctor "RequiresAnnotation", List.Old.map CF.Cn_ocaml.PpAil.dtree_of_cn_condition conds)
+  Dnode (pp_ctor "RequiresAnnotation", List.map ~f:CF.Cn_ocaml.PpAil.dtree_of_cn_condition conds)
 let dtree_of_ensures conds =
-  Dnode (pp_ctor "EnsuresAnnotation", List.Old.map CF.Cn_ocaml.PpAil.dtree_of_cn_condition conds)
+  Dnode (pp_ctor "EnsuresAnnotation", List.map ~f:CF.Cn_ocaml.PpAil.dtree_of_cn_condition conds)
 let dtree_of_accesses accesses =
   Dnode (pp_ctor "AccessesAnnotation",
-         List.Old.map (fun (_loc, (s, ct)) ->
+         List.map ~f:(fun (_loc, (s, ct)) ->
              Dnode (pp_ctor "Access", [Dleaf (Sym.pp s); Dleaf (Pp_core_ctype.pp_ctype ct)])
            ) accesses)
 
@@ -1247,10 +1247,10 @@ let normalise_fun_map_decl
            return (loc, logical_fun_sym)
          ) mk_functions
      in
-     let defn_spec_sites = List.Old.map fst requires @ List.Old.map fst ensures @
-       List.Old.map fst accesses in
+     let defn_spec_sites = List.map ~f:fst requires @ List.map ~f:fst ensures @
+       List.map ~f:fst accesses in
      let@ accesses = ListM.mapM (desugar_access d_st global_types) accesses in
-     let@ (requires, d_st) = desugar_conds d_st (List.Old.map snd requires) in
+     let@ (requires, d_st) = desugar_conds d_st (List.map ~f:snd requires) in
      Print.debug 6 (lazy (Print.string "desugared requires conds"));
      let@ (ret_s, ret_d_st) = register_new_cn_local (Id.id "return") d_st in
 (*
@@ -1259,7 +1259,7 @@ let normalise_fun_map_decl
      assertl loc (BT.equal bt1 bt2)
        !^"function return type mismatch" (lazy (Print.ineq (BT.pp bt1) (BT.pp bt2)));
 *)
-     let@ (ensures, _ret_d_st) = desugar_conds ret_d_st (List.Old.map snd ensures) in
+     let@ (ensures, _ret_d_st) = desugar_conds ret_d_st (List.map ~f:snd ensures) in
      Print.debug 6 (lazy (Print.string "desugared ensures conds"));
 
      let@ (spec_req, spec_ens, env) = match SymMap.find_opt fname fun_specs with
@@ -1270,7 +1270,7 @@ let normalise_fun_map_decl
               !^"re-specification of CN annotations from:" ^^ P.break 1 ^^^
               Locations.pp spec.cn_spec_loc)}
         in
-        let env = add_spec_arg_renames loc args (List.Old.map snd arg_cts) spec env in
+        let env = add_spec_arg_renames loc args (List.map ~f:snd arg_cts) spec env in
         let env = C.add_renamed_computational spec.cn_spec_ret_name ret_s
             (Memory.sbt_of_sct (convert_ct loc ret_ct)) env in
         return (spec.cn_spec_requires, spec.cn_spec_ensures, env)
@@ -1308,7 +1308,7 @@ let normalise_fun_map_decl
      in
      (* let ft = at_of_arguments (fun (_body, _labels, rt) -> rt) args_and_body in *)
 
-     let desugared_spec = { accesses = List.Old.map snd accesses; requires; ensures } in
+     let desugared_spec = { accesses = List.map ~f:snd accesses; requires; ensures } in
 
      return (Some (M_Proc(loc, args_and_body, trusted, desugared_spec), mk_functions))
 
@@ -1325,7 +1325,7 @@ let normalise_fun_map_decl
                (spec.cn_spec_ret_name, ret_ct) ([], spec.cn_spec_ensures)
            in
            return returned
-         ) loc env (List.Old.combine spec.cn_spec_args (List.Old.map snd arg_cts)) spec.cn_spec_requires
+         ) loc env (List.Old.combine spec.cn_spec_args (List.map ~f:snd arg_cts)) spec.cn_spec_requires
        in
        let ft = at_of_arguments Tools.id args_and_rt in
        return (Some (M_ProcDecl (loc, Some ft), []))
@@ -1333,7 +1333,7 @@ let normalise_fun_map_decl
      end
   | Mi_BuiltinDecl(_loc, _bt, _bts) ->
      assert false
-     (* M_BuiltinDecl(loc, convert_bt loc bt, List.Old.map (convert_bt loc) bts) *)
+     (* M_BuiltinDecl(loc, convert_bt loc bt, List.map ~f:(convert_bt loc) bts) *)
 
 let normalise_fun_map
       ~inherit_loc
@@ -1354,7 +1354,7 @@ let normalise_fun_map
       match r with
       | Some (fdecl, more_mk_functions) ->
          let mk_functions' =
-           List.Old.map (fun (loc, lsym) -> {c_fun_sym = fsym; loc; l_fun_sym = lsym})
+           List.map ~f:(fun (loc, lsym) -> {c_fun_sym = fsym; loc; l_fun_sym = lsym})
              more_mk_functions
          in
          return (Pmap.add fsym fdecl fmap, mk_functions' @ mk_functions, failed)
@@ -1468,7 +1468,7 @@ let translate_datatype env {cn_dt_loc; cn_dt_name; cn_dt_cases; cn_dt_magic_loc 
   let translate_arg (id, bt) =
     (id, SBT.to_basetype (Compile.translate_cn_base_type env bt)) in
   let cases =
-    List.Old.map (fun (c, args) -> (c, List.Old.map translate_arg args)) cn_dt_cases in
+    List.map ~f:(fun (c, args) -> (c, List.map ~f:translate_arg args)) cn_dt_cases in
   (cn_dt_name, { loc = cn_dt_loc; cases })
 
 
@@ -1492,7 +1492,7 @@ let normalise_file ~inherit_loc ((fin_markers_env : CAE.fin_markers_env), ail_pr
   let@ lemmata = ListM.mapM (C.translate_cn_lemma env) ail_prog.cn_lemmata in
 
   let global_types =
-    List.Old.map (fun (s, global) ->
+    List.map ~f:(fun (s, global) ->
         match global with
         | GlobalDef ((_bt, ct), _e) -> (s, ct)
         | GlobalDecl (_bt, ct) -> (s, ct)
@@ -1514,13 +1514,13 @@ let normalise_file ~inherit_loc ((fin_markers_env : CAE.fin_markers_env), ail_pr
   in
 
   let mu_call_funinfo = Pmap.mapi (fun _fsym (_, _, ret, args, variadic, has_proto) ->
-    Sctypes.{ sig_return_ty = ret; sig_arg_tys = List.Old.map snd args;
+    Sctypes.{ sig_return_ty = ret; sig_arg_tys = List.map ~f:snd args;
       sig_variadic = variadic; sig_has_proto = has_proto;
     }) file.mi_funinfo in
 
-  let stdlib_syms = SymSet.of_list (List.Old.map fst (Pmap.bindings_list file.mi_stdlib)) in
+  let stdlib_syms = SymSet.of_list (List.map ~f:fst (Pmap.bindings_list file.mi_stdlib)) in
 
-  let datatypes = List.Old.map (translate_datatype env) ail_prog.cn_datatypes in
+  let datatypes = List.map ~f:(translate_datatype env) ail_prog.cn_datatypes in
 
   let file = {
       mu_main = file.mi_main;
@@ -1564,8 +1564,8 @@ type instrumentation = {
 let rt_stmts_subst = (fun subst (rt, stmts) ->
    let rt = ReturnTypes.subst subst rt in
    let stmts =
-     List.Old.map (fun (loc, cn_progs) ->
-       (loc, List.Old.map (Cnprog.subst subst) cn_progs)
+     List.map ~f:(fun (loc, cn_progs) ->
+       (loc, List.map ~f:(Cnprog.subst subst) cn_progs)
      ) stmts
    in
    (rt, stmts)
@@ -1644,7 +1644,7 @@ let stmts_in_function args_and_body =
 
 let collect_instrumentation (file : _ mu_file) =
   let instrs =
-    List.Old.map (fun (fn, decl) ->
+    List.map ~f:(fun (fn, decl) ->
         match decl with
         | M_Proc (fn_loc, args_and_body, _trusted, _spec) ->
             let args_and_body = at_of_arguments Fun.id args_and_body in

--- a/backend/cn/core_to_mucore.ml
+++ b/backend/cn/core_to_mucore.ml
@@ -844,7 +844,7 @@ let rec n_expr ~inherit_loc (loc : Loc.t) ((env, old_states), desugaring_things)
                   return (desugared_stmt, stmt)
               ) parsed_stmts
             in
-            let desugared_stmts, stmts = List.Old.split desugared_stmts_and_stmts in
+            let desugared_stmts, stmts = List.unzip desugared_stmts_and_stmts in
             return (M_Expr (loc, [], (), M_CN_progs (desugared_stmts, stmts)))
           | [] ->
              n_expr e1

--- a/backend/cn/core_to_mucore.ml
+++ b/backend/cn/core_to_mucore.ml
@@ -1042,7 +1042,7 @@ let make_function_args f_i loc env args (accesses, requires) =
        return (Mu.mComputational ((pure_arg, bt), (loc, None)) at)
     | [] ->
        let@ lat = make_largs_with_accesses (f_i arg_states) env st (accesses, requires) in
-       return (M_L (Mu.mConstraints (List.Old.rev good_lcs) lat))
+       return (M_L (Mu.mConstraints (List.rev good_lcs) lat))
   in
   aux [] [] env (C.LocalState.init_st) args
 
@@ -1067,7 +1067,7 @@ let make_fun_with_spec_args f_i loc env args requires =
        return (Mu.mComputational ((pure_arg, bt), (loc, None)) at)
     | [] ->
        let@ lat = make_largs_with_accesses f_i env st ([], requires) in
-       return (M_L (Mu.mConstraints (List.Old.rev good_lcs) lat))
+       return (M_L (Mu.mConstraints (List.rev good_lcs) lat))
   in
   aux [] env (C.LocalState.init_st) args
 
@@ -1115,7 +1115,7 @@ let desugar_conds d_st conds =
   let@ (conds, d_st) = ListM.fold_leftM (fun (conds, d_st) cond ->
     let@ (cond, d_st) = desugar_cond d_st cond in
     return (cond :: conds, d_st)) ([], d_st) conds in
-  return (List.Old.rev conds, d_st)
+  return (List.rev conds, d_st)
 
 let fetch_enum d_st loc sym =
   let@ expr_ = do_ail_desugar_rdonly d_st (CAE.resolve_enum_constant sym) in

--- a/backend/cn/core_to_mucore.ml
+++ b/backend/cn/core_to_mucore.ml
@@ -1176,7 +1176,7 @@ let normalise_label
             loc
             env
             st
-            (List.Old.combine lt label_args)
+            (List.zip_exn lt label_args)
             (accesses, desugared_inv)
         in
         (* let lt =  *)
@@ -1209,7 +1209,7 @@ let normalise_label
 let add_spec_arg_renames loc args arg_cts (spec : (Symbol.sym, Ctype.ctype) cn_fun_spec) env =
   List.Old.fold_right (fun ((fun_sym, _), (ct, (spec_sym, _))) env ->
       C.add_renamed_computational spec_sym fun_sym (Memory.sbt_of_sct (convert_ct loc ct)) env)
-    (List.Old.combine args (List.Old.combine arg_cts spec.cn_spec_args)) env
+    (List.zip_exn args (List.zip_exn arg_cts spec.cn_spec_args)) env
 
 let normalise_fun_map_decl
       ~inherit_loc
@@ -1303,7 +1303,7 @@ let normalise_fun_map_decl
          )
          loc
          env
-         (List.Old.combine (List.Old.combine ail_args arg_cts) args)
+         (List.zip_exn (List.zip_exn ail_args arg_cts) args)
          (accesses, requires)
      in
      (* let ft = at_of_arguments (fun (_body, _labels, rt) -> rt) args_and_body in *)
@@ -1325,7 +1325,7 @@ let normalise_fun_map_decl
                (spec.cn_spec_ret_name, ret_ct) ([], spec.cn_spec_ensures)
            in
            return returned
-         ) loc env (List.Old.combine spec.cn_spec_args (List.map ~f:snd arg_cts)) spec.cn_spec_requires
+         ) loc env (List.zip_exn spec.cn_spec_args (List.map ~f:snd arg_cts)) spec.cn_spec_requires
        in
        let ft = at_of_arguments Tools.id args_and_rt in
        return (Some (M_ProcDecl (loc, Some ft), []))

--- a/backend/cn/diagnostics.ml
+++ b/backend/cn/diagnostics.ml
@@ -19,7 +19,7 @@ type opt = {
 let opt_key = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
 let continue_with (opts : opt list) cfg =
-  assert (List.Old.length opts <= String.length opt_key);
+  assert (List.length opts <= String.length opt_key);
   let xs = List.Old.mapi (fun i opt ->
     let c = String.get opt_key i in
     let s = String.make 1 c in
@@ -129,7 +129,7 @@ let rec investigate_term cfg t =
   in
   let@ ite_opts = investigate_ite cfg t in
   let opts = sub_t_opts @ simp_opts @ simp_opts2 @ eq_opts @ pred_opts @ ite_opts in
-  if List.Old.length opts == 0
+  if List.length opts == 0
   then Pp.print stdout (Pp.item "out of diagnostic options at" (IT.pp t))
   else ();
   continue_with opts cfg
@@ -144,7 +144,7 @@ and investigate_eq_side _cfg (side_nm, t, t2) =
     []
     | _ ->
     print stdout (string side_nm ^^^ string "is in an equality group of size"
-      ^^^ int (List.Old.length xs + 1) ^^^ string "with:" ^^^ brackets (list IT.pp xs));
+      ^^^ int (List.length xs + 1) ^^^ string "with:" ^^^ brackets (list IT.pp xs));
     [{doc = string "switch with another from" ^^^ string side_nm ^^^ string "eq-group";
       continue = continue_with (List.map ~f:(fun t ->
           {doc = IT.pp t; continue = fun cfg ->
@@ -171,7 +171,7 @@ and investigate_trans_eq t cfg =
     return {doc; continue = fun cfg -> investigate_term cfg eq}
   in
   let@ opts = ListM.mapM opt_of opt_xs in
-  if List.Old.length opts == 0
+  if List.length opts == 0
   then Pp.print stdout (Pp.item "no interesting transitive options for" (IT.pp t))
   else ();
   continue_with opts cfg

--- a/backend/cn/diagnostics.ml
+++ b/backend/cn/diagnostics.ml
@@ -66,7 +66,7 @@ let bool_subterms1 t = match IT.term t with
   | _ -> []
 
 let rec bool_subterms_of t =
-  t :: List.Old.concat (List.map ~f:bool_subterms_of (bool_subterms1 t))
+  t :: List.concat (List.map ~f:bool_subterms_of (bool_subterms1 t))
 
 let constraint_ts () =
   let@ cs = get_cs () in
@@ -121,7 +121,7 @@ let rec investigate_term cfg t =
           let here = Locations.other __FUNCTION__ in
           ListM.mapM (fun (x, y) -> rec_opt "parametric eq" (IT.eq_ (x, y) here)) bits
       in
-      return (List.Old.concat trans_opts @ [get_eq_opt] @ split_opts)
+      return (List.concat trans_opts @ [get_eq_opt] @ split_opts)
   in
   let@ pred_opts = match IT.term t with
     | IT.Apply (nm, _xs) -> investigate_pred cfg nm t
@@ -217,7 +217,7 @@ and investigate_ite cfg t =
   in
   let opts x = ListM.mapM (opt x) [true; false] in
   let@ xs = ListM.mapM opts ites in
-  return (List.Old.concat xs)
+  return (List.concat xs)
 
 let investigate_lc cfg lc = match lc with
   | LC.T t -> investigate_term cfg t

--- a/backend/cn/diagnostics.ml
+++ b/backend/cn/diagnostics.ml
@@ -70,7 +70,7 @@ let rec bool_subterms_of t =
 
 let constraint_ts () =
   let@ cs = get_cs () in
-  let ts = List.Old.filter_map (function
+  let ts = List.filter_map ~f:(function
     | LC.T t -> Some t
     | _ -> None) (LCSet.elements cs)
   in

--- a/backend/cn/diagnostics.ml
+++ b/backend/cn/diagnostics.ml
@@ -20,7 +20,7 @@ let opt_key = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
 let continue_with (opts : opt list) cfg =
   assert (List.length opts <= String.length opt_key);
-  let xs = List.Old.mapi (fun i opt ->
+  let xs = List.mapi ~f:(fun i opt ->
     let c = String.get opt_key i in
     let s = String.make 1 c in
     Pp.print stdout (Pp.string (s ^ " to continue with:"));

--- a/backend/cn/diagnostics.ml
+++ b/backend/cn/diagnostics.ml
@@ -136,7 +136,7 @@ let rec investigate_term cfg t =
 
 and investigate_eq_side _cfg (side_nm, t, t2) =
   let@ eq_group = value_eq_group None t in
-  let xs = ITSet.elements eq_group |> List.Old.filter (fun x -> not (IT.equal t x)) in
+  let xs = ITSet.elements eq_group |> List.filter ~f:(fun x -> not (IT.equal t x)) in
   let open Pp in
   let clique_opts = match xs with
     | [] ->
@@ -163,7 +163,7 @@ and investigate_trans_eq t cfg =
     | Some (x, y) -> if BT.equal (IT.bt x) (IT.bt t) then [x; y] @ acc else acc
   ) [] [] cs in
   let opt_xs = eq_xs
-    |> List.Old.filter (fun x -> Option.is_some (split_eq t x))
+    |> List.filter ~f:(fun x -> Option.is_some (split_eq t x))
     |> ITSet.of_list |> ITSet.elements in
   let opt_of x =
     let eq = (IT.eq_ (t, x)) @@ Locations.other __FUNCTION__ in

--- a/backend/cn/diagnostics.ml
+++ b/backend/cn/diagnostics.ml
@@ -87,11 +87,11 @@ let pred_args t = match IT.term t with
 let split_eq x y = match (IT.term x, IT.term y) with
   | (IT.MapGet (m1, x1), IT.MapGet (m2, x2)) -> Some [(m1, m2); (x1, x2)]
   | (IT.Apply (nm, xs), IT.Apply (nm2, ys)) when Sym.equal nm nm2 ->
-    Some (List.Old.map2 (fun x y -> (x, y)) xs ys)
+    Some (List.map2_exn ~f:(fun x y -> (x, y)) xs ys)
   | (IT.Constructor (nm, xs), IT.Constructor (nm2, ys)) when Sym.equal nm nm2 ->
     let xs = List.Old.sort WellTyped.compare_by_fst_id xs in
     let ys = List.Old.sort WellTyped.compare_by_fst_id ys in
-    Some (List.Old.map2 (fun (_, x) (_, y) -> (x, y)) xs ys)
+    Some (List.map2_exn ~f:(fun (_, x) (_, y) -> (x, y)) xs ys)
   | _ -> None
 
 (* investigate the provability of a term *)

--- a/backend/cn/diagnostics.ml
+++ b/backend/cn/diagnostics.ml
@@ -28,7 +28,7 @@ let continue_with (opts : opt list) cfg =
     (c, opt.continue)) opts in
   let next = if cfg.arc_index >= String.length cfg.arc
     then None
-    else List.Old.find_opt (fun (c, _) -> Char.equal c (String.get cfg.arc cfg.arc_index)) xs
+    else List.find ~f:(fun (c, _) -> Char.equal c (String.get cfg.arc cfg.arc_index)) xs
   in
   match next with
   | None -> return ()

--- a/backend/cn/diagnostics.ml
+++ b/backend/cn/diagnostics.ml
@@ -66,7 +66,7 @@ let bool_subterms1 t = match IT.term t with
   | _ -> []
 
 let rec bool_subterms_of t =
-  t :: List.Old.concat (List.Old.map bool_subterms_of (bool_subterms1 t))
+  t :: List.Old.concat (List.map ~f:bool_subterms_of (bool_subterms1 t))
 
 let constraint_ts () =
   let@ cs = get_cs () in
@@ -146,7 +146,7 @@ and investigate_eq_side _cfg (side_nm, t, t2) =
     print stdout (string side_nm ^^^ string "is in an equality group of size"
       ^^^ int (List.Old.length xs + 1) ^^^ string "with:" ^^^ brackets (list IT.pp xs));
     [{doc = string "switch with another from" ^^^ string side_nm ^^^ string "eq-group";
-      continue = continue_with (List.Old.map (fun t ->
+      continue = continue_with (List.map ~f:(fun t ->
           {doc = IT.pp t; continue = fun cfg ->
               let eq = IT.eq_ (t, t2) @@ Locations.other __FUNCTION__ in
               print stdout (bold "investigating eq:" ^^^ IT.pp eq);

--- a/backend/cn/dune
+++ b/backend/cn/dune
@@ -12,6 +12,7 @@
   cerb_frontend
   cerb_util
   cmdliner
+  base
   mem_concrete
   menhirLib
   monomorphic

--- a/backend/cn/effectful.ml
+++ b/backend/cn/effectful.ml
@@ -61,7 +61,7 @@ module Make(T : S) = struct
 
     let concat_mapM f l =
       let@ xs = mapM f l in
-      return (List.Old.concat xs)
+      return (List.concat xs)
 
     let filter_mapM f l =
       let@ xs = mapM f l in

--- a/backend/cn/effectful.ml
+++ b/backend/cn/effectful.ml
@@ -65,7 +65,7 @@ module Make(T : S) = struct
 
     let filter_mapM f l =
       let@ xs = mapM f l in
-      return (List.Old.filter_map (fun x -> x) xs)
+      return (List.filter_map ~f:(fun x -> x) xs)
 
     let filterM f xs =
       let@ ys = mapM (fun x -> let@ b = f x in return (b, x)) xs in

--- a/backend/cn/effectful.ml
+++ b/backend/cn/effectful.ml
@@ -69,7 +69,7 @@ module Make(T : S) = struct
 
     let filterM f xs =
       let@ ys = mapM (fun x -> let@ b = f x in return (b, x)) xs in
-      return (List.map ~f:snd (List.Old.filter fst ys))
+      return (List.map ~f:snd (List.filter ~f:fst ys))
 
 
     let fold_leftM (f : 'a -> 'b -> 'c m) (a : 'a) (bs : 'b list) =

--- a/backend/cn/effectful.ml
+++ b/backend/cn/effectful.ml
@@ -49,7 +49,7 @@ module Make(T : S) = struct
               (l1 : 'a list)
               (l2 : 'b list)
             : ('c list) m =
-      let l12 = List.Old.combine l1 l2 in
+      let l12 = List.zip_exn l1 l2 in
       mapM (Tools.uncurry f) l12
 
     let iteriM (f : (int -> 'a -> unit m)) (l : 'a list) : unit m =

--- a/backend/cn/effectful.ml
+++ b/backend/cn/effectful.ml
@@ -17,8 +17,6 @@ module Make(T : S) = struct
 
   module ListM = struct
 
-    open List
-
     let rec mapM (f : 'a -> 'b m) (l : 'a list) : ('b list) m =
       match l with
       | [] -> return []
@@ -51,7 +49,7 @@ module Make(T : S) = struct
               (l1 : 'a list)
               (l2 : 'b list)
             : ('c list) m =
-      let l12 = List.combine l1 l2 in
+      let l12 = List.Old.combine l1 l2 in
       mapM (Tools.uncurry f) l12
 
     let iteriM (f : (int -> 'a -> unit m)) (l : 'a list) : unit m =
@@ -63,23 +61,23 @@ module Make(T : S) = struct
 
     let concat_mapM f l =
       let@ xs = mapM f l in
-      return (concat xs)
+      return (List.Old.concat xs)
 
     let filter_mapM f l =
       let@ xs = mapM f l in
-      return (filter_map (fun x -> x) xs)
+      return (List.Old.filter_map (fun x -> x) xs)
 
     let filterM f xs =
       let@ ys = mapM (fun x -> let@ b = f x in return (b, x)) xs in
-      return (List.map snd (List.filter fst ys))
+      return (List.Old.map snd (List.Old.filter fst ys))
 
 
     let fold_leftM (f : 'a -> 'b -> 'c m) (a : 'a) (bs : 'b list) =
-      Stdlib.List.fold_left (fun aM b -> let@ a = aM in f a b) (return a) bs
+      List.Old.fold_left (fun aM b -> let@ a = aM in f a b) (return a) bs
 
     (* maybe from Exception.lem *)
     let fold_rightM (f : 'b -> 'a -> 'c m) (bs : 'b list) (a : 'a) =
-      Stdlib.List.fold_right (fun b aM -> let@ a = aM in f b a) bs (return a)
+      List.Old.fold_right (fun b aM -> let@ a = aM in f b a) bs (return a)
 
   end
 
@@ -95,7 +93,7 @@ module Make(T : S) = struct
           (map : ('k,'x) Pmap.map) (init: 'y) : 'y m =
       ListM.fold_leftM (fun y (i, (k, x)) -> f i k x y)
           init
-          (List.mapi (fun i (k, x) -> (i, (k, x))) (Pmap.bindings_list map))
+          (List.Old.mapi (fun i (k, x) -> (i, (k, x))) (Pmap.bindings_list map))
 
     let iterM f m =
       Pmap.fold (fun k v m -> let@ () = m in f k v)

--- a/backend/cn/effectful.ml
+++ b/backend/cn/effectful.ml
@@ -69,7 +69,7 @@ module Make(T : S) = struct
 
     let filterM f xs =
       let@ ys = mapM (fun x -> let@ b = f x in return (b, x)) xs in
-      return (List.Old.map snd (List.Old.filter fst ys))
+      return (List.map ~f:snd (List.Old.filter fst ys))
 
 
     let fold_leftM (f : 'a -> 'b -> 'c m) (a : 'a) (bs : 'b list) =

--- a/backend/cn/effectful.ml
+++ b/backend/cn/effectful.ml
@@ -93,7 +93,7 @@ module Make(T : S) = struct
           (map : ('k,'x) Pmap.map) (init: 'y) : 'y m =
       ListM.fold_leftM (fun y (i, (k, x)) -> f i k x y)
           init
-          (List.Old.mapi (fun i (k, x) -> (i, (k, x))) (Pmap.bindings_list map))
+          (List.mapi ~f:(fun i (k, x) -> (i, (k, x))) (Pmap.bindings_list map))
 
     let iterM f m =
       Pmap.fold (fun k v m -> let@ () = m in f k v)

--- a/backend/cn/eqTable.ml
+++ b/backend/cn/eqTable.ml
@@ -26,7 +26,7 @@ let guard_implies guard1 guard2 = match (guard1, guard2) with
   | _ -> false
 
 let eq_is_known tab (guard, lhs, rhs) =
-  List.exists (fun info -> IT.equal rhs info.rhs && guard_implies guard info.guard)
+  List.Old.exists (fun info -> IT.equal rhs info.rhs && guard_implies guard info.guard)
     (fetch_eqs tab lhs)
 
 let add_eq (guard, lhs, rhs) (tab : table) =
@@ -45,7 +45,7 @@ let add_one_eq (tab : table) (it : IT.t) = match IT.term it with
   | _ -> tab
 
 let add_eqs tab (it : IT.t) = match IT.is_and it with
-  | Some (it1,it2) -> List.fold_left add_one_eq tab [it1;it2]
+  | Some (it1,it2) -> List.Old.fold_left add_one_eq tab [it1;it2]
   | _ -> add_one_eq tab it
 
 let add_lc_eqs tab (lc : LogicalConstraints.t) = match lc with
@@ -53,7 +53,7 @@ let add_lc_eqs tab (lc : LogicalConstraints.t) = match lc with
   | _ -> tab
 
 let fetch_implied_eqs tab guard lhs = fetch_eqs tab lhs
-  |> List.filter_map (fun info -> if guard_implies guard info.guard
+  |> List.Old.filter_map (fun info -> if guard_implies guard info.guard
     then Some info.rhs else None)
 
 (* computing the closure of the above *)

--- a/backend/cn/eqTable.ml
+++ b/backend/cn/eqTable.ml
@@ -26,7 +26,7 @@ let guard_implies guard1 guard2 = match (guard1, guard2) with
   | _ -> false
 
 let eq_is_known tab (guard, lhs, rhs) =
-  List.Old.exists (fun info -> IT.equal rhs info.rhs && guard_implies guard info.guard)
+  List.exists ~f:(fun info -> IT.equal rhs info.rhs && guard_implies guard info.guard)
     (fetch_eqs tab lhs)
 
 let add_eq (guard, lhs, rhs) (tab : table) =

--- a/backend/cn/eqTable.ml
+++ b/backend/cn/eqTable.ml
@@ -53,7 +53,7 @@ let add_lc_eqs tab (lc : LogicalConstraints.t) = match lc with
   | _ -> tab
 
 let fetch_implied_eqs tab guard lhs = fetch_eqs tab lhs
-  |> List.Old.filter_map (fun info -> if guard_implies guard info.guard
+  |> List.filter_map ~f:(fun info -> if guard_implies guard info.guard
     then Some info.rhs else None)
 
 (* computing the closure of the above *)

--- a/backend/cn/executable_spec.ml
+++ b/backend/cn/executable_spec.ml
@@ -1,7 +1,7 @@
 let rec group_toplevel_defs new_list = function
   | [] -> new_list
   | (loc, strs) :: xs ->
-      let matching_elems = List.Old.filter (fun (toplevel_loc, _) ->
+      let matching_elems = List.filter ~f:(fun (toplevel_loc, _) ->
         loc == toplevel_loc
       ) new_list in
       if List.Old.is_empty matching_elems then
@@ -9,7 +9,7 @@ let rec group_toplevel_defs new_list = function
       else
         (* Unsafe *)
         let (_, toplevel_strs) = List.nth_exn matching_elems 0 in
-        let non_matching_elems = List.Old.filter (fun (toplevel_loc, _) ->
+        let non_matching_elems = List.filter ~f:(fun (toplevel_loc, _) ->
           loc != toplevel_loc
         ) new_list in
         group_toplevel_defs ((loc, toplevel_strs @ strs) :: non_matching_elems) xs
@@ -33,7 +33,7 @@ let rec open_auxilliary_files source_filename prefix included_filenames already_
     end
 
 let filter_injs_by_filename inj_pairs fn =
-  List.Old.filter (fun (loc, _) -> match Cerb_location.get_filename loc with | Some name -> (String.equal name fn) | None -> false) inj_pairs
+  List.filter ~f:(fun (loc, _) -> match Cerb_location.get_filename loc with | Some name -> (String.equal name fn) | None -> false) inj_pairs
 
 let rec inject_injs_to_multiple_files ail_prog in_stmt_injs block_return_injs cn_header = function
   | [] -> ()
@@ -74,8 +74,8 @@ let copy_source_dir_files_into_output_dir filename already_opened_fns_and_ocs pr
   let source_dir_path = String.concat "/" (remove_last_elem split_str_list) in 
   let source_dir_all_files_without_path = Array.to_list (Sys.readdir source_dir_path) in
   let source_dir_all_files_with_path = List.map ~f:(fun fn -> String.concat "/" [source_dir_path; fn]) source_dir_all_files_without_path in 
-  let remaining_source_dir_files = List.Old.filter (fun fn -> not (List.Old.mem String.equal fn source_files_already_opened)) source_dir_all_files_with_path in
-  let remaining_source_dir_files = List.Old.filter (fun fn -> List.Old.mem String.equal (Filename.extension fn) [".c"; ".h"]) remaining_source_dir_files in
+  let remaining_source_dir_files = List.filter ~f:(fun fn -> not (List.Old.mem String.equal fn source_files_already_opened)) source_dir_all_files_with_path in
+  let remaining_source_dir_files = List.filter ~f:(fun fn -> List.Old.mem String.equal (Filename.extension fn) [".c"; ".h"]) remaining_source_dir_files in
   let remaining_source_dir_files_opt = List.map ~f:(fun str -> Some str) remaining_source_dir_files in
   let remaining_fns_and_ocs = open_auxilliary_files filename prefix remaining_source_dir_files_opt [] in 
   let read_file file =

--- a/backend/cn/executable_spec.ml
+++ b/backend/cn/executable_spec.ml
@@ -182,7 +182,7 @@ let main ?(with_ownership_checking=false) ?(copy_source_dir=false) filename ((_,
     else "" 
   in *)
   let datatype_strs = String.concat "\n" (List.map ~f:snd c_datatype_defs) in 
-  let predicate_decls = String.concat "\n" (List.Old.concat (List.map ~f:snd locs_and_c_predicate_decls)) in
+  let predicate_decls = String.concat "\n" (List.concat (List.map ~f:snd locs_and_c_predicate_decls)) in
 
   let cn_header_decls_list = 
     [cn_utils_header;

--- a/backend/cn/executable_spec.ml
+++ b/backend/cn/executable_spec.ml
@@ -21,7 +21,7 @@ let rec open_auxilliary_files source_filename prefix included_filenames already_
     | Some fn' ->
       if String.equal fn' source_filename || List.Old.mem String.equal fn' already_opened_list then [] else
       let fn_list = String.split_on_char '/' fn' in
-      let output_fn = List.Old.nth fn_list (List.Old.length fn_list - 1) in
+      let output_fn = List.Old.nth fn_list (List.length fn_list - 1) in
       let output_fn_with_prefix = prefix ^ output_fn in
       if Sys.file_exists output_fn_with_prefix then
         (Printf.printf "Error in opening file %s as it already exists\n" output_fn_with_prefix;

--- a/backend/cn/executable_spec.ml
+++ b/backend/cn/executable_spec.ml
@@ -8,7 +8,7 @@ let rec group_toplevel_defs new_list = function
         group_toplevel_defs ((loc, strs) :: new_list) xs
       else
         (* Unsafe *)
-        let (_, toplevel_strs) = List.Old.nth matching_elems 0 in
+        let (_, toplevel_strs) = List.nth_exn matching_elems 0 in
         let non_matching_elems = List.Old.filter (fun (toplevel_loc, _) ->
           loc != toplevel_loc
         ) new_list in
@@ -21,7 +21,7 @@ let rec open_auxilliary_files source_filename prefix included_filenames already_
     | Some fn' ->
       if String.equal fn' source_filename || List.Old.mem String.equal fn' already_opened_list then [] else
       let fn_list = String.split_on_char '/' fn' in
-      let output_fn = List.Old.nth fn_list (List.length fn_list - 1) in
+      let output_fn = List.nth_exn fn_list (List.length fn_list - 1) in
       let output_fn_with_prefix = prefix ^ output_fn in
       if Sys.file_exists output_fn_with_prefix then
         (Printf.printf "Error in opening file %s as it already exists\n" output_fn_with_prefix;

--- a/backend/cn/executable_spec.ml
+++ b/backend/cn/executable_spec.ml
@@ -43,9 +43,9 @@ let rec inject_injs_to_multiple_files ail_prog in_stmt_injs block_return_injs cn
 
     let in_stmt_injs_for_fn' = filter_injs_by_filename in_stmt_injs fn' in
     let squashed_return_injs_for_fn' = filter_injs_by_filename block_return_injs fn' in 
-    let return_injs_for_fn' = List.Old.map (fun (loc, (e_opt, strs)) -> (loc, e_opt, strs)) squashed_return_injs_for_fn' in 
+    let return_injs_for_fn' = List.map ~f:(fun (loc, (e_opt, strs)) -> (loc, e_opt, strs)) squashed_return_injs_for_fn' in 
 
-    (* let injs_for_fn' = List.Old.map (fun (loc, (_, strs)) -> (loc, strs)) injs_with_syms in *)
+    (* let injs_for_fn' = List.map ~f:(fun (loc, (_, strs)) -> (loc, strs)) injs_with_syms in *)
     begin match
       Source_injection.(output_injections oc'
         { filename=fn'; program= ail_prog
@@ -64,7 +64,7 @@ let rec inject_injs_to_multiple_files ail_prog in_stmt_injs block_return_injs cn
     inject_injs_to_multiple_files ail_prog in_stmt_injs block_return_injs cn_header xs
 
 let copy_source_dir_files_into_output_dir filename already_opened_fns_and_ocs prefix = 
-  let source_files_already_opened = filename :: (List.Old.map fst already_opened_fns_and_ocs) in 
+  let source_files_already_opened = filename :: (List.map ~f:fst already_opened_fns_and_ocs) in 
   let split_str_list = String.split_on_char '/' filename in 
   let rec remove_last_elem = function 
     | [] -> []
@@ -73,10 +73,10 @@ let copy_source_dir_files_into_output_dir filename already_opened_fns_and_ocs pr
   in
   let source_dir_path = String.concat "/" (remove_last_elem split_str_list) in 
   let source_dir_all_files_without_path = Array.to_list (Sys.readdir source_dir_path) in
-  let source_dir_all_files_with_path = List.Old.map (fun fn -> String.concat "/" [source_dir_path; fn]) source_dir_all_files_without_path in 
+  let source_dir_all_files_with_path = List.map ~f:(fun fn -> String.concat "/" [source_dir_path; fn]) source_dir_all_files_without_path in 
   let remaining_source_dir_files = List.Old.filter (fun fn -> not (List.Old.mem String.equal fn source_files_already_opened)) source_dir_all_files_with_path in
   let remaining_source_dir_files = List.Old.filter (fun fn -> List.Old.mem String.equal (Filename.extension fn) [".c"; ".h"]) remaining_source_dir_files in
-  let remaining_source_dir_files_opt = List.Old.map (fun str -> Some str) remaining_source_dir_files in
+  let remaining_source_dir_files_opt = List.map ~f:(fun str -> Some str) remaining_source_dir_files in
   let remaining_fns_and_ocs = open_auxilliary_files filename prefix remaining_source_dir_files_opt [] in 
   let read_file file =
     In_channel.with_open_bin file In_channel.input_all 
@@ -86,7 +86,7 @@ let copy_source_dir_files_into_output_dir filename already_opened_fns_and_ocs pr
     Stdlib.output_string fn_oc input_file_contents;
     ()
   in
-  let _ = List.Old.map copy_file_contents_to_output_dir remaining_fns_and_ocs in 
+  let _ = List.map ~f:copy_file_contents_to_output_dir remaining_fns_and_ocs in 
   ()
 
 let memory_accesses_injections ail_prog =
@@ -181,8 +181,8 @@ let main ?(with_ownership_checking=false) ?(copy_source_dir=false) filename ((_,
       "\n" ^ generate_ownership_globals ~is_extern:true ()
     else "" 
   in *)
-  let datatype_strs = String.concat "\n" (List.Old.map snd c_datatype_defs) in 
-  let predicate_decls = String.concat "\n" (List.Old.concat (List.Old.map snd locs_and_c_predicate_decls)) in
+  let datatype_strs = String.concat "\n" (List.map ~f:snd c_datatype_defs) in 
+  let predicate_decls = String.concat "\n" (List.Old.concat (List.map ~f:snd locs_and_c_predicate_decls)) in
 
   let cn_header_decls_list = 
     [cn_utils_header;
@@ -225,7 +225,7 @@ let main ?(with_ownership_checking=false) ?(copy_source_dir=false) filename ((_,
   output_to_oc cn_oc cn_defs_list;
 
   let incls = [("assert.h", true); ("stdlib.h", true); ("stdbool.h", true); ("math.h", true);] in
-  let headers = List.Old.map Executable_spec_utils.generate_include_header incls in
+  let headers = List.map ~f:Executable_spec_utils.generate_include_header incls in
 
   let source_file_strs_list =
     [cn_header;
@@ -236,18 +236,18 @@ let main ?(with_ownership_checking=false) ?(copy_source_dir=false) filename ((_,
   output_to_oc oc source_file_strs_list;
   
   let c_datatypes_with_fn_prots = List.Old.combine c_datatype_defs c_datatype_equality_fun_decls in
-  let c_datatypes_locs_and_strs = List.Old.map (fun ((loc, dt_str), eq_prot_str) -> (loc, [String.concat "\n" [dt_str; eq_prot_str]])) c_datatypes_with_fn_prots in
+  let c_datatypes_locs_and_strs = List.map ~f:(fun ((loc, dt_str), eq_prot_str) -> (loc, [String.concat "\n" [dt_str; eq_prot_str]])) c_datatypes_with_fn_prots in
   
   let toplevel_locs_and_defs = group_toplevel_defs [] (c_datatypes_locs_and_strs @ locs_and_c_extern_function_decls @ locs_and_c_predicate_decls) in
-  let toplevel_locs_and_defs = List.Old.map (fun (loc, _) -> (loc, [""])) toplevel_locs_and_defs in 
+  let toplevel_locs_and_defs = List.map ~f:(fun (loc, _) -> (loc, [""])) toplevel_locs_and_defs in 
 
   let accesses_stmt_injs = if with_ownership_checking then memory_accesses_injections ail_prog else [] in
   let struct_injs_with_filenames = Executable_spec_internal.generate_struct_injs sigm in
-  let struct_injs_with_filenames = List.Old.map (fun (loc, _) -> (loc, [""])) struct_injs_with_filenames in 
+  let struct_injs_with_filenames = List.map ~f:(fun (loc, _) -> (loc, [""])) struct_injs_with_filenames in 
 
   
   (* Printf.printf "Locations for injection of CN statements:\n";
-  let _ = List.Old.map (fun (loc, _) -> Printf.printf "%s: %s\n" (Option.get (Cerb_location.get_filename loc)) (Cerb_location.simple_location loc)) executable_spec.in_stmt in  *)
+  let _ = List.map ~f:(fun (loc, _) -> Printf.printf "%s: %s\n" (Option.get (Cerb_location.get_filename loc)) (Cerb_location.simple_location loc)) executable_spec.in_stmt in  *)
   let in_stmt_injs = 
     executable_spec.in_stmt @
     accesses_stmt_injs 
@@ -257,12 +257,12 @@ let main ?(with_ownership_checking=false) ?(copy_source_dir=false) filename ((_,
 
   (* Return injections *)
   let block_return_injs = executable_spec.returns in 
-  let squashed_block_return_injs = List.Old.map (fun (l, e_opt, strs) -> (l, (e_opt, strs))) block_return_injs in 
+  let squashed_block_return_injs = List.map ~f:(fun (l, e_opt, strs) -> (l, (e_opt, strs))) block_return_injs in 
   let source_file_return_injs_squashed = filter_injs_by_filename squashed_block_return_injs filename in 
-  let source_file_return_injs = List.Old.map (fun (l, (e_opt, strs)) -> (l, e_opt, strs)) source_file_return_injs_squashed in 
+  let source_file_return_injs = List.map ~f:(fun (l, (e_opt, strs)) -> (l, e_opt, strs)) source_file_return_injs_squashed in 
     
-  let included_filenames = List.Old.map (fun (loc, _) -> Cerb_location.get_filename loc) in_stmt_injs in
-  let included_filenames' = included_filenames @ List.Old.map (fun (loc, _) -> Cerb_location.get_filename loc) squashed_block_return_injs in 
+  let included_filenames = List.map ~f:(fun (loc, _) -> Cerb_location.get_filename loc) in_stmt_injs in
+  let included_filenames' = included_filenames @ List.map ~f:(fun (loc, _) -> Cerb_location.get_filename loc) squashed_block_return_injs in 
 
   let remaining_fns_and_ocs = open_auxilliary_files filename prefix included_filenames' [] in
 

--- a/backend/cn/executable_spec.ml
+++ b/backend/cn/executable_spec.ml
@@ -235,7 +235,7 @@ let main ?(with_ownership_checking=false) ?(copy_source_dir=false) filename ((_,
 
   output_to_oc oc source_file_strs_list;
   
-  let c_datatypes_with_fn_prots = List.Old.combine c_datatype_defs c_datatype_equality_fun_decls in
+  let c_datatypes_with_fn_prots = List.zip_exn  c_datatype_defs c_datatype_equality_fun_decls in
   let c_datatypes_locs_and_strs = List.map ~f:(fun ((loc, dt_str), eq_prot_str) -> (loc, [String.concat "\n" [dt_str; eq_prot_str]])) c_datatypes_with_fn_prots in
   
   let toplevel_locs_and_defs = group_toplevel_defs [] (c_datatypes_locs_and_strs @ locs_and_c_extern_function_decls @ locs_and_c_predicate_decls) in

--- a/backend/cn/executable_spec.ml
+++ b/backend/cn/executable_spec.ml
@@ -99,7 +99,7 @@ let memory_accesses_injections ail_prog =
     | `Bbox (b, e) -> (b, e) in
   let acc = ref [] in
   let xs = Ail_analysis.collect_memory_accesses ail_prog in
-  List.Old.iter (fun access ->
+  List.iter ~f:(fun access ->
     match access with
     | Ail_analysis.Load {loc; _} ->
         let b, e = pos_bbox loc in
@@ -139,7 +139,7 @@ let memory_accesses_injections ail_prog =
   !acc
 
 let output_to_oc oc str_list =
-  List.Old.iter (Stdlib.output_string oc) str_list 
+  List.iter ~f:(Stdlib.output_string oc) str_list 
 
 open Executable_spec_internal
 

--- a/backend/cn/executable_spec.ml
+++ b/backend/cn/executable_spec.ml
@@ -1,15 +1,15 @@
 let rec group_toplevel_defs new_list = function
   | [] -> new_list
   | (loc, strs) :: xs ->
-      let matching_elems = List.filter (fun (toplevel_loc, _) ->
+      let matching_elems = List.Old.filter (fun (toplevel_loc, _) ->
         loc == toplevel_loc
       ) new_list in
-      if List.is_empty matching_elems then
+      if List.Old.is_empty matching_elems then
         group_toplevel_defs ((loc, strs) :: new_list) xs
       else
         (* Unsafe *)
-        let (_, toplevel_strs) = List.nth matching_elems 0 in
-        let non_matching_elems = List.filter (fun (toplevel_loc, _) ->
+        let (_, toplevel_strs) = List.Old.nth matching_elems 0 in
+        let non_matching_elems = List.Old.filter (fun (toplevel_loc, _) ->
           loc != toplevel_loc
         ) new_list in
         group_toplevel_defs ((loc, toplevel_strs @ strs) :: non_matching_elems) xs
@@ -19,9 +19,9 @@ let rec open_auxilliary_files source_filename prefix included_filenames already_
 | fn :: fns ->
     begin match fn with
     | Some fn' ->
-      if String.equal fn' source_filename || List.mem String.equal fn' already_opened_list then [] else
+      if String.equal fn' source_filename || List.Old.mem String.equal fn' already_opened_list then [] else
       let fn_list = String.split_on_char '/' fn' in
-      let output_fn = List.nth fn_list (List.length fn_list - 1) in
+      let output_fn = List.Old.nth fn_list (List.Old.length fn_list - 1) in
       let output_fn_with_prefix = prefix ^ output_fn in
       if Sys.file_exists output_fn_with_prefix then
         (Printf.printf "Error in opening file %s as it already exists\n" output_fn_with_prefix;
@@ -33,7 +33,7 @@ let rec open_auxilliary_files source_filename prefix included_filenames already_
     end
 
 let filter_injs_by_filename inj_pairs fn =
-  List.filter (fun (loc, _) -> match Cerb_location.get_filename loc with | Some name -> (String.equal name fn) | None -> false) inj_pairs
+  List.Old.filter (fun (loc, _) -> match Cerb_location.get_filename loc with | Some name -> (String.equal name fn) | None -> false) inj_pairs
 
 let rec inject_injs_to_multiple_files ail_prog in_stmt_injs block_return_injs cn_header = function
   | [] -> ()
@@ -43,9 +43,9 @@ let rec inject_injs_to_multiple_files ail_prog in_stmt_injs block_return_injs cn
 
     let in_stmt_injs_for_fn' = filter_injs_by_filename in_stmt_injs fn' in
     let squashed_return_injs_for_fn' = filter_injs_by_filename block_return_injs fn' in 
-    let return_injs_for_fn' = List.map (fun (loc, (e_opt, strs)) -> (loc, e_opt, strs)) squashed_return_injs_for_fn' in 
+    let return_injs_for_fn' = List.Old.map (fun (loc, (e_opt, strs)) -> (loc, e_opt, strs)) squashed_return_injs_for_fn' in 
 
-    (* let injs_for_fn' = List.map (fun (loc, (_, strs)) -> (loc, strs)) injs_with_syms in *)
+    (* let injs_for_fn' = List.Old.map (fun (loc, (_, strs)) -> (loc, strs)) injs_with_syms in *)
     begin match
       Source_injection.(output_injections oc'
         { filename=fn'; program= ail_prog
@@ -64,7 +64,7 @@ let rec inject_injs_to_multiple_files ail_prog in_stmt_injs block_return_injs cn
     inject_injs_to_multiple_files ail_prog in_stmt_injs block_return_injs cn_header xs
 
 let copy_source_dir_files_into_output_dir filename already_opened_fns_and_ocs prefix = 
-  let source_files_already_opened = filename :: (List.map fst already_opened_fns_and_ocs) in 
+  let source_files_already_opened = filename :: (List.Old.map fst already_opened_fns_and_ocs) in 
   let split_str_list = String.split_on_char '/' filename in 
   let rec remove_last_elem = function 
     | [] -> []
@@ -73,10 +73,10 @@ let copy_source_dir_files_into_output_dir filename already_opened_fns_and_ocs pr
   in
   let source_dir_path = String.concat "/" (remove_last_elem split_str_list) in 
   let source_dir_all_files_without_path = Array.to_list (Sys.readdir source_dir_path) in
-  let source_dir_all_files_with_path = List.map (fun fn -> String.concat "/" [source_dir_path; fn]) source_dir_all_files_without_path in 
-  let remaining_source_dir_files = List.filter (fun fn -> not (List.mem String.equal fn source_files_already_opened)) source_dir_all_files_with_path in
-  let remaining_source_dir_files = List.filter (fun fn -> List.mem String.equal (Filename.extension fn) [".c"; ".h"]) remaining_source_dir_files in
-  let remaining_source_dir_files_opt = List.map (fun str -> Some str) remaining_source_dir_files in
+  let source_dir_all_files_with_path = List.Old.map (fun fn -> String.concat "/" [source_dir_path; fn]) source_dir_all_files_without_path in 
+  let remaining_source_dir_files = List.Old.filter (fun fn -> not (List.Old.mem String.equal fn source_files_already_opened)) source_dir_all_files_with_path in
+  let remaining_source_dir_files = List.Old.filter (fun fn -> List.Old.mem String.equal (Filename.extension fn) [".c"; ".h"]) remaining_source_dir_files in
+  let remaining_source_dir_files_opt = List.Old.map (fun str -> Some str) remaining_source_dir_files in
   let remaining_fns_and_ocs = open_auxilliary_files filename prefix remaining_source_dir_files_opt [] in 
   let read_file file =
     In_channel.with_open_bin file In_channel.input_all 
@@ -86,7 +86,7 @@ let copy_source_dir_files_into_output_dir filename already_opened_fns_and_ocs pr
     Stdlib.output_string fn_oc input_file_contents;
     ()
   in
-  let _ = List.map copy_file_contents_to_output_dir remaining_fns_and_ocs in 
+  let _ = List.Old.map copy_file_contents_to_output_dir remaining_fns_and_ocs in 
   ()
 
 let memory_accesses_injections ail_prog =
@@ -99,7 +99,7 @@ let memory_accesses_injections ail_prog =
     | `Bbox (b, e) -> (b, e) in
   let acc = ref [] in
   let xs = Ail_analysis.collect_memory_accesses ail_prog in
-  List.iter (fun access ->
+  List.Old.iter (fun access ->
     match access with
     | Ail_analysis.Load {loc; _} ->
         let b, e = pos_bbox loc in
@@ -139,7 +139,7 @@ let memory_accesses_injections ail_prog =
   !acc
 
 let output_to_oc oc str_list =
-  List.iter (Stdlib.output_string oc) str_list 
+  List.Old.iter (Stdlib.output_string oc) str_list 
 
 open Executable_spec_internal
 
@@ -181,8 +181,8 @@ let main ?(with_ownership_checking=false) ?(copy_source_dir=false) filename ((_,
       "\n" ^ generate_ownership_globals ~is_extern:true ()
     else "" 
   in *)
-  let datatype_strs = String.concat "\n" (List.map snd c_datatype_defs) in 
-  let predicate_decls = String.concat "\n" (List.concat (List.map snd locs_and_c_predicate_decls)) in
+  let datatype_strs = String.concat "\n" (List.Old.map snd c_datatype_defs) in 
+  let predicate_decls = String.concat "\n" (List.Old.concat (List.Old.map snd locs_and_c_predicate_decls)) in
 
   let cn_header_decls_list = 
     [cn_utils_header;
@@ -225,29 +225,29 @@ let main ?(with_ownership_checking=false) ?(copy_source_dir=false) filename ((_,
   output_to_oc cn_oc cn_defs_list;
 
   let incls = [("assert.h", true); ("stdlib.h", true); ("stdbool.h", true); ("math.h", true);] in
-  let headers = List.map Executable_spec_utils.generate_include_header incls in
+  let headers = List.Old.map Executable_spec_utils.generate_include_header incls in
 
   let source_file_strs_list =
     [cn_header;
-    (List.fold_left (^) "" headers);
+    (List.Old.fold_left (^) "" headers);
     "\n";]
   in
 
   output_to_oc oc source_file_strs_list;
   
-  let c_datatypes_with_fn_prots = List.combine c_datatype_defs c_datatype_equality_fun_decls in
-  let c_datatypes_locs_and_strs = List.map (fun ((loc, dt_str), eq_prot_str) -> (loc, [String.concat "\n" [dt_str; eq_prot_str]])) c_datatypes_with_fn_prots in
+  let c_datatypes_with_fn_prots = List.Old.combine c_datatype_defs c_datatype_equality_fun_decls in
+  let c_datatypes_locs_and_strs = List.Old.map (fun ((loc, dt_str), eq_prot_str) -> (loc, [String.concat "\n" [dt_str; eq_prot_str]])) c_datatypes_with_fn_prots in
   
   let toplevel_locs_and_defs = group_toplevel_defs [] (c_datatypes_locs_and_strs @ locs_and_c_extern_function_decls @ locs_and_c_predicate_decls) in
-  let toplevel_locs_and_defs = List.map (fun (loc, _) -> (loc, [""])) toplevel_locs_and_defs in 
+  let toplevel_locs_and_defs = List.Old.map (fun (loc, _) -> (loc, [""])) toplevel_locs_and_defs in 
 
   let accesses_stmt_injs = if with_ownership_checking then memory_accesses_injections ail_prog else [] in
   let struct_injs_with_filenames = Executable_spec_internal.generate_struct_injs sigm in
-  let struct_injs_with_filenames = List.map (fun (loc, _) -> (loc, [""])) struct_injs_with_filenames in 
+  let struct_injs_with_filenames = List.Old.map (fun (loc, _) -> (loc, [""])) struct_injs_with_filenames in 
 
   
   (* Printf.printf "Locations for injection of CN statements:\n";
-  let _ = List.map (fun (loc, _) -> Printf.printf "%s: %s\n" (Option.get (Cerb_location.get_filename loc)) (Cerb_location.simple_location loc)) executable_spec.in_stmt in  *)
+  let _ = List.Old.map (fun (loc, _) -> Printf.printf "%s: %s\n" (Option.get (Cerb_location.get_filename loc)) (Cerb_location.simple_location loc)) executable_spec.in_stmt in  *)
   let in_stmt_injs = 
     executable_spec.in_stmt @
     accesses_stmt_injs 
@@ -257,12 +257,12 @@ let main ?(with_ownership_checking=false) ?(copy_source_dir=false) filename ((_,
 
   (* Return injections *)
   let block_return_injs = executable_spec.returns in 
-  let squashed_block_return_injs = List.map (fun (l, e_opt, strs) -> (l, (e_opt, strs))) block_return_injs in 
+  let squashed_block_return_injs = List.Old.map (fun (l, e_opt, strs) -> (l, (e_opt, strs))) block_return_injs in 
   let source_file_return_injs_squashed = filter_injs_by_filename squashed_block_return_injs filename in 
-  let source_file_return_injs = List.map (fun (l, (e_opt, strs)) -> (l, e_opt, strs)) source_file_return_injs_squashed in 
+  let source_file_return_injs = List.Old.map (fun (l, (e_opt, strs)) -> (l, e_opt, strs)) source_file_return_injs_squashed in 
     
-  let included_filenames = List.map (fun (loc, _) -> Cerb_location.get_filename loc) in_stmt_injs in
-  let included_filenames' = included_filenames @ List.map (fun (loc, _) -> Cerb_location.get_filename loc) squashed_block_return_injs in 
+  let included_filenames = List.Old.map (fun (loc, _) -> Cerb_location.get_filename loc) in_stmt_injs in
+  let included_filenames' = included_filenames @ List.Old.map (fun (loc, _) -> Cerb_location.get_filename loc) squashed_block_return_injs in 
 
   let remaining_fns_and_ocs = open_auxilliary_files filename prefix included_filenames' [] in
 

--- a/backend/cn/executable_spec_internal.ml
+++ b/backend/cn/executable_spec_internal.ml
@@ -93,7 +93,7 @@ let generate_c_pres_and_posts_internal with_ownership_checking (instrumentation 
 
 
   let in_stmt = List.map ~f:(fun (loc, bs_and_ss) -> (modify_magic_comment_loc loc, generate_ail_stat_strs bs_and_ss)) ail_executable_spec.in_stmt in
-  let return_injs = List.Old.filter_map (fun (loc, e_opt, bs, ss) -> match e_opt with | Some e_opt' -> Some (loc, e_opt', bs, ss) | None -> None ) block_ownership_injs in 
+  let return_injs = List.filter_map ~f:(fun (loc, e_opt, bs, ss) -> match e_opt with | Some e_opt' -> Some (loc, e_opt', bs, ss) | None -> None ) block_ownership_injs in 
   let non_return_injs = List.Old.filter (fun (_, e_opt, _, _) -> Option.is_none e_opt) block_ownership_injs in 
   let block_ownership_stmts = List.map ~f:(fun (loc, _, bs, ss) -> (loc, generate_ail_stat_strs ~with_newline:true (bs, ss))) non_return_injs in 
   let block_ownership_stmts = List.map ~f:(fun (loc, strs) -> (loc, [String.concat "\n" strs])) block_ownership_stmts in 
@@ -268,7 +268,7 @@ let generate_c_functions_internal (sigm : CF.GenTypes.genTypeCategory CF.AilSynt
   let decl_strs = List.map ~f:(fun doc -> CF.Pp_utils.to_plain_pretty_string doc) decl_docs in
   let decl_str = String.concat "\n" decl_strs in
 
-  let defs = List.Old.filter_map (fun x -> x) defs in
+  let defs = List.filter_map ~f:(fun x -> x) defs in
   let modified_prog_1 : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma = {sigm with declarations = decls; function_definitions = defs} in
   let doc_1 = CF.Pp_ail.pp_program ~executable_spec:true ~show_include:true (None, modified_prog_1) in
   let inline_decl_docs = List.map ~f:(fun (sym, (_, _, decl)) -> CF.Pp_ail.pp_function_prototype ~executable_spec:true sym decl) decls in

--- a/backend/cn/executable_spec_internal.ml
+++ b/backend/cn/executable_spec_internal.ml
@@ -25,12 +25,12 @@ let generate_ail_stat_strs ?(with_newline=false) (bs, (ail_stats_ : CF.GenTypes.
     | _ -> false
   in
 
-  let ail_stats_ = List.filter (fun s -> not (is_assert_true s)) ail_stats_ in
-  let doc = List.map (fun s -> CF.Pp_ail.pp_statement ~executable_spec:true ~bs (mk_stmt s)) ail_stats_ in
-  let doc = List.map (fun d ->
+  let ail_stats_ = List.Old.filter (fun s -> not (is_assert_true s)) ail_stats_ in
+  let doc = List.Old.map (fun s -> CF.Pp_ail.pp_statement ~executable_spec:true ~bs (mk_stmt s)) ail_stats_ in
+  let doc = List.Old.map (fun d ->
     let newline = if with_newline then PPrint.hardline else PPrint.empty in
     newline ^^ d ^^ PPrint.hardline) doc in
-  List.map CF.Pp_utils.to_plain_pretty_string doc
+  List.Old.map CF.Pp_utils.to_plain_pretty_string doc
 
 
 let populate_record_map_aux (sym, bt_ret_type) =
@@ -43,9 +43,9 @@ let populate_record_map_aux (sym, bt_ret_type) =
 
 (* Populate record table with function and predicate record return types *)
 let populate_record_map (prog5: unit Mucore.mu_file) =
-  let fun_syms_and_ret_types = List.map (fun (sym, (def : LogicalFunctions.definition)) -> (sym, def.return_bt)) prog5.mu_logical_predicates in
-  let pred_syms_and_ret_types = List.map (fun (sym, (def : ResourcePredicates.definition)) -> (sym, def.oarg_bt)) prog5.mu_resource_predicates in
-  let _ = List.map populate_record_map_aux (fun_syms_and_ret_types @ pred_syms_and_ret_types) in
+  let fun_syms_and_ret_types = List.Old.map (fun (sym, (def : LogicalFunctions.definition)) -> (sym, def.return_bt)) prog5.mu_logical_predicates in
+  let pred_syms_and_ret_types = List.Old.map (fun (sym, (def : ResourcePredicates.definition)) -> (sym, def.oarg_bt)) prog5.mu_resource_predicates in
+  let _ = List.Old.map populate_record_map_aux (fun_syms_and_ret_types @ pred_syms_and_ret_types) in
   ()
 
 
@@ -60,7 +60,7 @@ let rec extract_global_variables = function
 let generate_c_pres_and_posts_internal with_ownership_checking (instrumentation : Core_to_mucore.instrumentation) _ (sigm: _ CF.AilSyntax.sigma) (prog5: unit Mucore.mu_file) =
   let dts = sigm.cn_datatypes in
   let preds = prog5.mu_resource_predicates in
-  let c_return_type = match List.assoc CF.Symbol.equal_sym instrumentation.fn sigm.A.declarations with
+  let c_return_type = match List.Old.assoc CF.Symbol.equal_sym instrumentation.fn sigm.A.declarations with
     | (_, _, A.Decl_function (_, (_, ret_ty), _, _, _, _)) -> ret_ty
     | _ -> failwith "TODO"
   in
@@ -92,13 +92,13 @@ let generate_c_pres_and_posts_internal with_ownership_checking (instrumentation 
   in
 
 
-  let in_stmt = List.map (fun (loc, bs_and_ss) -> (modify_magic_comment_loc loc, generate_ail_stat_strs bs_and_ss)) ail_executable_spec.in_stmt in
-  let return_injs = List.filter_map (fun (loc, e_opt, bs, ss) -> match e_opt with | Some e_opt' -> Some (loc, e_opt', bs, ss) | None -> None ) block_ownership_injs in 
-  let non_return_injs = List.filter (fun (_, e_opt, _, _) -> Option.is_none e_opt) block_ownership_injs in 
-  let block_ownership_stmts = List.map (fun (loc, _, bs, ss) -> (loc, generate_ail_stat_strs ~with_newline:true (bs, ss))) non_return_injs in 
-  let block_ownership_stmts = List.map (fun (loc, strs) -> (loc, [String.concat "\n" strs])) block_ownership_stmts in 
-  let return_ownership_stmts = List.map (fun (loc, e_opt, bs, ss) -> (loc, e_opt, generate_ail_stat_strs ~with_newline:true (bs, ss))) return_injs in 
-  let return_ownership_stmts = List.map (fun (loc, e_opt, strs) -> (loc, e_opt, [String.concat "\n" strs])) return_ownership_stmts in 
+  let in_stmt = List.Old.map (fun (loc, bs_and_ss) -> (modify_magic_comment_loc loc, generate_ail_stat_strs bs_and_ss)) ail_executable_spec.in_stmt in
+  let return_injs = List.Old.filter_map (fun (loc, e_opt, bs, ss) -> match e_opt with | Some e_opt' -> Some (loc, e_opt', bs, ss) | None -> None ) block_ownership_injs in 
+  let non_return_injs = List.Old.filter (fun (_, e_opt, _, _) -> Option.is_none e_opt) block_ownership_injs in 
+  let block_ownership_stmts = List.Old.map (fun (loc, _, bs, ss) -> (loc, generate_ail_stat_strs ~with_newline:true (bs, ss))) non_return_injs in 
+  let block_ownership_stmts = List.Old.map (fun (loc, strs) -> (loc, [String.concat "\n" strs])) block_ownership_stmts in 
+  let return_ownership_stmts = List.Old.map (fun (loc, e_opt, bs, ss) -> (loc, e_opt, generate_ail_stat_strs ~with_newline:true (bs, ss))) return_injs in 
+  let return_ownership_stmts = List.Old.map (fun (loc, e_opt, strs) -> (loc, e_opt, [String.concat "\n" strs])) return_ownership_stmts in 
   ([(instrumentation.fn, (pre_str, post_str))], in_stmt @ block_ownership_stmts, return_ownership_stmts)
 
 
@@ -112,9 +112,9 @@ let generate_c_specs_internal with_ownership_checking instrumentation_list type_
 let generate_c_spec (instrumentation : Core_to_mucore.instrumentation) =
   generate_c_pres_and_posts_internal with_ownership_checking instrumentation type_map sigm prog5
 in
-let specs = List.map generate_c_spec instrumentation_list in
+let specs = List.Old.map generate_c_spec instrumentation_list in
 let (pre_post, in_stmt, returns) = Executable_spec_utils.list_split_three specs in
-let executable_spec = {pre_post = List.concat pre_post; in_stmt = List.concat in_stmt; returns = List.concat returns} in
+let executable_spec = {pre_post = List.Old.concat pre_post; in_stmt = List.Old.concat in_stmt; returns = List.Old.concat returns} in
 executable_spec
 
 let concat_map_newline docs =
@@ -130,27 +130,27 @@ let generate_struct_decl_str (tag, (_, _, def)) = match def with
     
     
 let generate_c_records ail_structs =
-  let struct_docs = List.map generate_doc_from_ail_struct ail_structs in
-  (CF.Pp_utils.to_plain_pretty_string (PPrint.concat struct_docs), (String.concat "" (List.map generate_struct_decl_str ail_structs)))
+  let struct_docs = List.Old.map generate_doc_from_ail_struct ail_structs in
+  (CF.Pp_utils.to_plain_pretty_string (PPrint.concat struct_docs), (String.concat "" (List.Old.map generate_struct_decl_str ail_structs)))
 
 let generate_record_strs (_sigm : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma) ail_records =
   let (record_def_strs, record_decl_strs) = generate_c_records ail_records in
   (record_def_strs, record_decl_strs)
 
-  (* let ail_record_equality_functions = List.map (fun r -> Cn_internal_to_ail.generate_struct_equality_function ~is_record:true sigm.cn_datatypes r) ail_records in
-  let ail_record_equality_functions = List.concat ail_record_equality_functions in
-  let ail_record_default_functions = List.map (fun r -> Cn_internal_to_ail.generate_struct_default_function ~is_record:true sigm.cn_datatypes r) ail_records in
-  let ail_record_default_functions = List.concat ail_record_default_functions in 
-  let ail_record_mapget_functions = List.map (fun r -> Cn_internal_to_ail.generate_struct_map_get ~is_record:true sigm.cn_datatypes r) ail_records in
-  let ail_record_mapget_functions = List.concat ail_record_mapget_functions in  *)
-  (* let (eq_decls, eq_defs) = List.split ail_record_equality_functions in
-  let (default_decls, default_defs) = List.split ail_record_default_functions in 
-  let (mapget_decls, mapget_defs) = List.split ail_record_mapget_functions in  *)
+  (* let ail_record_equality_functions = List.Old.map (fun r -> Cn_internal_to_ail.generate_struct_equality_function ~is_record:true sigm.cn_datatypes r) ail_records in
+  let ail_record_equality_functions = List.Old.concat ail_record_equality_functions in
+  let ail_record_default_functions = List.Old.map (fun r -> Cn_internal_to_ail.generate_struct_default_function ~is_record:true sigm.cn_datatypes r) ail_records in
+  let ail_record_default_functions = List.Old.concat ail_record_default_functions in 
+  let ail_record_mapget_functions = List.Old.map (fun r -> Cn_internal_to_ail.generate_struct_map_get ~is_record:true sigm.cn_datatypes r) ail_records in
+  let ail_record_mapget_functions = List.Old.concat ail_record_mapget_functions in  *)
+  (* let (eq_decls, eq_defs) = List.Old.split ail_record_equality_functions in
+  let (default_decls, default_defs) = List.Old.split ail_record_default_functions in 
+  let (mapget_decls, mapget_defs) = List.Old.split ail_record_mapget_functions in  *)
   (* let modified_prog1 : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma = {sigm with declarations = eq_decls @ default_decls @ mapget_decls; function_definitions = eq_defs @ default_defs @ mapget_defs} in
   let equality_fun_strs = CF.Pp_ail.pp_program ~executable_spec:true ~show_include:true (None, modified_prog1) in
-  let decl_docs = List.map (fun (sym, (_, _, decl)) -> CF.Pp_ail.pp_function_prototype ~executable_spec:true sym decl) eq_decls in
-  let equality_fun_prot_strs = List.map (fun doc -> [CF.Pp_utils.to_plain_pretty_string doc]) decl_docs in
-  let equality_fun_prot_strs = String.concat "\n" (List.concat equality_fun_prot_strs) in *)
+  let decl_docs = List.Old.map (fun (sym, (_, _, decl)) -> CF.Pp_ail.pp_function_prototype ~executable_spec:true sym decl) eq_decls in
+  let equality_fun_prot_strs = List.Old.map (fun doc -> [CF.Pp_utils.to_plain_pretty_string doc]) decl_docs in
+  let equality_fun_prot_strs = String.concat "\n" (List.Old.concat equality_fun_prot_strs) in *)
   (* (record_def_strs, record_decl_strs, CF.Pp_utils.to_plain_pretty_string equality_fun_strs, equality_fun_prot_strs) *)
 
 let generate_all_record_strs sigm =
@@ -160,7 +160,7 @@ let generate_str_from_ail_struct ail_struct =
   CF.Pp_utils.to_plain_pretty_string (generate_doc_from_ail_struct ail_struct)
 
 let generate_str_from_ail_structs ail_structs =
-  let docs = List.map generate_doc_from_ail_struct ail_structs in
+  let docs = List.Old.map generate_doc_from_ail_struct ail_structs in
   CF.Pp_utils.to_plain_pretty_string (concat_map_newline docs)
 
 (* TODO: Use Mucore datatypes instead of CN datatypes from Ail program *)
@@ -169,34 +169,34 @@ let generate_c_datatypes (sigm : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma)
     | [] -> []
     | (d :: ds) ->
         let ail_dt1 = Cn_internal_to_ail.cn_to_ail_datatype ~first:true d in
-        let ail_dts = List.map Cn_internal_to_ail.cn_to_ail_datatype ds in
+        let ail_dts = List.Old.map Cn_internal_to_ail.cn_to_ail_datatype ds in
         ail_dt1 :: ail_dts
       in
 
-  let ail_datatype_decls = List.map generate_struct_decl_str (List.concat (List.map snd ail_datatypes)) in 
-  let locs_and_structs = List.map (fun (loc, structs) -> (loc, List.map generate_doc_from_ail_struct structs)) ail_datatypes in
-  let locs_and_struct_strs = List.map (fun (loc, ail_structs) -> (loc, CF.Pp_utils.to_plain_pretty_string (concat_map_newline ail_structs))) locs_and_structs in
-  (* let structs = List.map generate_doc_from_ail_struct ail_datatypes in *)
+  let ail_datatype_decls = List.Old.map generate_struct_decl_str (List.Old.concat (List.Old.map snd ail_datatypes)) in 
+  let locs_and_structs = List.Old.map (fun (loc, structs) -> (loc, List.Old.map generate_doc_from_ail_struct structs)) ail_datatypes in
+  let locs_and_struct_strs = List.Old.map (fun (loc, ail_structs) -> (loc, CF.Pp_utils.to_plain_pretty_string (concat_map_newline ail_structs))) locs_and_structs in
+  (* let structs = List.Old.map generate_doc_from_ail_struct ail_datatypes in *)
   (* CF.Pp_utils.to_plain_pretty_string (concat_map_newline structs) *)
-  (* let _ = List.map (fun (loc, _) -> Printf.printf "Datatype location: %s\n" (Cerb_location.simple_location loc)) locs_and_struct_strs in *)
+  (* let _ = List.Old.map (fun (loc, _) -> Printf.printf "Datatype location: %s\n" (Cerb_location.simple_location loc)) locs_and_struct_strs in *)
 
   (* Need to generate function prototype for corresponding equality function *)
-  let datatype_equality_funs = List.map Cn_internal_to_ail.generate_datatype_equality_function sigm.cn_datatypes in
-  let datatype_equality_funs = List.concat datatype_equality_funs in
-  let (dt_eq_decls, _) = List.split datatype_equality_funs in
-  let decl_docs = List.map (fun (sym, (_, _, decl)) -> CF.Pp_ail.pp_function_prototype ~executable_spec:true sym decl) dt_eq_decls in
-  let decl_strs = List.map (fun doc -> CF.Pp_utils.to_plain_pretty_string doc) decl_docs in
+  let datatype_equality_funs = List.Old.map Cn_internal_to_ail.generate_datatype_equality_function sigm.cn_datatypes in
+  let datatype_equality_funs = List.Old.concat datatype_equality_funs in
+  let (dt_eq_decls, _) = List.Old.split datatype_equality_funs in
+  let decl_docs = List.Old.map (fun (sym, (_, _, decl)) -> CF.Pp_ail.pp_function_prototype ~executable_spec:true sym decl) dt_eq_decls in
+  let decl_strs = List.Old.map (fun doc -> CF.Pp_utils.to_plain_pretty_string doc) decl_docs in
   (locs_and_struct_strs, String.concat "\n" ail_datatype_decls, decl_strs)
 
 
 let print_c_structs c_structs =
   let struct_defs_str = generate_str_from_ail_structs c_structs in 
-  let struct_decls_str = List.map generate_struct_decl_str c_structs in 
+  let struct_decls_str = List.Old.map generate_struct_decl_str c_structs in 
   ("\n/* ORIGINAL C STRUCTS */\n\n" ^ struct_defs_str, String.concat "" struct_decls_str)
 
 let generate_cn_versions_of_structs c_structs =
-  let ail_structs = List.concat (List.map Cn_internal_to_ail.cn_to_ail_struct c_structs) in
-  let struct_decls = List.map generate_struct_decl_str ail_structs in
+  let ail_structs = List.Old.concat (List.Old.map Cn_internal_to_ail.cn_to_ail_struct c_structs) in
+  let struct_decls = List.Old.map generate_struct_decl_str ail_structs in
   ("\n/* CN VERSIONS OF C STRUCTS */\n\n" ^ generate_str_from_ail_structs ail_structs, String.concat "" struct_decls)
 
 let generate_struct_injs (sigm: CF.GenTypes.genTypeCategory CF.AilSyntax.sigma)  =
@@ -211,8 +211,8 @@ let generate_struct_injs (sigm: CF.GenTypes.genTypeCategory CF.AilSyntax.sigma) 
         | (((sym1, (loc1, attrs1, conversion_decl)), _) :: _, ((sym2, (loc2, attrs2, equality_decl)), _) :: _) ->
           let conversion_def = (sym1, (loc1, attrs1, conversion_decl)) in
           let equality_def = (sym2, (loc2, attrs2, equality_decl)) in
-          let decl_docs = List.map (fun (sym, (_, _, decl)) -> CF.Pp_ail.pp_function_prototype ~executable_spec:true sym decl) [conversion_def; equality_def] in
-          let decl_strs = List.map (fun doc -> CF.Pp_utils.to_plain_pretty_string doc) decl_docs in
+          let decl_docs = List.Old.map (fun (sym, (_, _, decl)) -> CF.Pp_ail.pp_function_prototype ~executable_spec:true sym decl) [conversion_def; equality_def] in
+          let decl_strs = List.Old.map (fun doc -> CF.Pp_utils.to_plain_pretty_string doc) decl_docs in
           String.concat "\n" decl_strs
         | (_, _) -> ""
       in
@@ -221,8 +221,8 @@ let generate_struct_injs (sigm: CF.GenTypes.genTypeCategory CF.AilSyntax.sigma) 
       [(loc, str_list)]
     | C.UnionDef _ -> []
   in
-  let struct_injs = List.map generate_struct_inj sigm.tag_definitions in
-  List.concat struct_injs
+  let struct_injs = List.Old.map generate_struct_inj sigm.tag_definitions in
+  List.Old.concat struct_injs
 
 
 let bt_is_record_or_tuple = function
@@ -231,53 +231,53 @@ let bt_is_record_or_tuple = function
   | _ -> false
 
 let fns_and_preds_with_record_rt (funs, preds) =
-  let funs' = List.filter (fun (_, (def : LogicalFunctions.definition)) -> bt_is_record_or_tuple def.return_bt) funs in
-  let fun_syms = List.map (fun (fn_sym, _) -> fn_sym) funs' in
-  let preds' = List.filter (fun (_, (def : ResourcePredicates.definition)) -> bt_is_record_or_tuple def.oarg_bt) preds in
-  let pred_syms = List.map (fun (pred_sym, _) -> pred_sym) preds' in
+  let funs' = List.Old.filter (fun (_, (def : LogicalFunctions.definition)) -> bt_is_record_or_tuple def.return_bt) funs in
+  let fun_syms = List.Old.map (fun (fn_sym, _) -> fn_sym) funs' in
+  let preds' = List.Old.filter (fun (_, (def : ResourcePredicates.definition)) -> bt_is_record_or_tuple def.oarg_bt) preds in
+  let pred_syms = List.Old.map (fun (pred_sym, _) -> pred_sym) preds' in
   (fun_syms, pred_syms)
 
 let generate_c_record_funs (sigm : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma) (logical_predicates : Mucore.T.logical_predicates) (resource_predicates : Mucore.T.resource_predicates) =
-  let cn_record_info = List.map (fun (sym, (def : LogicalFunctions.definition)) ->
+  let cn_record_info = List.Old.map (fun (sym, (def : LogicalFunctions.definition)) ->
     match def.return_bt with | BT.Record ms -> [(Cn_internal_to_ail.generate_sym_with_suffix ~suffix:"_record" sym, ms)] | _ -> []) logical_predicates in 
-  let cn_record_info' = List.map (fun (sym, (def : ResourcePredicates.definition)) ->
+  let cn_record_info' = List.Old.map (fun (sym, (def : ResourcePredicates.definition)) ->
     match def.oarg_bt with | BT.Record ms -> [(Cn_internal_to_ail.generate_sym_with_suffix ~suffix:"_record" sym, ms)] | _ -> []) resource_predicates in 
-  let cn_record_info = List.concat (cn_record_info @ cn_record_info') in 
-  let record_equality_functions = List.concat (List.map (Cn_internal_to_ail.generate_record_equality_function sigm.cn_datatypes) cn_record_info) in 
-  let record_default_functions = List.concat (List.map (Cn_internal_to_ail.generate_record_default_function sigm.cn_datatypes) cn_record_info) in 
-  let record_map_get_functions = List.concat (List.map (Cn_internal_to_ail.generate_record_map_get sigm.cn_datatypes) cn_record_info) in 
-  let (eq_decls, eq_defs) = List.split record_equality_functions in
-  let (default_decls, default_defs) = List.split record_default_functions in 
-  let (mapget_decls, mapget_defs) = List.split record_map_get_functions in 
+  let cn_record_info = List.Old.concat (cn_record_info @ cn_record_info') in 
+  let record_equality_functions = List.Old.concat (List.Old.map (Cn_internal_to_ail.generate_record_equality_function sigm.cn_datatypes) cn_record_info) in 
+  let record_default_functions = List.Old.concat (List.Old.map (Cn_internal_to_ail.generate_record_default_function sigm.cn_datatypes) cn_record_info) in 
+  let record_map_get_functions = List.Old.concat (List.Old.map (Cn_internal_to_ail.generate_record_map_get sigm.cn_datatypes) cn_record_info) in 
+  let (eq_decls, eq_defs) = List.Old.split record_equality_functions in
+  let (default_decls, default_defs) = List.Old.split record_default_functions in 
+  let (mapget_decls, mapget_defs) = List.Old.split record_map_get_functions in 
   let modified_prog1 : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma = {sigm with declarations = eq_decls @ default_decls @ mapget_decls; function_definitions = eq_defs @ default_defs @ mapget_defs} in
   let fun_doc = CF.Pp_ail.pp_program ~executable_spec:true ~show_include:true (None, modified_prog1) in
   let fun_strs = CF.Pp_utils.to_plain_pretty_string fun_doc in
-  let decl_docs = List.map (fun (sym, (_, _, decl)) -> CF.Pp_ail.pp_function_prototype ~executable_spec:true sym decl) (eq_decls @ default_decls @ mapget_decls) in
-  let fun_prot_strs = List.map (fun doc -> [CF.Pp_utils.to_plain_pretty_string doc]) decl_docs in
-  let fun_prot_strs = String.concat "\n" (List.concat fun_prot_strs) in
+  let decl_docs = List.Old.map (fun (sym, (_, _, decl)) -> CF.Pp_ail.pp_function_prototype ~executable_spec:true sym decl) (eq_decls @ default_decls @ mapget_decls) in
+  let fun_prot_strs = List.Old.map (fun doc -> [CF.Pp_utils.to_plain_pretty_string doc]) decl_docs in
+  let fun_prot_strs = String.concat "\n" (List.Old.concat fun_prot_strs) in
   (fun_strs, fun_prot_strs)
 
 
 let generate_c_functions_internal (sigm : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma) (logical_predicates : Mucore.T.logical_predicates)  =
-  let ail_funs_and_records = List.map (fun cn_f -> Cn_internal_to_ail.cn_to_ail_function_internal cn_f sigm.cn_datatypes sigm.cn_functions) logical_predicates in
+  let ail_funs_and_records = List.Old.map (fun cn_f -> Cn_internal_to_ail.cn_to_ail_function_internal cn_f sigm.cn_datatypes sigm.cn_functions) logical_predicates in
 
-  let (ail_funs, ail_records_opt) = List.split ail_funs_and_records in
-  let (locs_and_decls, defs) = List.split ail_funs in
-  let (locs, decls) = List.split locs_and_decls in
-  let decl_docs = List.map (fun (sym, (_, _, decl)) -> CF.Pp_ail.pp_function_prototype ~executable_spec:true sym decl) decls in
-  let decl_strs = List.map (fun doc -> CF.Pp_utils.to_plain_pretty_string doc) decl_docs in
+  let (ail_funs, ail_records_opt) = List.Old.split ail_funs_and_records in
+  let (locs_and_decls, defs) = List.Old.split ail_funs in
+  let (locs, decls) = List.Old.split locs_and_decls in
+  let decl_docs = List.Old.map (fun (sym, (_, _, decl)) -> CF.Pp_ail.pp_function_prototype ~executable_spec:true sym decl) decls in
+  let decl_strs = List.Old.map (fun doc -> CF.Pp_utils.to_plain_pretty_string doc) decl_docs in
   let decl_str = String.concat "\n" decl_strs in
 
-  let defs = List.filter_map (fun x -> x) defs in
+  let defs = List.Old.filter_map (fun x -> x) defs in
   let modified_prog_1 : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma = {sigm with declarations = decls; function_definitions = defs} in
   let doc_1 = CF.Pp_ail.pp_program ~executable_spec:true ~show_include:true (None, modified_prog_1) in
-  let inline_decl_docs = List.map (fun (sym, (_, _, decl)) -> CF.Pp_ail.pp_function_prototype ~executable_spec:true sym decl) decls in
-  let inline_decl_strs = List.map (fun doc -> [CF.Pp_utils.to_plain_pretty_string doc]) inline_decl_docs in
-  let locs_and_decls' = List.combine locs inline_decl_strs in
+  let inline_decl_docs = List.Old.map (fun (sym, (_, _, decl)) -> CF.Pp_ail.pp_function_prototype ~executable_spec:true sym decl) decls in
+  let inline_decl_strs = List.Old.map (fun doc -> [CF.Pp_utils.to_plain_pretty_string doc]) inline_decl_docs in
+  let locs_and_decls' = List.Old.combine locs inline_decl_strs in
   (* let modified_prog_2 : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma = {sigm with declarations = decls; function_definitions = []} in *)
   (* let doc_2 = CF.Pp_ail.pp_program ~executable_spec:true ~show_include:true (None, modified_prog_2) in *)
-  let ail_records = List.map (fun r -> match r with | Some record -> [record] | None -> []) ail_records_opt in
-  let record_triple_str = generate_record_strs sigm (List.concat ail_records) in
+  let ail_records = List.Old.map (fun r -> match r with | Some record -> [record] | None -> []) ail_records_opt in
+  let record_triple_str = generate_record_strs sigm (List.Old.concat ail_records) in
   let funs_defs_str = CF.Pp_utils.to_plain_pretty_string doc_1 in
   (* let funs_decls_str = CF.Pp_utils.to_plain_pretty_string doc_2 in  *)
   (funs_defs_str, "\n/* CN FUNCTIONS */\n\n" ^ decl_str, locs_and_decls', record_triple_str)
@@ -285,41 +285,41 @@ let generate_c_functions_internal (sigm : CF.GenTypes.genTypeCategory CF.AilSynt
 let rec remove_duplicates eq_fun = function
   | [] -> []
   | t :: ts ->
-    if List.mem eq_fun t ts then
+    if List.Old.mem eq_fun t ts then
       remove_duplicates eq_fun ts
     else
       t :: (remove_duplicates eq_fun ts)
 
 let generate_c_predicates_internal (sigm : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma) (resource_predicates : Mucore.T.resource_predicates) =
-  (* let ail_info = List.map (fun cn_f -> Cn_internal_to_ail.cn_to_ail_predicate_internal cn_f sigm.cn_datatypes [] ownership_ctypes resource_predicates) resource_predicates in *)
+  (* let ail_info = List.Old.map (fun cn_f -> Cn_internal_to_ail.cn_to_ail_predicate_internal cn_f sigm.cn_datatypes [] ownership_ctypes resource_predicates) resource_predicates in *)
   (* TODO: Remove passing of resource_predicates argument twice - could use counter? *)
   let (ail_funs, ail_records_opt) = Cn_internal_to_ail.cn_to_ail_predicates_internal resource_predicates sigm.cn_datatypes [] resource_predicates sigm.cn_predicates in
-  let (locs_and_decls, defs) = List.split ail_funs in
-  let (locs, decls) = List.split locs_and_decls in
+  let (locs_and_decls, defs) = List.Old.split ail_funs in
+  let (locs, decls) = List.Old.split locs_and_decls in
   let modified_prog1 : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma = {sigm with declarations = decls; function_definitions = defs} in
   let doc1 = CF.Pp_ail.pp_program ~executable_spec:true ~show_include:true (None, modified_prog1) in
   let pred_defs_str =
   CF.Pp_utils.to_plain_pretty_string doc1 in
-  let pred_locs_and_decls = List.map (fun (loc, (sym, (_, _, decl))) ->
-     (loc, [CF.Pp_utils.to_plain_pretty_string (CF.Pp_ail.pp_function_prototype ~executable_spec:true sym decl)])) (List.combine locs decls) in
-  let ail_records = List.map (fun r -> match r with | Some record -> [record] | None -> []) ail_records_opt in
-  let record_triple_str = generate_record_strs sigm (List.concat ail_records) in
+  let pred_locs_and_decls = List.Old.map (fun (loc, (sym, (_, _, decl))) ->
+     (loc, [CF.Pp_utils.to_plain_pretty_string (CF.Pp_ail.pp_function_prototype ~executable_spec:true sym decl)])) (List.Old.combine locs decls) in
+  let ail_records = List.Old.map (fun r -> match r with | Some record -> [record] | None -> []) ail_records_opt in
+  let record_triple_str = generate_record_strs sigm (List.Old.concat ail_records) in
   ("\n/* CN PREDICATES */\n\n" ^ pred_defs_str, pred_locs_and_decls, record_triple_str)
 
 let generate_ownership_functions with_ownership_checking ownership_ctypes (sigm : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma)  =
-  (* let ctypes = List.map get_ctype_without_ptr ctypes in  *)
+  (* let ctypes = List.Old.map get_ctype_without_ptr ctypes in  *)
   let rec remove_duplicates ret_list = function 
     | [] -> []
     | x :: xs ->
-        if (List.mem execCtypeEqual x ret_list) then 
+        if (List.Old.mem execCtypeEqual x ret_list) then 
           remove_duplicates (x :: ret_list) xs
         else 
           x :: remove_duplicates (x :: ret_list) xs  
   in 
   let ctypes = !ownership_ctypes in 
   let ctypes = remove_duplicates [] ctypes in 
-  let ail_funs = List.map (fun ctype -> Cn_internal_to_ail.generate_ownership_function with_ownership_checking ctype) ctypes in
-  let (decls, defs) = List.split ail_funs in
+  let ail_funs = List.Old.map (fun ctype -> Cn_internal_to_ail.generate_ownership_function with_ownership_checking ctype) ctypes in
+  let (decls, defs) = List.Old.split ail_funs in
   let modified_prog1 : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma = {sigm with declarations = decls; function_definitions = defs} in
   let doc1 = CF.Pp_ail.pp_program ~executable_spec:true ~show_include:true (None, modified_prog1) in
   let modified_prog2 : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma = {sigm with declarations = decls; function_definitions = []} in
@@ -328,14 +328,14 @@ let generate_ownership_functions with_ownership_checking ownership_ctypes (sigm 
   (comment ^ CF.Pp_utils.to_plain_pretty_string doc1, CF.Pp_utils.to_plain_pretty_string doc2)
 
 let generate_conversion_and_equality_functions (sigm : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma) =
-  let ail_funs = List.map Cn_internal_to_ail.generate_struct_conversion_function sigm.tag_definitions in
-  let ail_funs' = List.map (Cn_internal_to_ail.generate_struct_equality_function sigm.cn_datatypes) sigm.tag_definitions in
-  let ail_funs'' = List.map Cn_internal_to_ail.generate_datatype_equality_function sigm.cn_datatypes in
-  let ail_funs''' = List.map (Cn_internal_to_ail.generate_struct_map_get sigm.cn_datatypes) sigm.tag_definitions in
-  let ail_funs'''' = List.map (Cn_internal_to_ail.generate_struct_default_function sigm.cn_datatypes) sigm.tag_definitions in
-  let ail_funs = List.concat ail_funs in
-  let ail_funs = ail_funs @ List.concat ail_funs' @ List.concat ail_funs'' @ List.concat ail_funs''' @ List.concat ail_funs'''' in
-  let (decls, defs) = List.split ail_funs in
+  let ail_funs = List.Old.map Cn_internal_to_ail.generate_struct_conversion_function sigm.tag_definitions in
+  let ail_funs' = List.Old.map (Cn_internal_to_ail.generate_struct_equality_function sigm.cn_datatypes) sigm.tag_definitions in
+  let ail_funs'' = List.Old.map Cn_internal_to_ail.generate_datatype_equality_function sigm.cn_datatypes in
+  let ail_funs''' = List.Old.map (Cn_internal_to_ail.generate_struct_map_get sigm.cn_datatypes) sigm.tag_definitions in
+  let ail_funs'''' = List.Old.map (Cn_internal_to_ail.generate_struct_default_function sigm.cn_datatypes) sigm.tag_definitions in
+  let ail_funs = List.Old.concat ail_funs in
+  let ail_funs = ail_funs @ List.Old.concat ail_funs' @ List.Old.concat ail_funs'' @ List.Old.concat ail_funs''' @ List.Old.concat ail_funs'''' in
+  let (decls, defs) = List.Old.split ail_funs in
   let modified_prog1 : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma = {sigm with declarations = decls; function_definitions = defs} in
   let doc1 = CF.Pp_ail.pp_program ~executable_spec:true ~show_include:true (None, modified_prog1) in
   let modified_prog2 : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma = {sigm with declarations = decls; function_definitions = []} in
@@ -345,15 +345,15 @@ let generate_conversion_and_equality_functions (sigm : CF.GenTypes.genTypeCatego
 
 
 let generate_ownership_global_assignments (sigm : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma) (prog5: unit Mucore.mu_file) = 
-  let main_fn_sym_list = List.filter (fun (fn_sym, _) -> String.equal "main" (Sym.pp_string fn_sym)) sigm.function_definitions in 
+  let main_fn_sym_list = List.Old.filter (fun (fn_sym, _) -> String.equal "main" (Sym.pp_string fn_sym)) sigm.function_definitions in 
   match main_fn_sym_list with 
     | [] -> failwith "CN-exec: No main function so ownership globals cannot be initialised"
     | (main_sym, _) :: _ ->
       let globals = extract_global_variables prog5.mu_globs in 
-      let global_map_fcalls = List.map Ownership_exec.generate_c_local_ownership_entry_fcall globals in 
-      let global_map_stmts_ = List.map (fun e -> A.AilSexpr e) global_map_fcalls in 
+      let global_map_fcalls = List.Old.map Ownership_exec.generate_c_local_ownership_entry_fcall globals in 
+      let global_map_stmts_ = List.Old.map (fun e -> A.AilSexpr e) global_map_fcalls in 
       let assignments = Ownership_exec.get_ownership_global_init_stats () in
       let init_and_global_mapping_str = generate_ail_stat_strs ([], assignments @ global_map_stmts_) in
-      let global_unmapping_stmts_ = List.map Ownership_exec.generate_c_local_ownership_exit globals in 
+      let global_unmapping_stmts_ = List.Old.map Ownership_exec.generate_c_local_ownership_exit globals in 
       let global_unmapping_str = generate_ail_stat_strs ([], global_unmapping_stmts_) in
       [(main_sym, (init_and_global_mapping_str, global_unmapping_str))]

--- a/backend/cn/executable_spec_internal.ml
+++ b/backend/cn/executable_spec_internal.ml
@@ -143,9 +143,9 @@ let generate_record_strs (_sigm : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma
   let ail_record_default_functions = List.concat ail_record_default_functions in 
   let ail_record_mapget_functions = List.map ~f:(fun r -> Cn_internal_to_ail.generate_struct_map_get ~is_record:true sigm.cn_datatypes r) ail_records in
   let ail_record_mapget_functions = List.concat ail_record_mapget_functions in  *)
-  (* let (eq_decls, eq_defs) = List.Old.split ail_record_equality_functions in
-  let (default_decls, default_defs) = List.Old.split ail_record_default_functions in 
-  let (mapget_decls, mapget_defs) = List.Old.split ail_record_mapget_functions in  *)
+  (* let (eq_decls, eq_defs) = List.unzip  ail_record_equality_functions in
+  let (default_decls, default_defs) = List.unzip  ail_record_default_functions in 
+  let (mapget_decls, mapget_defs) = List.unzip  ail_record_mapget_functions in  *)
   (* let modified_prog1 : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma = {sigm with declarations = eq_decls @ default_decls @ mapget_decls; function_definitions = eq_defs @ default_defs @ mapget_defs} in
   let equality_fun_strs = CF.Pp_ail.pp_program ~executable_spec:true ~show_include:true (None, modified_prog1) in
   let decl_docs = List.map ~f:(fun (sym, (_, _, decl)) -> CF.Pp_ail.pp_function_prototype ~executable_spec:true sym decl) eq_decls in
@@ -183,7 +183,7 @@ let generate_c_datatypes (sigm : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma)
   (* Need to generate function prototype for corresponding equality function *)
   let datatype_equality_funs = List.map ~f:Cn_internal_to_ail.generate_datatype_equality_function sigm.cn_datatypes in
   let datatype_equality_funs = List.concat datatype_equality_funs in
-  let (dt_eq_decls, _) = List.Old.split datatype_equality_funs in
+  let (dt_eq_decls, _) = List.unzip  datatype_equality_funs in
   let decl_docs = List.map ~f:(fun (sym, (_, _, decl)) -> CF.Pp_ail.pp_function_prototype ~executable_spec:true sym decl) dt_eq_decls in
   let decl_strs = List.map ~f:(fun doc -> CF.Pp_utils.to_plain_pretty_string doc) decl_docs in
   (locs_and_struct_strs, String.concat "\n" ail_datatype_decls, decl_strs)
@@ -246,9 +246,9 @@ let generate_c_record_funs (sigm : CF.GenTypes.genTypeCategory CF.AilSyntax.sigm
   let record_equality_functions = List.concat (List.map ~f:(Cn_internal_to_ail.generate_record_equality_function sigm.cn_datatypes) cn_record_info) in 
   let record_default_functions = List.concat (List.map ~f:(Cn_internal_to_ail.generate_record_default_function sigm.cn_datatypes) cn_record_info) in 
   let record_map_get_functions = List.concat (List.map ~f:(Cn_internal_to_ail.generate_record_map_get sigm.cn_datatypes) cn_record_info) in 
-  let (eq_decls, eq_defs) = List.Old.split record_equality_functions in
-  let (default_decls, default_defs) = List.Old.split record_default_functions in 
-  let (mapget_decls, mapget_defs) = List.Old.split record_map_get_functions in 
+  let (eq_decls, eq_defs) = List.unzip  record_equality_functions in
+  let (default_decls, default_defs) = List.unzip  record_default_functions in 
+  let (mapget_decls, mapget_defs) = List.unzip  record_map_get_functions in 
   let modified_prog1 : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma = {sigm with declarations = eq_decls @ default_decls @ mapget_decls; function_definitions = eq_defs @ default_defs @ mapget_defs} in
   let fun_doc = CF.Pp_ail.pp_program ~executable_spec:true ~show_include:true (None, modified_prog1) in
   let fun_strs = CF.Pp_utils.to_plain_pretty_string fun_doc in
@@ -261,9 +261,9 @@ let generate_c_record_funs (sigm : CF.GenTypes.genTypeCategory CF.AilSyntax.sigm
 let generate_c_functions_internal (sigm : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma) (logical_predicates : Mucore.T.logical_predicates)  =
   let ail_funs_and_records = List.map ~f:(fun cn_f -> Cn_internal_to_ail.cn_to_ail_function_internal cn_f sigm.cn_datatypes sigm.cn_functions) logical_predicates in
 
-  let (ail_funs, ail_records_opt) = List.Old.split ail_funs_and_records in
-  let (locs_and_decls, defs) = List.Old.split ail_funs in
-  let (locs, decls) = List.Old.split locs_and_decls in
+  let (ail_funs, ail_records_opt) = List.unzip  ail_funs_and_records in
+  let (locs_and_decls, defs) = List.unzip  ail_funs in
+  let (locs, decls) = List.unzip  locs_and_decls in
   let decl_docs = List.map ~f:(fun (sym, (_, _, decl)) -> CF.Pp_ail.pp_function_prototype ~executable_spec:true sym decl) decls in
   let decl_strs = List.map ~f:(fun doc -> CF.Pp_utils.to_plain_pretty_string doc) decl_docs in
   let decl_str = String.concat "\n" decl_strs in
@@ -294,8 +294,8 @@ let generate_c_predicates_internal (sigm : CF.GenTypes.genTypeCategory CF.AilSyn
   (* let ail_info = List.map ~f:(fun cn_f -> Cn_internal_to_ail.cn_to_ail_predicate_internal cn_f sigm.cn_datatypes [] ownership_ctypes resource_predicates) resource_predicates in *)
   (* TODO: Remove passing of resource_predicates argument twice - could use counter? *)
   let (ail_funs, ail_records_opt) = Cn_internal_to_ail.cn_to_ail_predicates_internal resource_predicates sigm.cn_datatypes [] resource_predicates sigm.cn_predicates in
-  let (locs_and_decls, defs) = List.Old.split ail_funs in
-  let (locs, decls) = List.Old.split locs_and_decls in
+  let (locs_and_decls, defs) = List.unzip  ail_funs in
+  let (locs, decls) = List.unzip  locs_and_decls in
   let modified_prog1 : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma = {sigm with declarations = decls; function_definitions = defs} in
   let doc1 = CF.Pp_ail.pp_program ~executable_spec:true ~show_include:true (None, modified_prog1) in
   let pred_defs_str =
@@ -319,7 +319,7 @@ let generate_ownership_functions with_ownership_checking ownership_ctypes (sigm 
   let ctypes = !ownership_ctypes in 
   let ctypes = remove_duplicates [] ctypes in 
   let ail_funs = List.map ~f:(fun ctype -> Cn_internal_to_ail.generate_ownership_function with_ownership_checking ctype) ctypes in
-  let (decls, defs) = List.Old.split ail_funs in
+  let (decls, defs) = List.unzip  ail_funs in
   let modified_prog1 : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma = {sigm with declarations = decls; function_definitions = defs} in
   let doc1 = CF.Pp_ail.pp_program ~executable_spec:true ~show_include:true (None, modified_prog1) in
   let modified_prog2 : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma = {sigm with declarations = decls; function_definitions = []} in
@@ -335,7 +335,7 @@ let generate_conversion_and_equality_functions (sigm : CF.GenTypes.genTypeCatego
   let ail_funs'''' = List.map ~f:(Cn_internal_to_ail.generate_struct_default_function sigm.cn_datatypes) sigm.tag_definitions in
   let ail_funs = List.concat ail_funs in
   let ail_funs = ail_funs @ List.concat ail_funs' @ List.concat ail_funs'' @ List.concat ail_funs''' @ List.concat ail_funs'''' in
-  let (decls, defs) = List.Old.split ail_funs in
+  let (decls, defs) = List.unzip  ail_funs in
   let modified_prog1 : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma = {sigm with declarations = decls; function_definitions = defs} in
   let doc1 = CF.Pp_ail.pp_program ~executable_spec:true ~show_include:true (None, modified_prog1) in
   let modified_prog2 : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma = {sigm with declarations = decls; function_definitions = []} in

--- a/backend/cn/executable_spec_internal.ml
+++ b/backend/cn/executable_spec_internal.ml
@@ -273,7 +273,7 @@ let generate_c_functions_internal (sigm : CF.GenTypes.genTypeCategory CF.AilSynt
   let doc_1 = CF.Pp_ail.pp_program ~executable_spec:true ~show_include:true (None, modified_prog_1) in
   let inline_decl_docs = List.map ~f:(fun (sym, (_, _, decl)) -> CF.Pp_ail.pp_function_prototype ~executable_spec:true sym decl) decls in
   let inline_decl_strs = List.map ~f:(fun doc -> [CF.Pp_utils.to_plain_pretty_string doc]) inline_decl_docs in
-  let locs_and_decls' = List.Old.combine locs inline_decl_strs in
+  let locs_and_decls' = List.zip_exn locs inline_decl_strs in
   (* let modified_prog_2 : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma = {sigm with declarations = decls; function_definitions = []} in *)
   (* let doc_2 = CF.Pp_ail.pp_program ~executable_spec:true ~show_include:true (None, modified_prog_2) in *)
   let ail_records = List.map ~f:(fun r -> match r with | Some record -> [record] | None -> []) ail_records_opt in
@@ -301,7 +301,7 @@ let generate_c_predicates_internal (sigm : CF.GenTypes.genTypeCategory CF.AilSyn
   let pred_defs_str =
   CF.Pp_utils.to_plain_pretty_string doc1 in
   let pred_locs_and_decls = List.map ~f:(fun (loc, (sym, (_, _, decl))) ->
-     (loc, [CF.Pp_utils.to_plain_pretty_string (CF.Pp_ail.pp_function_prototype ~executable_spec:true sym decl)])) (List.Old.combine locs decls) in
+     (loc, [CF.Pp_utils.to_plain_pretty_string (CF.Pp_ail.pp_function_prototype ~executable_spec:true sym decl)])) (List.zip_exn locs decls) in
   let ail_records = List.map ~f:(fun r -> match r with | Some record -> [record] | None -> []) ail_records_opt in
   let record_triple_str = generate_record_strs sigm (List.concat ail_records) in
   ("\n/* CN PREDICATES */\n\n" ^ pred_defs_str, pred_locs_and_decls, record_triple_str)

--- a/backend/cn/executable_spec_internal.ml
+++ b/backend/cn/executable_spec_internal.ml
@@ -114,7 +114,7 @@ let generate_c_spec (instrumentation : Core_to_mucore.instrumentation) =
 in
 let specs = List.map ~f:generate_c_spec instrumentation_list in
 let (pre_post, in_stmt, returns) = Executable_spec_utils.list_split_three specs in
-let executable_spec = {pre_post = List.Old.concat pre_post; in_stmt = List.Old.concat in_stmt; returns = List.Old.concat returns} in
+let executable_spec = {pre_post = List.concat pre_post; in_stmt = List.concat in_stmt; returns = List.concat returns} in
 executable_spec
 
 let concat_map_newline docs =
@@ -138,11 +138,11 @@ let generate_record_strs (_sigm : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma
   (record_def_strs, record_decl_strs)
 
   (* let ail_record_equality_functions = List.map ~f:(fun r -> Cn_internal_to_ail.generate_struct_equality_function ~is_record:true sigm.cn_datatypes r) ail_records in
-  let ail_record_equality_functions = List.Old.concat ail_record_equality_functions in
+  let ail_record_equality_functions = List.concat ail_record_equality_functions in
   let ail_record_default_functions = List.map ~f:(fun r -> Cn_internal_to_ail.generate_struct_default_function ~is_record:true sigm.cn_datatypes r) ail_records in
-  let ail_record_default_functions = List.Old.concat ail_record_default_functions in 
+  let ail_record_default_functions = List.concat ail_record_default_functions in 
   let ail_record_mapget_functions = List.map ~f:(fun r -> Cn_internal_to_ail.generate_struct_map_get ~is_record:true sigm.cn_datatypes r) ail_records in
-  let ail_record_mapget_functions = List.Old.concat ail_record_mapget_functions in  *)
+  let ail_record_mapget_functions = List.concat ail_record_mapget_functions in  *)
   (* let (eq_decls, eq_defs) = List.Old.split ail_record_equality_functions in
   let (default_decls, default_defs) = List.Old.split ail_record_default_functions in 
   let (mapget_decls, mapget_defs) = List.Old.split ail_record_mapget_functions in  *)
@@ -150,7 +150,7 @@ let generate_record_strs (_sigm : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma
   let equality_fun_strs = CF.Pp_ail.pp_program ~executable_spec:true ~show_include:true (None, modified_prog1) in
   let decl_docs = List.map ~f:(fun (sym, (_, _, decl)) -> CF.Pp_ail.pp_function_prototype ~executable_spec:true sym decl) eq_decls in
   let equality_fun_prot_strs = List.map ~f:(fun doc -> [CF.Pp_utils.to_plain_pretty_string doc]) decl_docs in
-  let equality_fun_prot_strs = String.concat "\n" (List.Old.concat equality_fun_prot_strs) in *)
+  let equality_fun_prot_strs = String.concat "\n" (List.concat equality_fun_prot_strs) in *)
   (* (record_def_strs, record_decl_strs, CF.Pp_utils.to_plain_pretty_string equality_fun_strs, equality_fun_prot_strs) *)
 
 let generate_all_record_strs sigm =
@@ -173,7 +173,7 @@ let generate_c_datatypes (sigm : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma)
         ail_dt1 :: ail_dts
       in
 
-  let ail_datatype_decls = List.map ~f:generate_struct_decl_str (List.Old.concat (List.map ~f:snd ail_datatypes)) in 
+  let ail_datatype_decls = List.map ~f:generate_struct_decl_str (List.concat (List.map ~f:snd ail_datatypes)) in 
   let locs_and_structs = List.map ~f:(fun (loc, structs) -> (loc, List.map ~f:generate_doc_from_ail_struct structs)) ail_datatypes in
   let locs_and_struct_strs = List.map ~f:(fun (loc, ail_structs) -> (loc, CF.Pp_utils.to_plain_pretty_string (concat_map_newline ail_structs))) locs_and_structs in
   (* let structs = List.map ~f:generate_doc_from_ail_struct ail_datatypes in *)
@@ -182,7 +182,7 @@ let generate_c_datatypes (sigm : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma)
 
   (* Need to generate function prototype for corresponding equality function *)
   let datatype_equality_funs = List.map ~f:Cn_internal_to_ail.generate_datatype_equality_function sigm.cn_datatypes in
-  let datatype_equality_funs = List.Old.concat datatype_equality_funs in
+  let datatype_equality_funs = List.concat datatype_equality_funs in
   let (dt_eq_decls, _) = List.Old.split datatype_equality_funs in
   let decl_docs = List.map ~f:(fun (sym, (_, _, decl)) -> CF.Pp_ail.pp_function_prototype ~executable_spec:true sym decl) dt_eq_decls in
   let decl_strs = List.map ~f:(fun doc -> CF.Pp_utils.to_plain_pretty_string doc) decl_docs in
@@ -195,7 +195,7 @@ let print_c_structs c_structs =
   ("\n/* ORIGINAL C STRUCTS */\n\n" ^ struct_defs_str, String.concat "" struct_decls_str)
 
 let generate_cn_versions_of_structs c_structs =
-  let ail_structs = List.Old.concat (List.map ~f:Cn_internal_to_ail.cn_to_ail_struct c_structs) in
+  let ail_structs = List.concat (List.map ~f:Cn_internal_to_ail.cn_to_ail_struct c_structs) in
   let struct_decls = List.map ~f:generate_struct_decl_str ail_structs in
   ("\n/* CN VERSIONS OF C STRUCTS */\n\n" ^ generate_str_from_ail_structs ail_structs, String.concat "" struct_decls)
 
@@ -222,7 +222,7 @@ let generate_struct_injs (sigm: CF.GenTypes.genTypeCategory CF.AilSyntax.sigma) 
     | C.UnionDef _ -> []
   in
   let struct_injs = List.map ~f:generate_struct_inj sigm.tag_definitions in
-  List.Old.concat struct_injs
+  List.concat struct_injs
 
 
 let bt_is_record_or_tuple = function
@@ -242,10 +242,10 @@ let generate_c_record_funs (sigm : CF.GenTypes.genTypeCategory CF.AilSyntax.sigm
     match def.return_bt with | BT.Record ms -> [(Cn_internal_to_ail.generate_sym_with_suffix ~suffix:"_record" sym, ms)] | _ -> []) logical_predicates in 
   let cn_record_info' = List.map ~f:(fun (sym, (def : ResourcePredicates.definition)) ->
     match def.oarg_bt with | BT.Record ms -> [(Cn_internal_to_ail.generate_sym_with_suffix ~suffix:"_record" sym, ms)] | _ -> []) resource_predicates in 
-  let cn_record_info = List.Old.concat (cn_record_info @ cn_record_info') in 
-  let record_equality_functions = List.Old.concat (List.map ~f:(Cn_internal_to_ail.generate_record_equality_function sigm.cn_datatypes) cn_record_info) in 
-  let record_default_functions = List.Old.concat (List.map ~f:(Cn_internal_to_ail.generate_record_default_function sigm.cn_datatypes) cn_record_info) in 
-  let record_map_get_functions = List.Old.concat (List.map ~f:(Cn_internal_to_ail.generate_record_map_get sigm.cn_datatypes) cn_record_info) in 
+  let cn_record_info = List.concat (cn_record_info @ cn_record_info') in 
+  let record_equality_functions = List.concat (List.map ~f:(Cn_internal_to_ail.generate_record_equality_function sigm.cn_datatypes) cn_record_info) in 
+  let record_default_functions = List.concat (List.map ~f:(Cn_internal_to_ail.generate_record_default_function sigm.cn_datatypes) cn_record_info) in 
+  let record_map_get_functions = List.concat (List.map ~f:(Cn_internal_to_ail.generate_record_map_get sigm.cn_datatypes) cn_record_info) in 
   let (eq_decls, eq_defs) = List.Old.split record_equality_functions in
   let (default_decls, default_defs) = List.Old.split record_default_functions in 
   let (mapget_decls, mapget_defs) = List.Old.split record_map_get_functions in 
@@ -254,7 +254,7 @@ let generate_c_record_funs (sigm : CF.GenTypes.genTypeCategory CF.AilSyntax.sigm
   let fun_strs = CF.Pp_utils.to_plain_pretty_string fun_doc in
   let decl_docs = List.map ~f:(fun (sym, (_, _, decl)) -> CF.Pp_ail.pp_function_prototype ~executable_spec:true sym decl) (eq_decls @ default_decls @ mapget_decls) in
   let fun_prot_strs = List.map ~f:(fun doc -> [CF.Pp_utils.to_plain_pretty_string doc]) decl_docs in
-  let fun_prot_strs = String.concat "\n" (List.Old.concat fun_prot_strs) in
+  let fun_prot_strs = String.concat "\n" (List.concat fun_prot_strs) in
   (fun_strs, fun_prot_strs)
 
 
@@ -277,7 +277,7 @@ let generate_c_functions_internal (sigm : CF.GenTypes.genTypeCategory CF.AilSynt
   (* let modified_prog_2 : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma = {sigm with declarations = decls; function_definitions = []} in *)
   (* let doc_2 = CF.Pp_ail.pp_program ~executable_spec:true ~show_include:true (None, modified_prog_2) in *)
   let ail_records = List.map ~f:(fun r -> match r with | Some record -> [record] | None -> []) ail_records_opt in
-  let record_triple_str = generate_record_strs sigm (List.Old.concat ail_records) in
+  let record_triple_str = generate_record_strs sigm (List.concat ail_records) in
   let funs_defs_str = CF.Pp_utils.to_plain_pretty_string doc_1 in
   (* let funs_decls_str = CF.Pp_utils.to_plain_pretty_string doc_2 in  *)
   (funs_defs_str, "\n/* CN FUNCTIONS */\n\n" ^ decl_str, locs_and_decls', record_triple_str)
@@ -303,7 +303,7 @@ let generate_c_predicates_internal (sigm : CF.GenTypes.genTypeCategory CF.AilSyn
   let pred_locs_and_decls = List.map ~f:(fun (loc, (sym, (_, _, decl))) ->
      (loc, [CF.Pp_utils.to_plain_pretty_string (CF.Pp_ail.pp_function_prototype ~executable_spec:true sym decl)])) (List.Old.combine locs decls) in
   let ail_records = List.map ~f:(fun r -> match r with | Some record -> [record] | None -> []) ail_records_opt in
-  let record_triple_str = generate_record_strs sigm (List.Old.concat ail_records) in
+  let record_triple_str = generate_record_strs sigm (List.concat ail_records) in
   ("\n/* CN PREDICATES */\n\n" ^ pred_defs_str, pred_locs_and_decls, record_triple_str)
 
 let generate_ownership_functions with_ownership_checking ownership_ctypes (sigm : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma)  =
@@ -333,8 +333,8 @@ let generate_conversion_and_equality_functions (sigm : CF.GenTypes.genTypeCatego
   let ail_funs'' = List.map ~f:Cn_internal_to_ail.generate_datatype_equality_function sigm.cn_datatypes in
   let ail_funs''' = List.map ~f:(Cn_internal_to_ail.generate_struct_map_get sigm.cn_datatypes) sigm.tag_definitions in
   let ail_funs'''' = List.map ~f:(Cn_internal_to_ail.generate_struct_default_function sigm.cn_datatypes) sigm.tag_definitions in
-  let ail_funs = List.Old.concat ail_funs in
-  let ail_funs = ail_funs @ List.Old.concat ail_funs' @ List.Old.concat ail_funs'' @ List.Old.concat ail_funs''' @ List.Old.concat ail_funs'''' in
+  let ail_funs = List.concat ail_funs in
+  let ail_funs = ail_funs @ List.concat ail_funs' @ List.concat ail_funs'' @ List.concat ail_funs''' @ List.concat ail_funs'''' in
   let (decls, defs) = List.Old.split ail_funs in
   let modified_prog1 : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma = {sigm with declarations = decls; function_definitions = defs} in
   let doc1 = CF.Pp_ail.pp_program ~executable_spec:true ~show_include:true (None, modified_prog1) in

--- a/backend/cn/executable_spec_internal.ml
+++ b/backend/cn/executable_spec_internal.ml
@@ -26,11 +26,11 @@ let generate_ail_stat_strs ?(with_newline=false) (bs, (ail_stats_ : CF.GenTypes.
   in
 
   let ail_stats_ = List.Old.filter (fun s -> not (is_assert_true s)) ail_stats_ in
-  let doc = List.Old.map (fun s -> CF.Pp_ail.pp_statement ~executable_spec:true ~bs (mk_stmt s)) ail_stats_ in
-  let doc = List.Old.map (fun d ->
+  let doc = List.map ~f:(fun s -> CF.Pp_ail.pp_statement ~executable_spec:true ~bs (mk_stmt s)) ail_stats_ in
+  let doc = List.map ~f:(fun d ->
     let newline = if with_newline then PPrint.hardline else PPrint.empty in
     newline ^^ d ^^ PPrint.hardline) doc in
-  List.Old.map CF.Pp_utils.to_plain_pretty_string doc
+  List.map ~f:CF.Pp_utils.to_plain_pretty_string doc
 
 
 let populate_record_map_aux (sym, bt_ret_type) =
@@ -43,9 +43,9 @@ let populate_record_map_aux (sym, bt_ret_type) =
 
 (* Populate record table with function and predicate record return types *)
 let populate_record_map (prog5: unit Mucore.mu_file) =
-  let fun_syms_and_ret_types = List.Old.map (fun (sym, (def : LogicalFunctions.definition)) -> (sym, def.return_bt)) prog5.mu_logical_predicates in
-  let pred_syms_and_ret_types = List.Old.map (fun (sym, (def : ResourcePredicates.definition)) -> (sym, def.oarg_bt)) prog5.mu_resource_predicates in
-  let _ = List.Old.map populate_record_map_aux (fun_syms_and_ret_types @ pred_syms_and_ret_types) in
+  let fun_syms_and_ret_types = List.map ~f:(fun (sym, (def : LogicalFunctions.definition)) -> (sym, def.return_bt)) prog5.mu_logical_predicates in
+  let pred_syms_and_ret_types = List.map ~f:(fun (sym, (def : ResourcePredicates.definition)) -> (sym, def.oarg_bt)) prog5.mu_resource_predicates in
+  let _ = List.map ~f:populate_record_map_aux (fun_syms_and_ret_types @ pred_syms_and_ret_types) in
   ()
 
 
@@ -92,13 +92,13 @@ let generate_c_pres_and_posts_internal with_ownership_checking (instrumentation 
   in
 
 
-  let in_stmt = List.Old.map (fun (loc, bs_and_ss) -> (modify_magic_comment_loc loc, generate_ail_stat_strs bs_and_ss)) ail_executable_spec.in_stmt in
+  let in_stmt = List.map ~f:(fun (loc, bs_and_ss) -> (modify_magic_comment_loc loc, generate_ail_stat_strs bs_and_ss)) ail_executable_spec.in_stmt in
   let return_injs = List.Old.filter_map (fun (loc, e_opt, bs, ss) -> match e_opt with | Some e_opt' -> Some (loc, e_opt', bs, ss) | None -> None ) block_ownership_injs in 
   let non_return_injs = List.Old.filter (fun (_, e_opt, _, _) -> Option.is_none e_opt) block_ownership_injs in 
-  let block_ownership_stmts = List.Old.map (fun (loc, _, bs, ss) -> (loc, generate_ail_stat_strs ~with_newline:true (bs, ss))) non_return_injs in 
-  let block_ownership_stmts = List.Old.map (fun (loc, strs) -> (loc, [String.concat "\n" strs])) block_ownership_stmts in 
-  let return_ownership_stmts = List.Old.map (fun (loc, e_opt, bs, ss) -> (loc, e_opt, generate_ail_stat_strs ~with_newline:true (bs, ss))) return_injs in 
-  let return_ownership_stmts = List.Old.map (fun (loc, e_opt, strs) -> (loc, e_opt, [String.concat "\n" strs])) return_ownership_stmts in 
+  let block_ownership_stmts = List.map ~f:(fun (loc, _, bs, ss) -> (loc, generate_ail_stat_strs ~with_newline:true (bs, ss))) non_return_injs in 
+  let block_ownership_stmts = List.map ~f:(fun (loc, strs) -> (loc, [String.concat "\n" strs])) block_ownership_stmts in 
+  let return_ownership_stmts = List.map ~f:(fun (loc, e_opt, bs, ss) -> (loc, e_opt, generate_ail_stat_strs ~with_newline:true (bs, ss))) return_injs in 
+  let return_ownership_stmts = List.map ~f:(fun (loc, e_opt, strs) -> (loc, e_opt, [String.concat "\n" strs])) return_ownership_stmts in 
   ([(instrumentation.fn, (pre_str, post_str))], in_stmt @ block_ownership_stmts, return_ownership_stmts)
 
 
@@ -112,7 +112,7 @@ let generate_c_specs_internal with_ownership_checking instrumentation_list type_
 let generate_c_spec (instrumentation : Core_to_mucore.instrumentation) =
   generate_c_pres_and_posts_internal with_ownership_checking instrumentation type_map sigm prog5
 in
-let specs = List.Old.map generate_c_spec instrumentation_list in
+let specs = List.map ~f:generate_c_spec instrumentation_list in
 let (pre_post, in_stmt, returns) = Executable_spec_utils.list_split_three specs in
 let executable_spec = {pre_post = List.Old.concat pre_post; in_stmt = List.Old.concat in_stmt; returns = List.Old.concat returns} in
 executable_spec
@@ -130,26 +130,26 @@ let generate_struct_decl_str (tag, (_, _, def)) = match def with
     
     
 let generate_c_records ail_structs =
-  let struct_docs = List.Old.map generate_doc_from_ail_struct ail_structs in
-  (CF.Pp_utils.to_plain_pretty_string (PPrint.concat struct_docs), (String.concat "" (List.Old.map generate_struct_decl_str ail_structs)))
+  let struct_docs = List.map ~f:generate_doc_from_ail_struct ail_structs in
+  (CF.Pp_utils.to_plain_pretty_string (PPrint.concat struct_docs), (String.concat "" (List.map ~f:generate_struct_decl_str ail_structs)))
 
 let generate_record_strs (_sigm : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma) ail_records =
   let (record_def_strs, record_decl_strs) = generate_c_records ail_records in
   (record_def_strs, record_decl_strs)
 
-  (* let ail_record_equality_functions = List.Old.map (fun r -> Cn_internal_to_ail.generate_struct_equality_function ~is_record:true sigm.cn_datatypes r) ail_records in
+  (* let ail_record_equality_functions = List.map ~f:(fun r -> Cn_internal_to_ail.generate_struct_equality_function ~is_record:true sigm.cn_datatypes r) ail_records in
   let ail_record_equality_functions = List.Old.concat ail_record_equality_functions in
-  let ail_record_default_functions = List.Old.map (fun r -> Cn_internal_to_ail.generate_struct_default_function ~is_record:true sigm.cn_datatypes r) ail_records in
+  let ail_record_default_functions = List.map ~f:(fun r -> Cn_internal_to_ail.generate_struct_default_function ~is_record:true sigm.cn_datatypes r) ail_records in
   let ail_record_default_functions = List.Old.concat ail_record_default_functions in 
-  let ail_record_mapget_functions = List.Old.map (fun r -> Cn_internal_to_ail.generate_struct_map_get ~is_record:true sigm.cn_datatypes r) ail_records in
+  let ail_record_mapget_functions = List.map ~f:(fun r -> Cn_internal_to_ail.generate_struct_map_get ~is_record:true sigm.cn_datatypes r) ail_records in
   let ail_record_mapget_functions = List.Old.concat ail_record_mapget_functions in  *)
   (* let (eq_decls, eq_defs) = List.Old.split ail_record_equality_functions in
   let (default_decls, default_defs) = List.Old.split ail_record_default_functions in 
   let (mapget_decls, mapget_defs) = List.Old.split ail_record_mapget_functions in  *)
   (* let modified_prog1 : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma = {sigm with declarations = eq_decls @ default_decls @ mapget_decls; function_definitions = eq_defs @ default_defs @ mapget_defs} in
   let equality_fun_strs = CF.Pp_ail.pp_program ~executable_spec:true ~show_include:true (None, modified_prog1) in
-  let decl_docs = List.Old.map (fun (sym, (_, _, decl)) -> CF.Pp_ail.pp_function_prototype ~executable_spec:true sym decl) eq_decls in
-  let equality_fun_prot_strs = List.Old.map (fun doc -> [CF.Pp_utils.to_plain_pretty_string doc]) decl_docs in
+  let decl_docs = List.map ~f:(fun (sym, (_, _, decl)) -> CF.Pp_ail.pp_function_prototype ~executable_spec:true sym decl) eq_decls in
+  let equality_fun_prot_strs = List.map ~f:(fun doc -> [CF.Pp_utils.to_plain_pretty_string doc]) decl_docs in
   let equality_fun_prot_strs = String.concat "\n" (List.Old.concat equality_fun_prot_strs) in *)
   (* (record_def_strs, record_decl_strs, CF.Pp_utils.to_plain_pretty_string equality_fun_strs, equality_fun_prot_strs) *)
 
@@ -160,7 +160,7 @@ let generate_str_from_ail_struct ail_struct =
   CF.Pp_utils.to_plain_pretty_string (generate_doc_from_ail_struct ail_struct)
 
 let generate_str_from_ail_structs ail_structs =
-  let docs = List.Old.map generate_doc_from_ail_struct ail_structs in
+  let docs = List.map ~f:generate_doc_from_ail_struct ail_structs in
   CF.Pp_utils.to_plain_pretty_string (concat_map_newline docs)
 
 (* TODO: Use Mucore datatypes instead of CN datatypes from Ail program *)
@@ -169,34 +169,34 @@ let generate_c_datatypes (sigm : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma)
     | [] -> []
     | (d :: ds) ->
         let ail_dt1 = Cn_internal_to_ail.cn_to_ail_datatype ~first:true d in
-        let ail_dts = List.Old.map Cn_internal_to_ail.cn_to_ail_datatype ds in
+        let ail_dts = List.map ~f:Cn_internal_to_ail.cn_to_ail_datatype ds in
         ail_dt1 :: ail_dts
       in
 
-  let ail_datatype_decls = List.Old.map generate_struct_decl_str (List.Old.concat (List.Old.map snd ail_datatypes)) in 
-  let locs_and_structs = List.Old.map (fun (loc, structs) -> (loc, List.Old.map generate_doc_from_ail_struct structs)) ail_datatypes in
-  let locs_and_struct_strs = List.Old.map (fun (loc, ail_structs) -> (loc, CF.Pp_utils.to_plain_pretty_string (concat_map_newline ail_structs))) locs_and_structs in
-  (* let structs = List.Old.map generate_doc_from_ail_struct ail_datatypes in *)
+  let ail_datatype_decls = List.map ~f:generate_struct_decl_str (List.Old.concat (List.map ~f:snd ail_datatypes)) in 
+  let locs_and_structs = List.map ~f:(fun (loc, structs) -> (loc, List.map ~f:generate_doc_from_ail_struct structs)) ail_datatypes in
+  let locs_and_struct_strs = List.map ~f:(fun (loc, ail_structs) -> (loc, CF.Pp_utils.to_plain_pretty_string (concat_map_newline ail_structs))) locs_and_structs in
+  (* let structs = List.map ~f:generate_doc_from_ail_struct ail_datatypes in *)
   (* CF.Pp_utils.to_plain_pretty_string (concat_map_newline structs) *)
-  (* let _ = List.Old.map (fun (loc, _) -> Printf.printf "Datatype location: %s\n" (Cerb_location.simple_location loc)) locs_and_struct_strs in *)
+  (* let _ = List.map ~f:(fun (loc, _) -> Printf.printf "Datatype location: %s\n" (Cerb_location.simple_location loc)) locs_and_struct_strs in *)
 
   (* Need to generate function prototype for corresponding equality function *)
-  let datatype_equality_funs = List.Old.map Cn_internal_to_ail.generate_datatype_equality_function sigm.cn_datatypes in
+  let datatype_equality_funs = List.map ~f:Cn_internal_to_ail.generate_datatype_equality_function sigm.cn_datatypes in
   let datatype_equality_funs = List.Old.concat datatype_equality_funs in
   let (dt_eq_decls, _) = List.Old.split datatype_equality_funs in
-  let decl_docs = List.Old.map (fun (sym, (_, _, decl)) -> CF.Pp_ail.pp_function_prototype ~executable_spec:true sym decl) dt_eq_decls in
-  let decl_strs = List.Old.map (fun doc -> CF.Pp_utils.to_plain_pretty_string doc) decl_docs in
+  let decl_docs = List.map ~f:(fun (sym, (_, _, decl)) -> CF.Pp_ail.pp_function_prototype ~executable_spec:true sym decl) dt_eq_decls in
+  let decl_strs = List.map ~f:(fun doc -> CF.Pp_utils.to_plain_pretty_string doc) decl_docs in
   (locs_and_struct_strs, String.concat "\n" ail_datatype_decls, decl_strs)
 
 
 let print_c_structs c_structs =
   let struct_defs_str = generate_str_from_ail_structs c_structs in 
-  let struct_decls_str = List.Old.map generate_struct_decl_str c_structs in 
+  let struct_decls_str = List.map ~f:generate_struct_decl_str c_structs in 
   ("\n/* ORIGINAL C STRUCTS */\n\n" ^ struct_defs_str, String.concat "" struct_decls_str)
 
 let generate_cn_versions_of_structs c_structs =
-  let ail_structs = List.Old.concat (List.Old.map Cn_internal_to_ail.cn_to_ail_struct c_structs) in
-  let struct_decls = List.Old.map generate_struct_decl_str ail_structs in
+  let ail_structs = List.Old.concat (List.map ~f:Cn_internal_to_ail.cn_to_ail_struct c_structs) in
+  let struct_decls = List.map ~f:generate_struct_decl_str ail_structs in
   ("\n/* CN VERSIONS OF C STRUCTS */\n\n" ^ generate_str_from_ail_structs ail_structs, String.concat "" struct_decls)
 
 let generate_struct_injs (sigm: CF.GenTypes.genTypeCategory CF.AilSyntax.sigma)  =
@@ -211,8 +211,8 @@ let generate_struct_injs (sigm: CF.GenTypes.genTypeCategory CF.AilSyntax.sigma) 
         | (((sym1, (loc1, attrs1, conversion_decl)), _) :: _, ((sym2, (loc2, attrs2, equality_decl)), _) :: _) ->
           let conversion_def = (sym1, (loc1, attrs1, conversion_decl)) in
           let equality_def = (sym2, (loc2, attrs2, equality_decl)) in
-          let decl_docs = List.Old.map (fun (sym, (_, _, decl)) -> CF.Pp_ail.pp_function_prototype ~executable_spec:true sym decl) [conversion_def; equality_def] in
-          let decl_strs = List.Old.map (fun doc -> CF.Pp_utils.to_plain_pretty_string doc) decl_docs in
+          let decl_docs = List.map ~f:(fun (sym, (_, _, decl)) -> CF.Pp_ail.pp_function_prototype ~executable_spec:true sym decl) [conversion_def; equality_def] in
+          let decl_strs = List.map ~f:(fun doc -> CF.Pp_utils.to_plain_pretty_string doc) decl_docs in
           String.concat "\n" decl_strs
         | (_, _) -> ""
       in
@@ -221,7 +221,7 @@ let generate_struct_injs (sigm: CF.GenTypes.genTypeCategory CF.AilSyntax.sigma) 
       [(loc, str_list)]
     | C.UnionDef _ -> []
   in
-  let struct_injs = List.Old.map generate_struct_inj sigm.tag_definitions in
+  let struct_injs = List.map ~f:generate_struct_inj sigm.tag_definitions in
   List.Old.concat struct_injs
 
 
@@ -232,51 +232,51 @@ let bt_is_record_or_tuple = function
 
 let fns_and_preds_with_record_rt (funs, preds) =
   let funs' = List.Old.filter (fun (_, (def : LogicalFunctions.definition)) -> bt_is_record_or_tuple def.return_bt) funs in
-  let fun_syms = List.Old.map (fun (fn_sym, _) -> fn_sym) funs' in
+  let fun_syms = List.map ~f:(fun (fn_sym, _) -> fn_sym) funs' in
   let preds' = List.Old.filter (fun (_, (def : ResourcePredicates.definition)) -> bt_is_record_or_tuple def.oarg_bt) preds in
-  let pred_syms = List.Old.map (fun (pred_sym, _) -> pred_sym) preds' in
+  let pred_syms = List.map ~f:(fun (pred_sym, _) -> pred_sym) preds' in
   (fun_syms, pred_syms)
 
 let generate_c_record_funs (sigm : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma) (logical_predicates : Mucore.T.logical_predicates) (resource_predicates : Mucore.T.resource_predicates) =
-  let cn_record_info = List.Old.map (fun (sym, (def : LogicalFunctions.definition)) ->
+  let cn_record_info = List.map ~f:(fun (sym, (def : LogicalFunctions.definition)) ->
     match def.return_bt with | BT.Record ms -> [(Cn_internal_to_ail.generate_sym_with_suffix ~suffix:"_record" sym, ms)] | _ -> []) logical_predicates in 
-  let cn_record_info' = List.Old.map (fun (sym, (def : ResourcePredicates.definition)) ->
+  let cn_record_info' = List.map ~f:(fun (sym, (def : ResourcePredicates.definition)) ->
     match def.oarg_bt with | BT.Record ms -> [(Cn_internal_to_ail.generate_sym_with_suffix ~suffix:"_record" sym, ms)] | _ -> []) resource_predicates in 
   let cn_record_info = List.Old.concat (cn_record_info @ cn_record_info') in 
-  let record_equality_functions = List.Old.concat (List.Old.map (Cn_internal_to_ail.generate_record_equality_function sigm.cn_datatypes) cn_record_info) in 
-  let record_default_functions = List.Old.concat (List.Old.map (Cn_internal_to_ail.generate_record_default_function sigm.cn_datatypes) cn_record_info) in 
-  let record_map_get_functions = List.Old.concat (List.Old.map (Cn_internal_to_ail.generate_record_map_get sigm.cn_datatypes) cn_record_info) in 
+  let record_equality_functions = List.Old.concat (List.map ~f:(Cn_internal_to_ail.generate_record_equality_function sigm.cn_datatypes) cn_record_info) in 
+  let record_default_functions = List.Old.concat (List.map ~f:(Cn_internal_to_ail.generate_record_default_function sigm.cn_datatypes) cn_record_info) in 
+  let record_map_get_functions = List.Old.concat (List.map ~f:(Cn_internal_to_ail.generate_record_map_get sigm.cn_datatypes) cn_record_info) in 
   let (eq_decls, eq_defs) = List.Old.split record_equality_functions in
   let (default_decls, default_defs) = List.Old.split record_default_functions in 
   let (mapget_decls, mapget_defs) = List.Old.split record_map_get_functions in 
   let modified_prog1 : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma = {sigm with declarations = eq_decls @ default_decls @ mapget_decls; function_definitions = eq_defs @ default_defs @ mapget_defs} in
   let fun_doc = CF.Pp_ail.pp_program ~executable_spec:true ~show_include:true (None, modified_prog1) in
   let fun_strs = CF.Pp_utils.to_plain_pretty_string fun_doc in
-  let decl_docs = List.Old.map (fun (sym, (_, _, decl)) -> CF.Pp_ail.pp_function_prototype ~executable_spec:true sym decl) (eq_decls @ default_decls @ mapget_decls) in
-  let fun_prot_strs = List.Old.map (fun doc -> [CF.Pp_utils.to_plain_pretty_string doc]) decl_docs in
+  let decl_docs = List.map ~f:(fun (sym, (_, _, decl)) -> CF.Pp_ail.pp_function_prototype ~executable_spec:true sym decl) (eq_decls @ default_decls @ mapget_decls) in
+  let fun_prot_strs = List.map ~f:(fun doc -> [CF.Pp_utils.to_plain_pretty_string doc]) decl_docs in
   let fun_prot_strs = String.concat "\n" (List.Old.concat fun_prot_strs) in
   (fun_strs, fun_prot_strs)
 
 
 let generate_c_functions_internal (sigm : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma) (logical_predicates : Mucore.T.logical_predicates)  =
-  let ail_funs_and_records = List.Old.map (fun cn_f -> Cn_internal_to_ail.cn_to_ail_function_internal cn_f sigm.cn_datatypes sigm.cn_functions) logical_predicates in
+  let ail_funs_and_records = List.map ~f:(fun cn_f -> Cn_internal_to_ail.cn_to_ail_function_internal cn_f sigm.cn_datatypes sigm.cn_functions) logical_predicates in
 
   let (ail_funs, ail_records_opt) = List.Old.split ail_funs_and_records in
   let (locs_and_decls, defs) = List.Old.split ail_funs in
   let (locs, decls) = List.Old.split locs_and_decls in
-  let decl_docs = List.Old.map (fun (sym, (_, _, decl)) -> CF.Pp_ail.pp_function_prototype ~executable_spec:true sym decl) decls in
-  let decl_strs = List.Old.map (fun doc -> CF.Pp_utils.to_plain_pretty_string doc) decl_docs in
+  let decl_docs = List.map ~f:(fun (sym, (_, _, decl)) -> CF.Pp_ail.pp_function_prototype ~executable_spec:true sym decl) decls in
+  let decl_strs = List.map ~f:(fun doc -> CF.Pp_utils.to_plain_pretty_string doc) decl_docs in
   let decl_str = String.concat "\n" decl_strs in
 
   let defs = List.Old.filter_map (fun x -> x) defs in
   let modified_prog_1 : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma = {sigm with declarations = decls; function_definitions = defs} in
   let doc_1 = CF.Pp_ail.pp_program ~executable_spec:true ~show_include:true (None, modified_prog_1) in
-  let inline_decl_docs = List.Old.map (fun (sym, (_, _, decl)) -> CF.Pp_ail.pp_function_prototype ~executable_spec:true sym decl) decls in
-  let inline_decl_strs = List.Old.map (fun doc -> [CF.Pp_utils.to_plain_pretty_string doc]) inline_decl_docs in
+  let inline_decl_docs = List.map ~f:(fun (sym, (_, _, decl)) -> CF.Pp_ail.pp_function_prototype ~executable_spec:true sym decl) decls in
+  let inline_decl_strs = List.map ~f:(fun doc -> [CF.Pp_utils.to_plain_pretty_string doc]) inline_decl_docs in
   let locs_and_decls' = List.Old.combine locs inline_decl_strs in
   (* let modified_prog_2 : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma = {sigm with declarations = decls; function_definitions = []} in *)
   (* let doc_2 = CF.Pp_ail.pp_program ~executable_spec:true ~show_include:true (None, modified_prog_2) in *)
-  let ail_records = List.Old.map (fun r -> match r with | Some record -> [record] | None -> []) ail_records_opt in
+  let ail_records = List.map ~f:(fun r -> match r with | Some record -> [record] | None -> []) ail_records_opt in
   let record_triple_str = generate_record_strs sigm (List.Old.concat ail_records) in
   let funs_defs_str = CF.Pp_utils.to_plain_pretty_string doc_1 in
   (* let funs_decls_str = CF.Pp_utils.to_plain_pretty_string doc_2 in  *)
@@ -291,7 +291,7 @@ let rec remove_duplicates eq_fun = function
       t :: (remove_duplicates eq_fun ts)
 
 let generate_c_predicates_internal (sigm : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma) (resource_predicates : Mucore.T.resource_predicates) =
-  (* let ail_info = List.Old.map (fun cn_f -> Cn_internal_to_ail.cn_to_ail_predicate_internal cn_f sigm.cn_datatypes [] ownership_ctypes resource_predicates) resource_predicates in *)
+  (* let ail_info = List.map ~f:(fun cn_f -> Cn_internal_to_ail.cn_to_ail_predicate_internal cn_f sigm.cn_datatypes [] ownership_ctypes resource_predicates) resource_predicates in *)
   (* TODO: Remove passing of resource_predicates argument twice - could use counter? *)
   let (ail_funs, ail_records_opt) = Cn_internal_to_ail.cn_to_ail_predicates_internal resource_predicates sigm.cn_datatypes [] resource_predicates sigm.cn_predicates in
   let (locs_and_decls, defs) = List.Old.split ail_funs in
@@ -300,14 +300,14 @@ let generate_c_predicates_internal (sigm : CF.GenTypes.genTypeCategory CF.AilSyn
   let doc1 = CF.Pp_ail.pp_program ~executable_spec:true ~show_include:true (None, modified_prog1) in
   let pred_defs_str =
   CF.Pp_utils.to_plain_pretty_string doc1 in
-  let pred_locs_and_decls = List.Old.map (fun (loc, (sym, (_, _, decl))) ->
+  let pred_locs_and_decls = List.map ~f:(fun (loc, (sym, (_, _, decl))) ->
      (loc, [CF.Pp_utils.to_plain_pretty_string (CF.Pp_ail.pp_function_prototype ~executable_spec:true sym decl)])) (List.Old.combine locs decls) in
-  let ail_records = List.Old.map (fun r -> match r with | Some record -> [record] | None -> []) ail_records_opt in
+  let ail_records = List.map ~f:(fun r -> match r with | Some record -> [record] | None -> []) ail_records_opt in
   let record_triple_str = generate_record_strs sigm (List.Old.concat ail_records) in
   ("\n/* CN PREDICATES */\n\n" ^ pred_defs_str, pred_locs_and_decls, record_triple_str)
 
 let generate_ownership_functions with_ownership_checking ownership_ctypes (sigm : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma)  =
-  (* let ctypes = List.Old.map get_ctype_without_ptr ctypes in  *)
+  (* let ctypes = List.map ~f:get_ctype_without_ptr ctypes in  *)
   let rec remove_duplicates ret_list = function 
     | [] -> []
     | x :: xs ->
@@ -318,7 +318,7 @@ let generate_ownership_functions with_ownership_checking ownership_ctypes (sigm 
   in 
   let ctypes = !ownership_ctypes in 
   let ctypes = remove_duplicates [] ctypes in 
-  let ail_funs = List.Old.map (fun ctype -> Cn_internal_to_ail.generate_ownership_function with_ownership_checking ctype) ctypes in
+  let ail_funs = List.map ~f:(fun ctype -> Cn_internal_to_ail.generate_ownership_function with_ownership_checking ctype) ctypes in
   let (decls, defs) = List.Old.split ail_funs in
   let modified_prog1 : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma = {sigm with declarations = decls; function_definitions = defs} in
   let doc1 = CF.Pp_ail.pp_program ~executable_spec:true ~show_include:true (None, modified_prog1) in
@@ -328,11 +328,11 @@ let generate_ownership_functions with_ownership_checking ownership_ctypes (sigm 
   (comment ^ CF.Pp_utils.to_plain_pretty_string doc1, CF.Pp_utils.to_plain_pretty_string doc2)
 
 let generate_conversion_and_equality_functions (sigm : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma) =
-  let ail_funs = List.Old.map Cn_internal_to_ail.generate_struct_conversion_function sigm.tag_definitions in
-  let ail_funs' = List.Old.map (Cn_internal_to_ail.generate_struct_equality_function sigm.cn_datatypes) sigm.tag_definitions in
-  let ail_funs'' = List.Old.map Cn_internal_to_ail.generate_datatype_equality_function sigm.cn_datatypes in
-  let ail_funs''' = List.Old.map (Cn_internal_to_ail.generate_struct_map_get sigm.cn_datatypes) sigm.tag_definitions in
-  let ail_funs'''' = List.Old.map (Cn_internal_to_ail.generate_struct_default_function sigm.cn_datatypes) sigm.tag_definitions in
+  let ail_funs = List.map ~f:Cn_internal_to_ail.generate_struct_conversion_function sigm.tag_definitions in
+  let ail_funs' = List.map ~f:(Cn_internal_to_ail.generate_struct_equality_function sigm.cn_datatypes) sigm.tag_definitions in
+  let ail_funs'' = List.map ~f:Cn_internal_to_ail.generate_datatype_equality_function sigm.cn_datatypes in
+  let ail_funs''' = List.map ~f:(Cn_internal_to_ail.generate_struct_map_get sigm.cn_datatypes) sigm.tag_definitions in
+  let ail_funs'''' = List.map ~f:(Cn_internal_to_ail.generate_struct_default_function sigm.cn_datatypes) sigm.tag_definitions in
   let ail_funs = List.Old.concat ail_funs in
   let ail_funs = ail_funs @ List.Old.concat ail_funs' @ List.Old.concat ail_funs'' @ List.Old.concat ail_funs''' @ List.Old.concat ail_funs'''' in
   let (decls, defs) = List.Old.split ail_funs in
@@ -350,10 +350,10 @@ let generate_ownership_global_assignments (sigm : CF.GenTypes.genTypeCategory CF
     | [] -> failwith "CN-exec: No main function so ownership globals cannot be initialised"
     | (main_sym, _) :: _ ->
       let globals = extract_global_variables prog5.mu_globs in 
-      let global_map_fcalls = List.Old.map Ownership_exec.generate_c_local_ownership_entry_fcall globals in 
-      let global_map_stmts_ = List.Old.map (fun e -> A.AilSexpr e) global_map_fcalls in 
+      let global_map_fcalls = List.map ~f:Ownership_exec.generate_c_local_ownership_entry_fcall globals in 
+      let global_map_stmts_ = List.map ~f:(fun e -> A.AilSexpr e) global_map_fcalls in 
       let assignments = Ownership_exec.get_ownership_global_init_stats () in
       let init_and_global_mapping_str = generate_ail_stat_strs ([], assignments @ global_map_stmts_) in
-      let global_unmapping_stmts_ = List.Old.map Ownership_exec.generate_c_local_ownership_exit globals in 
+      let global_unmapping_stmts_ = List.map ~f:Ownership_exec.generate_c_local_ownership_exit globals in 
       let global_unmapping_str = generate_ail_stat_strs ([], global_unmapping_stmts_) in
       [(main_sym, (init_and_global_mapping_str, global_unmapping_str))]

--- a/backend/cn/executable_spec_internal.ml
+++ b/backend/cn/executable_spec_internal.ml
@@ -25,7 +25,7 @@ let generate_ail_stat_strs ?(with_newline=false) (bs, (ail_stats_ : CF.GenTypes.
     | _ -> false
   in
 
-  let ail_stats_ = List.Old.filter (fun s -> not (is_assert_true s)) ail_stats_ in
+  let ail_stats_ = List.filter ~f:(fun s -> not (is_assert_true s)) ail_stats_ in
   let doc = List.map ~f:(fun s -> CF.Pp_ail.pp_statement ~executable_spec:true ~bs (mk_stmt s)) ail_stats_ in
   let doc = List.map ~f:(fun d ->
     let newline = if with_newline then PPrint.hardline else PPrint.empty in
@@ -94,7 +94,7 @@ let generate_c_pres_and_posts_internal with_ownership_checking (instrumentation 
 
   let in_stmt = List.map ~f:(fun (loc, bs_and_ss) -> (modify_magic_comment_loc loc, generate_ail_stat_strs bs_and_ss)) ail_executable_spec.in_stmt in
   let return_injs = List.filter_map ~f:(fun (loc, e_opt, bs, ss) -> match e_opt with | Some e_opt' -> Some (loc, e_opt', bs, ss) | None -> None ) block_ownership_injs in 
-  let non_return_injs = List.Old.filter (fun (_, e_opt, _, _) -> Option.is_none e_opt) block_ownership_injs in 
+  let non_return_injs = List.filter ~f:(fun (_, e_opt, _, _) -> Option.is_none e_opt) block_ownership_injs in 
   let block_ownership_stmts = List.map ~f:(fun (loc, _, bs, ss) -> (loc, generate_ail_stat_strs ~with_newline:true (bs, ss))) non_return_injs in 
   let block_ownership_stmts = List.map ~f:(fun (loc, strs) -> (loc, [String.concat "\n" strs])) block_ownership_stmts in 
   let return_ownership_stmts = List.map ~f:(fun (loc, e_opt, bs, ss) -> (loc, e_opt, generate_ail_stat_strs ~with_newline:true (bs, ss))) return_injs in 
@@ -231,9 +231,9 @@ let bt_is_record_or_tuple = function
   | _ -> false
 
 let fns_and_preds_with_record_rt (funs, preds) =
-  let funs' = List.Old.filter (fun (_, (def : LogicalFunctions.definition)) -> bt_is_record_or_tuple def.return_bt) funs in
+  let funs' = List.filter ~f:(fun (_, (def : LogicalFunctions.definition)) -> bt_is_record_or_tuple def.return_bt) funs in
   let fun_syms = List.map ~f:(fun (fn_sym, _) -> fn_sym) funs' in
-  let preds' = List.Old.filter (fun (_, (def : ResourcePredicates.definition)) -> bt_is_record_or_tuple def.oarg_bt) preds in
+  let preds' = List.filter ~f:(fun (_, (def : ResourcePredicates.definition)) -> bt_is_record_or_tuple def.oarg_bt) preds in
   let pred_syms = List.map ~f:(fun (pred_sym, _) -> pred_sym) preds' in
   (fun_syms, pred_syms)
 
@@ -345,7 +345,7 @@ let generate_conversion_and_equality_functions (sigm : CF.GenTypes.genTypeCatego
 
 
 let generate_ownership_global_assignments (sigm : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma) (prog5: unit Mucore.mu_file) = 
-  let main_fn_sym_list = List.Old.filter (fun (fn_sym, _) -> String.equal "main" (Sym.pp_string fn_sym)) sigm.function_definitions in 
+  let main_fn_sym_list = List.filter ~f:(fun (fn_sym, _) -> String.equal "main" (Sym.pp_string fn_sym)) sigm.function_definitions in 
   match main_fn_sym_list with 
     | [] -> failwith "CN-exec: No main function so ownership globals cannot be initialised"
     | (main_sym, _) :: _ ->

--- a/backend/cn/executable_spec_utils.ml
+++ b/backend/cn/executable_spec_utils.ml
@@ -130,9 +130,9 @@ let rec execCtypeEqual (C.Ctype (_, ty1)) (C.Ctype (_, ty2)) =
       execCtypeEqual ty1 ty2 && n1_opt == n2_opt
     | (Function ((qs1, ty1), params1, b1),
         Function ((qs2, ty2), params2, b2)) ->
-        let bools = List.map paramsEqual (List.combine params1 params2) in 
+        let bools = List.Old.map paramsEqual (List.Old.combine params1 params2) in 
         C.qualifiersEqual qs1 qs2 && execCtypeEqual ty1 ty2 &&
-        List.fold_left (&&) true bools && b1 == b2
+        List.Old.fold_left (&&) true bools && b1 == b2
     | (FunctionNoParams (qs1, ty1),
         FunctionNoParams (qs2, ty2)) ->
         C.qualifiersEqual qs1 qs2 && execCtypeEqual ty1 ty2
@@ -157,7 +157,7 @@ let create_binding sym ctype =
     A.(sym, ((Cerb_location.unknown, Automatic, false), None, empty_qualifiers, ctype))
 
 let find_ctype_from_bindings bindings sym = 
-  let (_, (_, _, _, ctype)) = List.find (fun (sym', _) -> Sym.equal sym sym') bindings in 
+  let (_, (_, _, _, ctype)) = List.Old.find (fun (sym', _) -> Sym.equal sym sym') bindings in 
   ctype
 
 (* Decl_object  of (storageDuration * bool) * maybe alignment * qualifiers * ctype*)

--- a/backend/cn/executable_spec_utils.ml
+++ b/backend/cn/executable_spec_utils.ml
@@ -130,7 +130,7 @@ let rec execCtypeEqual (C.Ctype (_, ty1)) (C.Ctype (_, ty2)) =
       execCtypeEqual ty1 ty2 && n1_opt == n2_opt
     | (Function ((qs1, ty1), params1, b1),
         Function ((qs2, ty2), params2, b2)) ->
-        let bools = List.map ~f:paramsEqual (List.Old.combine params1 params2) in 
+        let bools = List.map ~f:paramsEqual (List.zip_exn params1 params2) in 
         C.qualifiersEqual qs1 qs2 && execCtypeEqual ty1 ty2 &&
         List.Old.fold_left (&&) true bools && b1 == b2
     | (FunctionNoParams (qs1, ty1),

--- a/backend/cn/executable_spec_utils.ml
+++ b/backend/cn/executable_spec_utils.ml
@@ -130,7 +130,7 @@ let rec execCtypeEqual (C.Ctype (_, ty1)) (C.Ctype (_, ty2)) =
       execCtypeEqual ty1 ty2 && n1_opt == n2_opt
     | (Function ((qs1, ty1), params1, b1),
         Function ((qs2, ty2), params2, b2)) ->
-        let bools = List.Old.map paramsEqual (List.Old.combine params1 params2) in 
+        let bools = List.map ~f:paramsEqual (List.Old.combine params1 params2) in 
         C.qualifiersEqual qs1 qs2 && execCtypeEqual ty1 ty2 &&
         List.Old.fold_left (&&) true bools && b1 == b2
     | (FunctionNoParams (qs1, ty1),

--- a/backend/cn/explain.ml
+++ b/backend/cn/explain.ml
@@ -55,13 +55,13 @@ let relevant_predicate_clauses global name req =
   let open ResourcePredicates in
   let clauses =
     let defs = SymMap.bindings global.resource_predicates in
-    List.concat_map (fun (nm, def) ->
+    List.Old.concat_map (fun (nm, def) ->
         match def.clauses with
-        | Some clauses -> List.map (fun c -> (nm, c)) clauses
+        | Some clauses -> List.Old.map (fun c -> (nm, c)) clauses
         | None -> []
       ) defs
   in
-  List.filter (fun (nm, c) -> 
+  List.Old.filter (fun (nm, c) -> 
       Sym.equal nm name
       || clause_has_resource req c
     ) clauses
@@ -88,9 +88,9 @@ end
 
 let subterms_without_bound_variables bindings = 
   fold_subterms ~bindings (fun bindings acc t ->
-      let pats = List.map fst bindings in
-      let bound = List.concat_map bound_by_pattern pats in
-      let bound = SymSet.of_list (List.map fst bound) in
+      let pats = List.Old.map fst bindings in
+      let bound = List.Old.concat_map bound_by_pattern pats in
+      let bound = SymSet.of_list (List.Old.map fst bound) in
       if SymSet.(is_empty (inter bound (IT.free_vars t))) 
       then ITSet.add t acc
       else acc
@@ -141,9 +141,9 @@ let state ctxt model_with_q extras =
         | BaseType ls -> Some (make s ls)
       in
       ITSet.of_list
-          (List.map (fun (s, ls) -> make s ls) quantifier_counter_model
-           @ List.filter_map basetype_binding (SymMap.bindings ctxt.computational)
-           @ List.filter_map basetype_binding (SymMap.bindings ctxt.logical))
+          (List.Old.map (fun (s, ls) -> make s ls) quantifier_counter_model
+           @ List.Old.filter_map basetype_binding (SymMap.bindings ctxt.computational)
+           @ List.Old.filter_map basetype_binding (SymMap.bindings ctxt.logical))
     in
 
     let unproven = match extras.unproven_constraint with
@@ -172,13 +172,13 @@ let state ctxt model_with_q extras =
     in
 
     let subterms = 
-      List.fold_left ITSet.union ITSet.empty 
+      List.Old.fold_left ITSet.union ITSet.empty 
         [variables; unproven; request] 
     in
 
 
     let filtered = 
-      List.filter_map (fun it -> 
+      List.Old.filter_map (fun it -> 
           match evaluate it with
           | Some value when not (IT.equal value it) ->
              Some (it, {term = IT.pp it; value = IT.pp value})
@@ -190,7 +190,7 @@ let state ctxt model_with_q extras =
     in
 
     let interesting, uninteresting = 
-      List.partition (fun (it, _entry) ->
+      List.Old.partition (fun (it, _entry) ->
           match IT.bt it with
           | BT.Unit -> false
           | BT.Loc -> false
@@ -198,14 +198,14 @@ let state ctxt model_with_q extras =
         ) filtered
     in
 
-    (List.map snd interesting, 
-     List.map snd uninteresting)
+    (List.Old.map snd interesting, 
+     List.Old.map snd uninteresting)
 
   in
 
   let constraints =
     let interesting, uninteresting = 
-      List.partition (fun lc ->
+      List.Old.partition (fun lc ->
           match lc with
           (* | LC.T (IT (Aligned _, _, _)) -> false *)
           | LC.T (IT (Representable _, _, _)) -> false
@@ -213,17 +213,17 @@ let state ctxt model_with_q extras =
           | _ -> true
         ) (LCSet.elements ctxt.constraints)
     in
-    (List.map LC.pp interesting, 
-     List.map LC.pp uninteresting)
+    (List.Old.map LC.pp interesting, 
+     List.Old.map LC.pp uninteresting)
   in
 
   let resources =
     let (same_res, diff_res) = match extras.request with
       | None -> ([], get_rs ctxt)
-      | Some req -> List.partition (fun r -> RET.same_predicate_name req (RE.request r)) (get_rs ctxt)
+      | Some req -> List.Old.partition (fun r -> RET.same_predicate_name req (RE.request r)) (get_rs ctxt)
     in
     let interesting_diff_res, uninteresting_diff_res = 
-      List.partition (fun (ret, _o) ->
+      List.Old.partition (fun (ret, _o) ->
           match ret with
           | P ret when equal_predicate_name ret.name ResourceTypes.alloc_name -> false
           | _ -> true
@@ -231,11 +231,11 @@ let state ctxt model_with_q extras =
     in
 
     let interesting = 
-      List.map (fun re -> RE.pp re ^^^ parens !^"same type") same_res 
-      @ List.map RE.pp interesting_diff_res
+      List.Old.map (fun re -> RE.pp re ^^^ parens !^"same type") same_res 
+      @ List.Old.map RE.pp interesting_diff_res
     in
     let uninteresting = 
-      List.map RE.pp uninteresting_diff_res
+      List.Old.map RE.pp uninteresting_diff_res
     in
     (interesting, uninteresting)
   in
@@ -271,7 +271,7 @@ let trace (ctxt,log) (model_with_q : Solver.model_with_q) (extras : state_extras
 
   let trace = 
     let statef ctxt = state ctxt model_with_q extras in
-    List.rev (statef ctxt :: List.filter_map (function State ctxt -> Some (statef ctxt) | _ -> None) log)
+    List.Old.rev (statef ctxt :: List.Old.filter_map (function State ctxt -> Some (statef ctxt) | _ -> None) log)
   in
 
 
@@ -287,7 +287,7 @@ let trace (ctxt,log) (model_with_q : Solver.model_with_q) (extras : state_extras
               clause = LogicalArgumentTypes.pp IT.pp c.packing_ft
             }
           in
-          List.map doc_clause (relevant_predicate_clauses ctxt.global pname req)
+          List.Old.map doc_clause (relevant_predicate_clauses ctxt.global pname req)
   in
   let requested = Option.map req_entry extras.request in
 

--- a/backend/cn/explain.ml
+++ b/backend/cn/explain.ml
@@ -57,7 +57,7 @@ let relevant_predicate_clauses global name req =
     let defs = SymMap.bindings global.resource_predicates in
     List.Old.concat_map (fun (nm, def) ->
         match def.clauses with
-        | Some clauses -> List.Old.map (fun c -> (nm, c)) clauses
+        | Some clauses -> List.map ~f:(fun c -> (nm, c)) clauses
         | None -> []
       ) defs
   in
@@ -88,9 +88,9 @@ end
 
 let subterms_without_bound_variables bindings = 
   fold_subterms ~bindings (fun bindings acc t ->
-      let pats = List.Old.map fst bindings in
+      let pats = List.map ~f:fst bindings in
       let bound = List.Old.concat_map bound_by_pattern pats in
-      let bound = SymSet.of_list (List.Old.map fst bound) in
+      let bound = SymSet.of_list (List.map ~f:fst bound) in
       if SymSet.(is_empty (inter bound (IT.free_vars t))) 
       then ITSet.add t acc
       else acc
@@ -141,7 +141,7 @@ let state ctxt model_with_q extras =
         | BaseType ls -> Some (make s ls)
       in
       ITSet.of_list
-          (List.Old.map (fun (s, ls) -> make s ls) quantifier_counter_model
+          (List.map ~f:(fun (s, ls) -> make s ls) quantifier_counter_model
            @ List.Old.filter_map basetype_binding (SymMap.bindings ctxt.computational)
            @ List.Old.filter_map basetype_binding (SymMap.bindings ctxt.logical))
     in
@@ -198,8 +198,8 @@ let state ctxt model_with_q extras =
         ) filtered
     in
 
-    (List.Old.map snd interesting, 
-     List.Old.map snd uninteresting)
+    (List.map ~f:snd interesting, 
+     List.map ~f:snd uninteresting)
 
   in
 
@@ -213,8 +213,8 @@ let state ctxt model_with_q extras =
           | _ -> true
         ) (LCSet.elements ctxt.constraints)
     in
-    (List.Old.map LC.pp interesting, 
-     List.Old.map LC.pp uninteresting)
+    (List.map ~f:LC.pp interesting, 
+     List.map ~f:LC.pp uninteresting)
   in
 
   let resources =
@@ -231,11 +231,11 @@ let state ctxt model_with_q extras =
     in
 
     let interesting = 
-      List.Old.map (fun re -> RE.pp re ^^^ parens !^"same type") same_res 
-      @ List.Old.map RE.pp interesting_diff_res
+      List.map ~f:(fun re -> RE.pp re ^^^ parens !^"same type") same_res 
+      @ List.map ~f:RE.pp interesting_diff_res
     in
     let uninteresting = 
-      List.Old.map RE.pp uninteresting_diff_res
+      List.map ~f:RE.pp uninteresting_diff_res
     in
     (interesting, uninteresting)
   in
@@ -287,7 +287,7 @@ let trace (ctxt,log) (model_with_q : Solver.model_with_q) (extras : state_extras
               clause = LogicalArgumentTypes.pp IT.pp c.packing_ft
             }
           in
-          List.Old.map doc_clause (relevant_predicate_clauses ctxt.global pname req)
+          List.map ~f:doc_clause (relevant_predicate_clauses ctxt.global pname req)
   in
   let requested = Option.map req_entry extras.request in
 

--- a/backend/cn/explain.ml
+++ b/backend/cn/explain.ml
@@ -61,7 +61,7 @@ let relevant_predicate_clauses global name req =
         | None -> []
       ) defs
   in
-  List.Old.filter (fun (nm, c) -> 
+  List.filter ~f:(fun (nm, c) -> 
       Sym.equal nm name
       || clause_has_resource req c
     ) clauses

--- a/backend/cn/explain.ml
+++ b/backend/cn/explain.ml
@@ -55,7 +55,7 @@ let relevant_predicate_clauses global name req =
   let open ResourcePredicates in
   let clauses =
     let defs = SymMap.bindings global.resource_predicates in
-    List.Old.concat_map (fun (nm, def) ->
+    List.concat_map ~f:(fun (nm, def) ->
         match def.clauses with
         | Some clauses -> List.map ~f:(fun c -> (nm, c)) clauses
         | None -> []
@@ -89,7 +89,7 @@ end
 let subterms_without_bound_variables bindings = 
   fold_subterms ~bindings (fun bindings acc t ->
       let pats = List.map ~f:fst bindings in
-      let bound = List.Old.concat_map bound_by_pattern pats in
+      let bound = List.concat_map ~f:bound_by_pattern pats in
       let bound = SymSet.of_list (List.map ~f:fst bound) in
       if SymSet.(is_empty (inter bound (IT.free_vars t))) 
       then ITSet.add t acc

--- a/backend/cn/explain.ml
+++ b/backend/cn/explain.ml
@@ -190,7 +190,7 @@ let state ctxt model_with_q extras =
     in
 
     let interesting, uninteresting = 
-      List.Old.partition (fun (it, _entry) ->
+      List.partition_tf ~f:(fun (it, _entry) ->
           match IT.bt it with
           | BT.Unit -> false
           | BT.Loc -> false
@@ -205,7 +205,7 @@ let state ctxt model_with_q extras =
 
   let constraints =
     let interesting, uninteresting = 
-      List.Old.partition (fun lc ->
+      List.partition_tf ~f:(fun lc ->
           match lc with
           (* | LC.T (IT (Aligned _, _, _)) -> false *)
           | LC.T (IT (Representable _, _, _)) -> false
@@ -220,10 +220,10 @@ let state ctxt model_with_q extras =
   let resources =
     let (same_res, diff_res) = match extras.request with
       | None -> ([], get_rs ctxt)
-      | Some req -> List.Old.partition (fun r -> RET.same_predicate_name req (RE.request r)) (get_rs ctxt)
+      | Some req -> List.partition_tf ~f:(fun r -> RET.same_predicate_name req (RE.request r)) (get_rs ctxt)
     in
     let interesting_diff_res, uninteresting_diff_res = 
-      List.Old.partition (fun (ret, _o) ->
+      List.partition_tf ~f:(fun (ret, _o) ->
           match ret with
           | P ret when equal_predicate_name ret.name ResourceTypes.alloc_name -> false
           | _ -> true

--- a/backend/cn/explain.ml
+++ b/backend/cn/explain.ml
@@ -271,7 +271,7 @@ let trace (ctxt,log) (model_with_q : Solver.model_with_q) (extras : state_extras
 
   let trace = 
     let statef ctxt = state ctxt model_with_q extras in
-    List.Old.rev (statef ctxt :: List.filter_map ~f:(function State ctxt -> Some (statef ctxt) | _ -> None) log)
+    List.rev (statef ctxt :: List.filter_map ~f:(function State ctxt -> Some (statef ctxt) | _ -> None) log)
   in
 
 

--- a/backend/cn/explain.ml
+++ b/backend/cn/explain.ml
@@ -142,8 +142,8 @@ let state ctxt model_with_q extras =
       in
       ITSet.of_list
           (List.map ~f:(fun (s, ls) -> make s ls) quantifier_counter_model
-           @ List.Old.filter_map basetype_binding (SymMap.bindings ctxt.computational)
-           @ List.Old.filter_map basetype_binding (SymMap.bindings ctxt.logical))
+           @ List.filter_map ~f:basetype_binding (SymMap.bindings ctxt.computational)
+           @ List.filter_map ~f:basetype_binding (SymMap.bindings ctxt.logical))
     in
 
     let unproven = match extras.unproven_constraint with
@@ -178,7 +178,7 @@ let state ctxt model_with_q extras =
 
 
     let filtered = 
-      List.Old.filter_map (fun it -> 
+      List.filter_map ~f:(fun it -> 
           match evaluate it with
           | Some value when not (IT.equal value it) ->
              Some (it, {term = IT.pp it; value = IT.pp value})
@@ -271,7 +271,7 @@ let trace (ctxt,log) (model_with_q : Solver.model_with_q) (extras : state_extras
 
   let trace = 
     let statef ctxt = state ctxt model_with_q extras in
-    List.Old.rev (statef ctxt :: List.Old.filter_map (function State ctxt -> Some (statef ctxt) | _ -> None) log)
+    List.Old.rev (statef ctxt :: List.filter_map ~f:(function State ctxt -> Some (statef ctxt) | _ -> None) log)
   in
 
 

--- a/backend/cn/free.ml
+++ b/backend/cn/free.ml
@@ -6,7 +6,7 @@ module SymSet = Set.Make(Sym)
 
 
 let union_map (f : 'a -> SymSet.t) (xs : 'a list) =
-  List.fold_left (fun acc x ->
+  List.Old.fold_left (fun acc x ->
       SymSet.union (f x) acc
     ) SymSet.empty xs
 

--- a/backend/cn/global.ml
+++ b/backend/cn/global.ml
@@ -91,7 +91,7 @@ let pp global =
 let mutual_datatypes (global : t) tag =
   let deps tag =
     let info = SymMap.find tag global.datatypes in
-    info.dt_all_params |> List.Old.filter_map (fun (_, bt) -> BaseTypes.is_datatype_bt bt)
+    info.dt_all_params |> List.filter_map ~f:(fun (_, bt) -> BaseTypes.is_datatype_bt bt)
   in
   let rec seek tags = function
     | [] -> tags

--- a/backend/cn/global.ml
+++ b/backend/cn/global.ml
@@ -49,7 +49,7 @@ let get_logical_function_def global id = SymMap.find_opt id global.logical_funct
 let get_fun_decl global sym = SymMap.find_opt sym global.fun_decls
 let get_lemma global sym = SymMap.find_opt sym global.lemmata
 
-let sym_map_from_bindings xs = List.fold_left (fun m (nm, x) -> SymMap.add nm x m)
+let sym_map_from_bindings xs = List.Old.fold_left (fun m (nm, x) -> SymMap.add nm x m)
     SymMap.empty xs
 
 
@@ -91,7 +91,7 @@ let pp global =
 let mutual_datatypes (global : t) tag =
   let deps tag =
     let info = SymMap.find tag global.datatypes in
-    info.dt_all_params |> List.filter_map (fun (_, bt) -> BaseTypes.is_datatype_bt bt)
+    info.dt_all_params |> List.Old.filter_map (fun (_, bt) -> BaseTypes.is_datatype_bt bt)
   in
   let rec seek tags = function
     | [] -> tags

--- a/backend/cn/indexTerms.ml
+++ b/backend/cn/indexTerms.ml
@@ -888,7 +888,7 @@ let value_check_pointer mode ~pointee_ct about loc =
   (*   | Function _ -> 1 *)
   (*   | _ -> Memory.size_of_ctype pointee_ct *)
   (* in *)
-  and_ (List.Old.filter_map Fun.id [
+  and_ (List.filter_map ~f:Fun.id [
     (* Some (le_ (intptr_int_ 0 loc, about_int) loc); *)
     (* Some (le_ (sub_ (add_ (about_int, intptr_int_ pointee_size loc) loc, intptr_int_ 1 loc) loc, *)
     (*         intptr_const_ Memory.max_pointer loc) loc); *)
@@ -934,7 +934,7 @@ let value_check mode (struct_layouts : Memory.struct_decls) ct about loc =
        value_check_pointer mode ~pointee_ct about loc
     | Struct tag ->
        and_ begin
-           List.Old.filter_map (fun piece ->
+           List.filter_map ~f:(fun piece ->
                match piece.member_or_padding with
                | Some (member, mct) ->
                   let member_bt = Memory.bt_of_sct mct in
@@ -996,13 +996,13 @@ let rec wrap_bindings_match bs default_v v =
 
 let nth_array_to_list_facts (binders_terms : (t_bindings * t) list) =
   let here = Locations.other __FUNCTION__ in
-  let nths = List.Old.filter_map (fun (bs, it) -> match term it with
+  let nths = List.filter_map ~f:(fun (bs, it) -> match term it with
     | NthList (n, xs, d) -> Some (bs, (n, d, bt xs))
     | _ -> None) binders_terms in
-  let arr_lists = List.Old.filter_map (fun (bs, it) -> match term it with
+  let arr_lists = List.filter_map ~f:(fun (bs, it) -> match term it with
     | ArrayToList _ -> Some (bs, (it, bt it))
     | _ -> None) binders_terms in
-  List.Old.concat_map (fun (bs1, (n, d, bt1)) -> List.Old.filter_map (fun (bs2, (xs, bt2)) ->
+  List.Old.concat_map (fun (bs1, (n, d, bt1)) -> List.filter_map ~f:(fun (bs2, (xs, bt2)) ->
     if BT.equal bt1 bt2
     then wrap_bindings_match (bs1 @ bs2) (bool_ true here) (nth_array_to_list_fact n xs d)
     else None) arr_lists

--- a/backend/cn/indexTerms.ml
+++ b/backend/cn/indexTerms.ml
@@ -58,7 +58,7 @@ let rec bound_by_pattern (Pat (pat_, bt, _)) =
   | PSym s -> [(s, bt)]
   | PWild -> []
   | PConstructor (_s, args) ->
-     List.Old.concat_map (fun (_id, pat) -> bound_by_pattern pat) args
+     List.concat_map ~f:(fun (_id, pat) -> bound_by_pattern pat) args
 
 let rec free_vars_ : 'a. 'a term_ -> SymSet.t = function
   | Const _ -> SymSet.empty
@@ -1002,7 +1002,7 @@ let nth_array_to_list_facts (binders_terms : (t_bindings * t) list) =
   let arr_lists = List.filter_map ~f:(fun (bs, it) -> match term it with
     | ArrayToList _ -> Some (bs, (it, bt it))
     | _ -> None) binders_terms in
-  List.Old.concat_map (fun (bs1, (n, d, bt1)) -> List.filter_map ~f:(fun (bs2, (xs, bt2)) ->
+  List.concat_map ~f:(fun (bs1, (n, d, bt1)) -> List.filter_map ~f:(fun (bs2, (xs, bt2)) ->
     if BT.equal bt1 bt2
     then wrap_bindings_match (bs1 @ bs2) (bool_ true here) (nth_array_to_list_fact n xs d)
     else None) arr_lists

--- a/backend/cn/lemmata.ml
+++ b/backend/cn/lemmata.ml
@@ -392,7 +392,7 @@ let tuple_syn xs =
   parens (flow (comma ^^^ !^ "") xs)
 
 let find_tuple_element (eq : 'a -> 'a -> bool) (x : 'a) (pp : 'a -> Pp.document) (ys : 'a list) =
-  let n_ys = List.Old.mapi (fun i y -> (i, y)) ys in
+  let n_ys = List.mapi ~f:(fun i y -> (i, y)) ys in
   match List.find ~f:(fun (_i, y) -> eq x y) n_ys with
     | None -> fail "tuple element not found" (pp x)
     | Some (i, _) -> (i, List.length ys)
@@ -513,7 +513,7 @@ and ensure_datatype (global : Global.t) (list_mono : list_mono) loc dt_tag =
               hardline ^^ flow hardline c_lines)
       ) family in
       return (flow hardline
-          (List.Old.mapi (fun i doc -> !^ (if i = 0 then "  Inductive" else "    with") ^^
+          (List.mapi ~f:(fun i doc -> !^ (if i = 0 then "  Inductive" else "    with") ^^
               hardline ^^ doc) dt_eqs) ^^ !^ "." ^^ hardline)
   )) [dt_tag]
 

--- a/backend/cn/lemmata.ml
+++ b/backend/cn/lemmata.ml
@@ -914,7 +914,7 @@ let lc_to_coq_check_triv loc global list_mono = function
       let@ enc = mk_forall global list_mono loc sym bt v in
       return (Some (Pp.parens enc))
 
-let nth_str_eq n s ss = Option.equal String.equal (List.Old.nth_opt ss n) (Some s)
+let nth_str_eq n s ss = Option.equal String.equal (List.nth ss n) (Some s)
 
 let types_spec types =
   let open Pp in

--- a/backend/cn/lemmata.ml
+++ b/backend/cn/lemmata.ml
@@ -226,7 +226,7 @@ let struct_layout_field_bts xs =
   let open Memory in
   let xs2 = List.Old.filter (fun x -> Option.is_some x.member_or_padding) xs
     |> List.Old.sort (fun (x : struct_piece) y -> Int.compare x.offset y.offset)
-    |> List.Old.filter_map (fun x -> x.member_or_padding)
+    |> List.filter_map ~f:(fun x -> x.member_or_padding)
   in
   (List.map ~f:fst xs2, List.map ~f:(fun x -> Memory.bt_of_sct (snd x)) xs2)
 
@@ -290,7 +290,7 @@ let monomorphise_dt_lists global =
     | _ -> None
   in
   let all_dt_types = SymMap.fold (fun _ dt_info ss ->
-        List.Old.filter_map dt_lists (List.map ~f:snd dt_info.BT.dt_all_params) @ ss)
+        List.filter_map ~f:dt_lists (List.map ~f:snd dt_info.BT.dt_all_params) @ ss)
     global.Global.datatypes [] in
   let uniq_dt_types = SymSet.elements (SymSet.of_list all_dt_types) in
   let new_sym sym = (sym, Sym.fresh_named ("list_of_" ^ Sym.pp_string sym)) in

--- a/backend/cn/lemmata.ml
+++ b/backend/cn/lemmata.ml
@@ -119,7 +119,7 @@ let release_failures () =
   let@ st = get in
   match st.failures with
   | [] -> return ()
-  | fs -> (fun _ -> Result.Error (List.hd_exn (List.Old.rev fs)))
+  | fs -> (fun _ -> Result.Error (List.hd_exn (List.rev fs)))
 
 (* set of functions with boolean return type that we want to use
    as toplevel propositions, i.e. return Prop rather than bool
@@ -1008,8 +1008,8 @@ let convert_lemma_defs global list_mono lemma_typs =
   Pp.debug 4 (lazy (Pp.item "saved conversion elements"
     (Pp.list (fun (ss, _) -> Pp.parens (Pp.list Pp.string ss))
         (StringListMap.bindings st.present))));
-  return (tys, List.Old.rev (get_section 0 st),
-        List.Old.rev (get_section 1 st), List.Old.rev (get_section 2 st))
+  return (tys, List.rev (get_section 0 st),
+        List.rev (get_section 1 st), List.rev (get_section 2 st))
 
 let defs_module aux_defs lemma_tys =
   let open Pp in

--- a/backend/cn/lemmata.ml
+++ b/backend/cn/lemmata.ml
@@ -395,7 +395,7 @@ let find_tuple_element (eq : 'a -> 'a -> bool) (x : 'a) (pp : 'a -> Pp.document)
   let n_ys = List.Old.mapi (fun i y -> (i, y)) ys in
   match List.Old.find_opt (fun (_i, y) -> eq x y) n_ys with
     | None -> fail "tuple element not found" (pp x)
-    | Some (i, _) -> (i, List.Old.length ys)
+    | Some (i, _) -> (i, List.length ys)
 
 let tuple_element t (i, len) =
   let open Pp in
@@ -691,7 +691,7 @@ let mk_forall global list_mono loc sym bt doc =
 
 let add_dt_param_counted (it, (m_nm : Id.t)) =
   let@ st = get in
-  let idx = List.Old.length (st.dt_params) in
+  let idx = List.length (st.dt_params) in
   let sym = Sym.fresh_named (Id.pp_string m_nm ^ "_" ^ Int.to_string idx) in
   let@ () = add_dt_param (it, m_nm, sym) in
   return sym
@@ -814,7 +814,7 @@ let it_to_coq loc global list_mono it =
     | IT.MapGet (m, x) -> parensM (build [aux m; aux x])
     | IT.RecordMember (t, m) ->
         let flds = BT.record_bt (IT.bt t) in
-        if List.Old.length flds == 1
+        if List.length flds == 1
         then aux t
         else
         let ix = find_tuple_element Id.equal m Id.pp (List.map ~f:fst flds) in
@@ -822,7 +822,7 @@ let it_to_coq loc global list_mono it =
         parensM (build [rets op_nm; aux t])
     | IT.RecordUpdate ((t, m), x) ->
         let flds = BT.record_bt (IT.bt t) in
-        if List.Old.length flds == 1
+        if List.length flds == 1
         then aux x
         else
         let ix = find_tuple_element Id.equal m Id.pp (List.map ~f:fst flds) in
@@ -835,7 +835,7 @@ let it_to_coq loc global list_mono it =
         let tag = BaseTypes.struct_bt (IT.bt t) in
         let (mems, _bts) = get_struct_xs global.struct_decls tag in
         let ix = find_tuple_element Id.equal m Id.pp mems in
-        if List.Old.length mems == 1
+        if List.length mems == 1
         then aux t
         else
         let@ op_nm = ensure_tuple_op false (Id.pp_string m) ix in
@@ -844,7 +844,7 @@ let it_to_coq loc global list_mono it =
         let tag = BaseTypes.struct_bt (IT.bt t) in
         let (mems, _bts) = get_struct_xs global.struct_decls tag in
         let ix = find_tuple_element Id.equal m Id.pp mems in
-        if List.Old.length mems == 1
+        if List.length mems == 1
         then aux x
         else
         let@ op_nm = ensure_tuple_op true (Id.pp_string m) ix in
@@ -920,7 +920,7 @@ let types_spec types =
   let open Pp in
   !^"Module Types."
   ^^ hardline ^^ hardline
-  ^^ (if List.Old.length types == 0
+  ^^ (if List.length types == 0
     then !^ "  (* no type definitions required *)" ^^ hardline
     else flow hardline types)
   ^^ hardline
@@ -932,7 +932,7 @@ let param_spec params =
   !^"Module Type Parameters." ^^ hardline
   ^^ !^"  Import Types."
   ^^ hardline ^^ hardline
-  ^^ (if List.Old.length params == 0
+  ^^ (if List.length params == 0
     then !^ "  (* no parameters required *)" ^^ hardline
     else flow hardline params)
   ^^ hardline

--- a/backend/cn/lemmata.ml
+++ b/backend/cn/lemmata.ml
@@ -308,7 +308,7 @@ let monomorphise_dt_lists global =
 
 let rec new_nm s nms i =
   let s2 = s ^ "_" ^ Int.to_string i in
-  if List.Old.exists (String.equal s2) nms
+  if List.exists ~f:(String.equal s2) nms
   then new_nm s nms (i + 1)
   else s2
 
@@ -316,7 +316,7 @@ let alpha_rename_if_pp_same s body =
   let vs = IT.free_vars body in
   let other_nms = List.filter ~f:(fun sym -> not (Sym.equal sym s)) (SymSet.elements vs)
     |> List.map ~f:Sym.pp_string in
-  if List.Old.exists (String.equal (Sym.pp_string s)) other_nms
+  if List.exists ~f:(String.equal (Sym.pp_string s)) other_nms
   then begin
     Pp.debug 6 (lazy (Pp.item "doing rename"
         (Pp.typ (Sym.pp s) (Pp.braces (Pp.list Pp.string other_nms)))));
@@ -492,7 +492,7 @@ and ensure_datatype (global : Global.t) (list_mono : list_mono) loc dt_tag =
   let dt_tag = List.hd_exn family in
   let inf = (loc, Pp.typ (Pp.string "datatype") (Sym.pp dt_tag)) in
   let bt_to_coq2 bt = match BT.is_datatype_bt bt with
-    | Some dt_tag2 -> if List.Old.exists (Sym.equal dt_tag2) family
+    | Some dt_tag2 -> if List.exists ~f:(Sym.equal dt_tag2) family
       then return (Sym.pp dt_tag2)
       else bt_to_coq global list_mono inf bt
     | _ -> bt_to_coq global list_mono inf bt
@@ -534,7 +534,7 @@ let ensure_datatype_member global list_mono loc dt_tag (mem_tag: Id.t) bt =
     in
     let open Pp in
     !^ "    |" ^^^ flow (!^ " ") (Sym.pp c :: pats) ^^^ !^"=>" ^^^
-    if List.Old.exists (Id.equal mem_tag) (List.map ~f:fst c_info.c_params)
+    if List.exists ~f:(Id.equal mem_tag) (List.map ~f:fst c_info.c_params)
     then Id.pp mem_tag
     else !^"default"
   in

--- a/backend/cn/lemmata.ml
+++ b/backend/cn/lemmata.ml
@@ -331,10 +331,10 @@ let it_adjust (global : Global.t) it =
     let loc = IT.loc t in
     match IT.term t with
         | IT.Binop (And, x1, x2) ->
-            let xs = List.map ~f:f [x1; x2] |> List.Old.partition IT.is_true |> snd in
+            let xs = List.map ~f:f [x1; x2] |> List.partition_tf ~f:IT.is_true |> snd in
             IT.and_ xs loc
         | IT.Binop (Or, x1, x2) ->
-            let xs = List.map ~f:f [x1; x2] |> List.Old.partition IT.is_false |> snd in
+            let xs = List.map ~f:f [x1; x2] |> List.partition_tf ~f:IT.is_false |> snd in
             IT.or_ xs loc
         | IT.Binop (EQ, x, y) ->
             let x = f x in
@@ -1099,9 +1099,9 @@ let generate (global : Global.t) directions (lemmata : (Sym.t * (Loc.t * AT.lemm
       ) lemmata
     |> List.Old.sort (fun x (y : scanned) -> cmp_loc_line_numbers x.loc y.loc)
   in
-  let (impure, pure) = List.Old.partition (fun x -> Option.is_some x.scan_res.res) scan_lemmata in
-  let (coerce, skip) = List.Old.partition
-        (fun x -> Option.is_some x.scan_res.res_coerce) impure in
+  let (impure, pure) = List.partition_tf ~f:(fun x -> Option.is_some x.scan_res.res) scan_lemmata in
+  let (coerce, skip) = List.partition_tf
+        ~f:(fun x -> Option.is_some x.scan_res.res_coerce) impure in
   List.Old.iter (fun x ->
     Pp.progress_simple "skipping trusted fun with resource"
         (Sym.pp_string x.sym ^ ": " ^ (Option.get x.scan_res.res))

--- a/backend/cn/lemmata.ml
+++ b/backend/cn/lemmata.ml
@@ -1102,7 +1102,7 @@ let generate (global : Global.t) directions (lemmata : (Sym.t * (Loc.t * AT.lemm
   let (impure, pure) = List.partition_tf ~f:(fun x -> Option.is_some x.scan_res.res) scan_lemmata in
   let (coerce, skip) = List.partition_tf
         ~f:(fun x -> Option.is_some x.scan_res.res_coerce) impure in
-  List.Old.iter (fun x ->
+  List.iter ~f:(fun x ->
     Pp.progress_simple "skipping trusted fun with resource"
         (Sym.pp_string x.sym ^ ": " ^ (Option.get x.scan_res.res))
   ) skip;

--- a/backend/cn/lemmata.ml
+++ b/backend/cn/lemmata.ml
@@ -224,7 +224,7 @@ let scan (ftyp : AT.lemmat) =
 
 let struct_layout_field_bts xs =
   let open Memory in
-  let xs2 = List.Old.filter (fun x -> Option.is_some x.member_or_padding) xs
+  let xs2 = List.filter ~f:(fun x -> Option.is_some x.member_or_padding) xs
     |> List.Old.sort (fun (x : struct_piece) y -> Int.compare x.offset y.offset)
     |> List.filter_map ~f:(fun x -> x.member_or_padding)
   in
@@ -314,7 +314,7 @@ let rec new_nm s nms i =
 
 let alpha_rename_if_pp_same s body =
   let vs = IT.free_vars body in
-  let other_nms = List.Old.filter (fun sym -> not (Sym.equal sym s)) (SymSet.elements vs)
+  let other_nms = List.filter ~f:(fun sym -> not (Sym.equal sym s)) (SymSet.elements vs)
     |> List.map ~f:Sym.pp_string in
   if List.Old.exists (String.equal (Sym.pp_string s)) other_nms
   then begin

--- a/backend/cn/lemmata.ml
+++ b/backend/cn/lemmata.ml
@@ -119,7 +119,7 @@ let release_failures () =
   let@ st = get in
   match st.failures with
   | [] -> return ()
-  | fs -> (fun _ -> Result.Error (List.Old.hd (List.Old.rev fs)))
+  | fs -> (fun _ -> Result.Error (List.hd_exn (List.Old.rev fs)))
 
 (* set of functions with boolean return type that we want to use
    as toplevel propositions, i.e. return Prop rather than bool
@@ -489,7 +489,7 @@ let rec bt_to_coq (global : Global.t) (list_mono : list_mono) loc_info =
 
 and ensure_datatype (global : Global.t) (list_mono : list_mono) loc dt_tag =
   let family = Global.mutual_datatypes global dt_tag in
-  let dt_tag = List.Old.hd family in
+  let dt_tag = List.hd_exn family in
   let inf = (loc, Pp.typ (Pp.string "datatype") (Sym.pp dt_tag)) in
   let bt_to_coq2 bt = match BT.is_datatype_bt bt with
     | Some dt_tag2 -> if List.Old.exists (Sym.equal dt_tag2) family

--- a/backend/cn/lemmata.ml
+++ b/backend/cn/lemmata.ml
@@ -59,7 +59,7 @@ module PrevDefs = struct
     {st with dt_params = x :: st.dt_params})
 
   let get_dt_param it m_nm = bind get (fun st ->
-    return (List.Old.find_opt (fun (it2, m2, _sym) -> IT.equal it it2 && Id.equal m_nm m2)
+    return (List.find ~f:(fun (it2, m2, _sym) -> IT.equal it it2 && Id.equal m_nm m2)
         st.dt_params |> Option.map (fun (_, _, sym) -> sym)))
 
   let debug_dt_params i = bind get (fun st ->
@@ -281,7 +281,7 @@ let add_list_mono_datatype (bt, nm) global =
 
 let mono_list_bt list_mono bt = Option.bind (BT.is_list_bt bt)
   (fun arg_bt -> Option.bind
-    (List.Old.find_opt (fun (bt2, _) -> BT.equal arg_bt bt2) list_mono)
+    (List.find ~f:(fun (bt2, _) -> BT.equal arg_bt bt2) list_mono)
     (fun (_, dt_sym) -> Some (BT.Datatype dt_sym)))
 
 let monomorphise_dt_lists global =
@@ -393,7 +393,7 @@ let tuple_syn xs =
 
 let find_tuple_element (eq : 'a -> 'a -> bool) (x : 'a) (pp : 'a -> Pp.document) (ys : 'a list) =
   let n_ys = List.Old.mapi (fun i y -> (i, y)) ys in
-  match List.Old.find_opt (fun (_i, y) -> eq x y) n_ys with
+  match List.find ~f:(fun (_i, y) -> eq x y) n_ys with
     | None -> fail "tuple element not found" (pp x)
     | Some (i, _) -> (i, List.length ys)
 

--- a/backend/cn/list.ml
+++ b/backend/cn/list.ml
@@ -121,4 +121,6 @@ let filter [@deprecated "Use List.filter xs ~f"] = filter
 
 let hd [@deprecated "Use List.hd_exn"] = hd
 
+let split [@deprecated "Use List.unzip"] = split
+
 end

--- a/backend/cn/list.ml
+++ b/backend/cn/list.ml
@@ -141,4 +141,6 @@ let mapi [@deprecated "Use List.mapi xs ~f"] = mapi
 
 let iter [@deprecated "Use List.iter xs ~f"] = iter
 
+let for_all2 [@deprecated "Use List.for_all2_exn xs ys ~f"] = for_all2
+
 end

--- a/backend/cn/list.ml
+++ b/backend/cn/list.ml
@@ -147,4 +147,6 @@ let nth_opt [@deprecated "Use List.nth xs"] = nth_opt
 
 let for_all [@deprecated "Use List.for_all xs ~f"] = for_all
 
+let tl [@deprecated "Use List.tl_ex"] = tl
+
 end

--- a/backend/cn/list.ml
+++ b/backend/cn/list.ml
@@ -137,4 +137,6 @@ let partition [@deprecated "Use List.partition_tf xs ~f"] = partition
 
 let find_opt [@deprecated "Use List.find xs ~f"] = find_opt
 
+let mapi [@deprecated "Use List.mapi xs ~f"] = mapi
+
 end

--- a/backend/cn/list.ml
+++ b/backend/cn/list.ml
@@ -2,6 +2,9 @@
    with a bunch of other useful list utilities. *)
 (* TODO: BCP: Probably not worth bothering with an mli file for this one... *)
 
+include Base.List
+
+module Old = struct
 include Stdlib.List
 
 let concat_map (f : 'a -> 'b list) (xs : 'a list) : 'b list =
@@ -104,3 +107,5 @@ let find_index pred xs =
     | [] -> None
     | x::xs -> if pred x then Some idx else aux (idx+1) xs in
   aux 0 xs
+
+end

--- a/backend/cn/list.ml
+++ b/backend/cn/list.ml
@@ -113,4 +113,6 @@ let length [@deprecated "Use List.length"] = length
 
 let nth [@deprecated "Use List.nth_exn"] = nth
 
+let concat [@deprecated "Use List.concat"] = concat
+
 end

--- a/backend/cn/list.ml
+++ b/backend/cn/list.ml
@@ -131,4 +131,5 @@ let exists [@deprecated "Use List.exists xs ~f"] = exists
 
 let concat_map [@deprecated "Use List.concat_map xs ~f"] = concat_map
 
+let map2 [@deprecated "Use List.map2_exn xs ~f"] = map2
 end

--- a/backend/cn/list.ml
+++ b/backend/cn/list.ml
@@ -115,4 +115,6 @@ let nth [@deprecated "Use List.nth_exn"] = nth
 
 let concat [@deprecated "Use List.concat"] = concat
 
+let filter_map [@deprecated "Use List.filter_map xs ~f"] = filter_map
+
 end

--- a/backend/cn/list.ml
+++ b/backend/cn/list.ml
@@ -143,4 +143,6 @@ let iter [@deprecated "Use List.iter xs ~f"] = iter
 
 let for_all2 [@deprecated "Use List.for_all2_exn xs ys ~f"] = for_all2
 
+let nth_opt [@deprecated "Use List.nth xs"] = nth_opt
+
 end

--- a/backend/cn/list.ml
+++ b/backend/cn/list.ml
@@ -107,6 +107,8 @@ let find_index pred xs =
     | x::xs -> if pred x then Some idx else aux (idx+1) xs in
   aux 0 xs
 
-let map [@deprecated "Use List.map ~f xs"] = map
+let map [@deprecated "Use List.map xs ~f"] = map
+
+let length [@deprecated "Use List.length"] = length
 
 end

--- a/backend/cn/list.ml
+++ b/backend/cn/list.ml
@@ -129,4 +129,6 @@ let combine [@deprecated "Use List.zip_exn"] = combine
 
 let exists [@deprecated "Use List.exists xs ~f"] = exists
 
+let concat_map [@deprecated "Use List.concat_map xs ~f"] = concat_map
+
 end

--- a/backend/cn/list.ml
+++ b/backend/cn/list.ml
@@ -117,4 +117,6 @@ let concat [@deprecated "Use List.concat"] = concat
 
 let filter_map [@deprecated "Use List.filter_map xs ~f"] = filter_map
 
+let filter [@deprecated "Use List.filter xs ~f"] = filter
+
 end

--- a/backend/cn/list.ml
+++ b/backend/cn/list.ml
@@ -111,4 +111,6 @@ let map [@deprecated "Use List.map xs ~f"] = map
 
 let length [@deprecated "Use List.length"] = length
 
+let nth [@deprecated "Use List.nth_exn"] = nth
+
 end

--- a/backend/cn/list.ml
+++ b/backend/cn/list.ml
@@ -132,4 +132,7 @@ let exists [@deprecated "Use List.exists xs ~f"] = exists
 let concat_map [@deprecated "Use List.concat_map xs ~f"] = concat_map
 
 let map2 [@deprecated "Use List.map2_exn xs ~f"] = map2
+
+let partition [@deprecated "Use List.partition_tf xs ~f"] = partition
+
 end

--- a/backend/cn/list.ml
+++ b/backend/cn/list.ml
@@ -125,4 +125,6 @@ let split [@deprecated "Use List.unzip"] = split
 
 let rev [@deprecated "Use List.rev"] = rev
 
+let combine [@deprecated "Use List.zip_exn"] = combine
+
 end

--- a/backend/cn/list.ml
+++ b/backend/cn/list.ml
@@ -145,4 +145,6 @@ let for_all2 [@deprecated "Use List.for_all2_exn xs ys ~f"] = for_all2
 
 let nth_opt [@deprecated "Use List.nth xs"] = nth_opt
 
+let for_all [@deprecated "Use List.for_all xs ~f"] = for_all
+
 end

--- a/backend/cn/list.ml
+++ b/backend/cn/list.ml
@@ -139,4 +139,6 @@ let find_opt [@deprecated "Use List.find xs ~f"] = find_opt
 
 let mapi [@deprecated "Use List.mapi xs ~f"] = mapi
 
+let iter [@deprecated "Use List.iter xs ~f"] = iter
+
 end

--- a/backend/cn/list.ml
+++ b/backend/cn/list.ml
@@ -127,4 +127,6 @@ let rev [@deprecated "Use List.rev"] = rev
 
 let combine [@deprecated "Use List.zip_exn"] = combine
 
+let exists [@deprecated "Use List.exists xs ~f"] = exists
+
 end

--- a/backend/cn/list.ml
+++ b/backend/cn/list.ml
@@ -135,4 +135,6 @@ let map2 [@deprecated "Use List.map2_exn xs ~f"] = map2
 
 let partition [@deprecated "Use List.partition_tf xs ~f"] = partition
 
+let find_opt [@deprecated "Use List.find xs ~f"] = find_opt
+
 end

--- a/backend/cn/list.ml
+++ b/backend/cn/list.ml
@@ -119,4 +119,6 @@ let filter_map [@deprecated "Use List.filter_map xs ~f"] = filter_map
 
 let filter [@deprecated "Use List.filter xs ~f"] = filter
 
+let hd [@deprecated "Use List.hd_exn"] = hd
+
 end

--- a/backend/cn/list.ml
+++ b/backend/cn/list.ml
@@ -123,4 +123,6 @@ let hd [@deprecated "Use List.hd_exn"] = hd
 
 let split [@deprecated "Use List.unzip"] = split
 
+let rev [@deprecated "Use List.rev"] = rev
+
 end

--- a/backend/cn/list.ml
+++ b/backend/cn/list.ml
@@ -1,6 +1,5 @@
-(* This file re-exports the standard List library functions together
-   with a bunch of other useful list utilities. *)
-(* TODO: BCP: Probably not worth bothering with an mli file for this one... *)
+(* This file is in a state of transition from the old re-exports of the
+   standard List library functions plus extras to Base. *)
 
 include Base.List
 
@@ -107,5 +106,7 @@ let find_index pred xs =
     | [] -> None
     | x::xs -> if pred x then Some idx else aux (idx+1) xs in
   aux 0 xs
+
+let map [@deprecated "Use List.map ~f xs"] = map
 
 end

--- a/backend/cn/locations.ml
+++ b/backend/cn/locations.ml
@@ -22,7 +22,7 @@ let other str = Cerb_location.other str
 
 let dirs_to_ignore =
   StringSet.of_list
-    (List.map Cerb_runtime.in_runtime
+    (List.Old.map Cerb_runtime.in_runtime
        [ "libc/include"
        ; "libcore"
        ; ("impls/" ^ Setup.impl_name ^ ".impl")
@@ -100,7 +100,7 @@ let json_raw_loc loc : Yojson.Safe.t =
        `Variant ("Region", Some (`Assoc args))
     | Loc_regions (starts_ends,cursor) ->
        let starts_ends' =
-         List.map (fun (startp, endp) ->
+         List.Old.map (fun (startp, endp) ->
              let startp' = json_lexing_position startp in
              let endp' = json_lexing_position endp in
              `Assoc [("regions_start", startp'); ("regions_end", endp')]
@@ -128,7 +128,7 @@ let json_loc loc : Yojson.Safe.t =
 
 
 let json_path locs : Yojson.Safe.t =
-  let locs_json = List.map json_loc (List.rev locs) in
+  let locs_json = List.Old.map json_loc (List.Old.rev locs) in
   `Variant ("path", Some (`List locs_json))
 
 
@@ -162,7 +162,7 @@ let end_pos = function
   | Loc_region (_, loc, _) -> Some loc
   | Loc_regions (list, _) ->
     (* can't use Option module without a cyclic dependency? *)
-    begin match List.last list with
+    begin match List.Old.last list with
     | None -> None
     | Some (_, loc) -> Some loc
     end

--- a/backend/cn/locations.ml
+++ b/backend/cn/locations.ml
@@ -22,7 +22,7 @@ let other str = Cerb_location.other str
 
 let dirs_to_ignore =
   StringSet.of_list
-    (List.Old.map Cerb_runtime.in_runtime
+    (List.map ~f:Cerb_runtime.in_runtime
        [ "libc/include"
        ; "libcore"
        ; ("impls/" ^ Setup.impl_name ^ ".impl")
@@ -100,7 +100,7 @@ let json_raw_loc loc : Yojson.Safe.t =
        `Variant ("Region", Some (`Assoc args))
     | Loc_regions (starts_ends,cursor) ->
        let starts_ends' =
-         List.Old.map (fun (startp, endp) ->
+         List.map ~f:(fun (startp, endp) ->
              let startp' = json_lexing_position startp in
              let endp' = json_lexing_position endp in
              `Assoc [("regions_start", startp'); ("regions_end", endp')]
@@ -128,7 +128,7 @@ let json_loc loc : Yojson.Safe.t =
 
 
 let json_path locs : Yojson.Safe.t =
-  let locs_json = List.Old.map json_loc (List.Old.rev locs) in
+  let locs_json = List.map ~f:json_loc (List.Old.rev locs) in
   `Variant ("path", Some (`List locs_json))
 
 

--- a/backend/cn/locations.ml
+++ b/backend/cn/locations.ml
@@ -128,7 +128,7 @@ let json_loc loc : Yojson.Safe.t =
 
 
 let json_path locs : Yojson.Safe.t =
-  let locs_json = List.map ~f:json_loc (List.Old.rev locs) in
+  let locs_json = List.map ~f:json_loc (List.rev locs) in
   `Variant ("path", Some (`List locs_json))
 
 

--- a/backend/cn/logicalArgumentTypes.ml
+++ b/backend/cn/logicalArgumentTypes.ml
@@ -17,9 +17,9 @@ let mDefine (name, it, info) t = Define ((name, it), info, t)
 let mResource (bound, info) t = Resource (bound, info, t)
 let mConstraint (bound, info) t = Constraint (bound, info, t)
 
-let mDefines defs t = List.fold_right mDefine defs t
-let mResources ress t = List.fold_right mResource ress t
-let mConstraints cons t = List.fold_right mConstraint cons t
+let mDefines defs t = List.Old.fold_right mDefine defs t
+let mResources ress t = List.Old.fold_right mResource ress t
+let mConstraints cons t = List.Old.fold_right mConstraint cons t
 
 
 

--- a/backend/cn/logicalFunctions.ml
+++ b/backend/cn/logicalFunctions.ml
@@ -124,7 +124,7 @@ let add_unfolds_to_terms preds terms =
 (*     | (nm, Some path) :: q -> if SymSet.mem nm known_ok *)
 (*       then search known_ok q *)
 (*       else if List.Old.exists (Sym.equal nm) path *)
-(*       then Some (List.Old.rev path @ [nm]) *)
+(*       then Some (List.rev path @ [nm]) *)
 (*       else *)
 (*         let deps = List.map ~f:(fun p -> (p, Some (nm :: path))) (def_preds nm) in *)
 (*         search known_ok (deps @ [(nm, None)] @ q) *)

--- a/backend/cn/logicalFunctions.ml
+++ b/backend/cn/logicalFunctions.ml
@@ -123,7 +123,7 @@ let add_unfolds_to_terms preds terms =
 (*     | [] -> None *)
 (*     | (nm, Some path) :: q -> if SymSet.mem nm known_ok *)
 (*       then search known_ok q *)
-(*       else if List.Old.exists (Sym.equal nm) path *)
+(*       else if List.exists ~f:(Sym.equal nm) path *)
 (*       then Some (List.rev path @ [nm]) *)
 (*       else *)
 (*         let deps = List.map ~f:(fun p -> (p, Some (nm :: path))) (def_preds nm) in *)

--- a/backend/cn/logicalFunctions.ml
+++ b/backend/cn/logicalFunctions.ml
@@ -62,7 +62,7 @@ let pp_def nm def =
 
 
 let open_fun def_args def_body args =
-  let su = make_subst (List.Old.map2 (fun (s, _) arg -> (s, arg)) def_args args) in
+  let su = make_subst (List.map2_exn ~f:(fun (s, _) arg -> (s, arg)) def_args args) in
   IT.subst su def_body
 
 

--- a/backend/cn/logicalFunctions.ml
+++ b/backend/cn/logicalFunctions.ml
@@ -62,7 +62,7 @@ let pp_def nm def =
 
 
 let open_fun def_args def_body args =
-  let su = make_subst (List.map2 (fun (s, _) arg -> (s, arg)) def_args args) in
+  let su = make_subst (List.Old.map2 (fun (s, _) arg -> (s, arg)) def_args args) in
   IT.subst su def_body
 
 
@@ -123,13 +123,13 @@ let add_unfolds_to_terms preds terms =
 (*     | [] -> None *)
 (*     | (nm, Some path) :: q -> if SymSet.mem nm known_ok *)
 (*       then search known_ok q *)
-(*       else if List.exists (Sym.equal nm) path *)
-(*       then Some (List.rev path @ [nm]) *)
+(*       else if List.Old.exists (Sym.equal nm) path *)
+(*       then Some (List.Old.rev path @ [nm]) *)
 (*       else *)
-(*         let deps = List.map (fun p -> (p, Some (nm :: path))) (def_preds nm) in *)
+(*         let deps = List.Old.map (fun p -> (p, Some (nm :: path))) (def_preds nm) in *)
 (*         search known_ok (deps @ [(nm, None)] @ q) *)
 (*     | (nm, None) :: q -> search (SymSet.add nm known_ok) q *)
-(*   in search SymSet.empty (List.map (fun (p, _) -> (p, Some [])) (SymMap.bindings defs)) *)
+(*   in search SymSet.empty (List.Old.map (fun (p, _) -> (p, Some [])) (SymMap.bindings defs)) *)
 
 
 

--- a/backend/cn/logicalFunctions.ml
+++ b/backend/cn/logicalFunctions.ml
@@ -126,10 +126,10 @@ let add_unfolds_to_terms preds terms =
 (*       else if List.Old.exists (Sym.equal nm) path *)
 (*       then Some (List.Old.rev path @ [nm]) *)
 (*       else *)
-(*         let deps = List.Old.map (fun p -> (p, Some (nm :: path))) (def_preds nm) in *)
+(*         let deps = List.map ~f:(fun p -> (p, Some (nm :: path))) (def_preds nm) in *)
 (*         search known_ok (deps @ [(nm, None)] @ q) *)
 (*     | (nm, None) :: q -> search (SymSet.add nm known_ok) q *)
-(*   in search SymSet.empty (List.Old.map (fun (p, _) -> (p, Some [])) (SymMap.bindings defs)) *)
+(*   in search SymSet.empty (List.map ~f:(fun (p, _) -> (p, Some [])) (SymMap.bindings defs)) *)
 
 
 

--- a/backend/cn/logicalReturnTypes.ml
+++ b/backend/cn/logicalReturnTypes.ml
@@ -23,9 +23,9 @@ let mResource (bound, info) t =
 let mConstraint (bound, info) t =
   Constraint (bound, info, t)
 
-let mDefines = List.fold_right mDefine
-let mResources = List.fold_right mResource
-let mConstraints = List.fold_right mConstraint
+let mDefines = List.Old.fold_right mDefine
+let mResources = List.Old.fold_right mResource
+let mConstraints = List.Old.fold_right mConstraint
 
 
 let rec subst (substitution: _ Subst.t) lrt =

--- a/backend/cn/memory.ml
+++ b/backend/cn/memory.ml
@@ -72,13 +72,13 @@ type struct_decls = struct_layout SymMap.t
 
 
 let members =
-  List.Old.filter_map (fun {member_or_padding; _} ->
+  List.filter_map ~f:(fun {member_or_padding; _} ->
       Option.map fst member_or_padding
     )
 
 
 let member_types =
-  List.Old.filter_map (fun {member_or_padding; _} ->
+  List.filter_map ~f:(fun {member_or_padding; _} ->
       member_or_padding
     )
 

--- a/backend/cn/memory.ml
+++ b/backend/cn/memory.ml
@@ -72,13 +72,13 @@ type struct_decls = struct_layout SymMap.t
 
 
 let members =
-  List.filter_map (fun {member_or_padding; _} ->
+  List.Old.filter_map (fun {member_or_padding; _} ->
       Option.map fst member_or_padding
     )
 
 
 let member_types =
-  List.filter_map (fun {member_or_padding; _} ->
+  List.Old.filter_map (fun {member_or_padding; _} ->
       member_or_padding
     )
 
@@ -100,7 +100,7 @@ let member_number layout member =
 
 
 let member_offset (layout : struct_layout) member : int option =
-  List.find_map (fun sp ->
+  List.Old.find_map (fun sp ->
       match sp.member_or_padding with
       | Some (member', _) when Id.equal member member' -> Some sp.offset
       | _ -> None

--- a/backend/cn/mucore.ml
+++ b/backend/cn/mucore.ml
@@ -404,7 +404,7 @@ let evaluate_fun mu_fun args =
         Option.bind (IT.is_bits_const arg2) (fun (bits_info, i) ->
             assert (BaseTypes.fits_range bits_info i);
             if Z.lt i (Z.of_int (List.length xs)) && Z.leq Z.zero i
-            then Option.bind (List.Old.nth_opt xs (Z.to_int i)) (fun it -> Some (`Result_IT it))
+            then Option.bind (List.nth xs (Z.to_int i)) (fun it -> Some (`Result_IT it))
             else None
         ))
      | _ -> None

--- a/backend/cn/mucore.ml
+++ b/backend/cn/mucore.ml
@@ -394,7 +394,7 @@ let evaluate_fun mu_fun args =
      begin match args with
      | [arg] ->
         Option.bind (IT.dest_list arg) (fun xs ->
-        Some (`Result_Integer (Z.of_int (List.Old.length xs))))
+        Some (`Result_Integer (Z.of_int (List.length xs))))
      | _ -> None
      end
   | M_F_params_nth ->
@@ -403,7 +403,7 @@ let evaluate_fun mu_fun args =
         Option.bind (IT.dest_list arg1) (fun xs ->
         Option.bind (IT.is_bits_const arg2) (fun (bits_info, i) ->
             assert (BaseTypes.fits_range bits_info i);
-            if Z.lt i (Z.of_int (List.Old.length xs)) && Z.leq Z.zero i
+            if Z.lt i (Z.of_int (List.length xs)) && Z.leq Z.zero i
             then Option.bind (List.Old.nth_opt xs (Z.to_int i)) (fun it -> Some (`Result_IT it))
             else None
         ))

--- a/backend/cn/mucore.ml
+++ b/backend/cn/mucore.ml
@@ -314,8 +314,8 @@ let mResource (bound, info) t = M_Resource (bound, info, t)
 let mConstraint (lc, info) t = M_Constraint (lc, info, t)
 let mComputational (bound, info) t = M_Computational (bound, info, t)
 
-let mConstraints lcs t = List.fold_right mConstraint lcs t
-let mResources res t = List.fold_right mResource res t
+let mConstraints lcs t = List.Old.fold_right mConstraint lcs t
+let mResources res t = List.Old.fold_right mResource res t
 
 let mu_fun_param_types mu_fun =
   let open BaseTypes in
@@ -394,7 +394,7 @@ let evaluate_fun mu_fun args =
      begin match args with
      | [arg] ->
         Option.bind (IT.dest_list arg) (fun xs ->
-        Some (`Result_Integer (Z.of_int (List.length xs))))
+        Some (`Result_Integer (Z.of_int (List.Old.length xs))))
      | _ -> None
      end
   | M_F_params_nth ->
@@ -403,47 +403,47 @@ let evaluate_fun mu_fun args =
         Option.bind (IT.dest_list arg1) (fun xs ->
         Option.bind (IT.is_bits_const arg2) (fun (bits_info, i) ->
             assert (BaseTypes.fits_range bits_info i);
-            if Z.lt i (Z.of_int (List.length xs)) && Z.leq Z.zero i
-            then Option.bind (List.nth_opt xs (Z.to_int i)) (fun it -> Some (`Result_IT it))
+            if Z.lt i (Z.of_int (List.Old.length xs)) && Z.leq Z.zero i
+            then Option.bind (List.Old.nth_opt xs (Z.to_int i)) (fun it -> Some (`Result_IT it))
             else None
         ))
      | _ -> None
      end
   | M_F_are_compatible ->
-     begin match List.map IT.is_const args with
+     begin match List.Old.map IT.is_const args with
      | [Some (IT.CType_const ct1, _); Some (IT.CType_const ct2, _)] ->
         if Sctypes.equal ct1 ct2
         then Some (`Result_IT (IT.bool_ true here)) else None
      | _ -> None
      end
   | M_F_size_of ->
-     begin match List.map IT.is_const args with
+     begin match List.Old.map IT.is_const args with
      | [Some (IT.CType_const ct, _)] ->
         Some (`Result_Integer (Z.of_int (Memory.size_of_ctype ct)))
      | _ -> None
      end
   | M_F_align_of ->
-     begin match List.map IT.is_const args with
+     begin match List.Old.map IT.is_const args with
      | [Some (IT.CType_const ct, _)] ->
         Some (`Result_Integer (Z.of_int (Memory.align_of_ctype ct)))
      | _ -> None
      end
   | M_F_max_int ->
-     begin match List.map IT.is_const args with
+     begin match List.Old.map IT.is_const args with
      | [Some (IT.CType_const (Sctypes.Integer ity), _)] ->
         let bt = Memory.bt_of_sct (Sctypes.Integer ity) in
         Some (`Result_IT (IT.num_lit_ (Memory.max_integer_type ity) bt here))
      | _ -> None
      end
   | M_F_min_int ->
-     begin match List.map IT.is_const args with
+     begin match List.Old.map IT.is_const args with
      | [Some (IT.CType_const (Sctypes.Integer ity), _)] ->
         let bt = Memory.bt_of_sct (Sctypes.Integer ity) in
         Some (`Result_IT (IT.num_lit_ (Memory.min_integer_type ity) bt here))
      | _ -> None
      end
   | M_F_ctype_width ->
-     begin match List.map IT.is_const args with
+     begin match List.Old.map IT.is_const args with
      | [Some (IT.CType_const ct, _)] ->
         Some (`Result_Integer (Z.of_int (Memory.size_of_ctype ct * 8)))
      | _ -> None

--- a/backend/cn/mucore.ml
+++ b/backend/cn/mucore.ml
@@ -410,40 +410,40 @@ let evaluate_fun mu_fun args =
      | _ -> None
      end
   | M_F_are_compatible ->
-     begin match List.Old.map IT.is_const args with
+     begin match List.map ~f:IT.is_const args with
      | [Some (IT.CType_const ct1, _); Some (IT.CType_const ct2, _)] ->
         if Sctypes.equal ct1 ct2
         then Some (`Result_IT (IT.bool_ true here)) else None
      | _ -> None
      end
   | M_F_size_of ->
-     begin match List.Old.map IT.is_const args with
+     begin match List.map ~f:IT.is_const args with
      | [Some (IT.CType_const ct, _)] ->
         Some (`Result_Integer (Z.of_int (Memory.size_of_ctype ct)))
      | _ -> None
      end
   | M_F_align_of ->
-     begin match List.Old.map IT.is_const args with
+     begin match List.map ~f:IT.is_const args with
      | [Some (IT.CType_const ct, _)] ->
         Some (`Result_Integer (Z.of_int (Memory.align_of_ctype ct)))
      | _ -> None
      end
   | M_F_max_int ->
-     begin match List.Old.map IT.is_const args with
+     begin match List.map ~f:IT.is_const args with
      | [Some (IT.CType_const (Sctypes.Integer ity), _)] ->
         let bt = Memory.bt_of_sct (Sctypes.Integer ity) in
         Some (`Result_IT (IT.num_lit_ (Memory.max_integer_type ity) bt here))
      | _ -> None
      end
   | M_F_min_int ->
-     begin match List.Old.map IT.is_const args with
+     begin match List.map ~f:IT.is_const args with
      | [Some (IT.CType_const (Sctypes.Integer ity), _)] ->
         let bt = Memory.bt_of_sct (Sctypes.Integer ity) in
         Some (`Result_IT (IT.num_lit_ (Memory.min_integer_type ity) bt here))
      | _ -> None
      end
   | M_F_ctype_width ->
-     begin match List.Old.map IT.is_const args with
+     begin match List.map ~f:IT.is_const args with
      | [Some (IT.CType_const ct, _)] ->
         Some (`Result_Integer (Z.of_int (Memory.size_of_ctype ct * 8)))
      | _ -> None

--- a/backend/cn/ownership_exec.ml
+++ b/backend/cn/ownership_exec.ml
@@ -53,7 +53,7 @@ let create_ail_ownership_global_decls () =
 let get_ownership_global_init_stats () = 
   let cn_ghost_state_init_fcall = mk_expr A.(AilEcall (mk_expr (AilEident (Sym.fresh_pretty "initialise_ownership_ghost_state")), [])) in
   let cn_ghost_stack_depth_init_fcall = mk_expr A.(AilEcall (mk_expr (AilEident (Sym.fresh_pretty "initialise_ghost_stack_depth")), [])) in
-  List.Old.map (fun e -> A.(AilSexpr e)) [cn_ghost_state_init_fcall; cn_ghost_stack_depth_init_fcall]
+  List.map ~f:(fun e -> A.(AilSexpr e)) [cn_ghost_state_init_fcall; cn_ghost_stack_depth_init_fcall]
   
 
 (*   
@@ -64,7 +64,7 @@ let generate_c_local_ownership_entry_fcall (local_sym, local_ctype) =
   let local_ident = mk_expr A.(AilEident local_sym) in
   let arg1 = A.(AilEcast (empty_qualifiers, C.uintptr_t, mk_expr (AilEunary (Address, local_ident)))) in 
   let arg2 = A.(AilEsizeof (empty_qualifiers, local_ctype)) in 
-  mk_expr (AilEcall (mk_expr (AilEident c_map_local_ownership_fn_sym), List.Old.map mk_expr [arg1; arg2]))
+  mk_expr (AilEcall (mk_expr (AilEident c_map_local_ownership_fn_sym), List.map ~f:mk_expr [arg1; arg2]))
 
 
 (* 
@@ -85,7 +85,7 @@ let rec gen_loop_ownership_entry_decls bindings = function
       let entry_fcall = generate_c_local_ownership_entry_fcall (sym, ctype) in 
       let zero_const = A.(AilEconst (ConstantInteger (IConstant (Z.of_int 0, Decimal, None)))) in
       let dummy_rhs = mk_expr A.(AilEbinary (entry_fcall, Comma, mk_expr zero_const)) in 
-      let new_bindings = List.Old.map (fun sym -> create_binding sym ctype) [sym; dummy_sym] in 
+      let new_bindings = List.map ~f:(fun sym -> create_binding sym ctype) [sym; dummy_sym] in 
       let (bindings', decls') = gen_loop_ownership_entry_decls bindings xs in 
       (new_bindings @ bindings', (sym, expr_opt) :: (dummy_sym, Some dummy_rhs) :: decls')
 
@@ -94,7 +94,7 @@ let generate_c_local_ownership_entry_inj dest_is_loop loc decls bindings =
     (let (new_bindings, new_decls) = gen_loop_ownership_entry_decls bindings decls in
     [loc, new_bindings, [A.AilSdeclaration new_decls]])
   else 
-    (let stats_ = List.Old.map (fun (sym, _) -> 
+    (let stats_ = List.map ~f:(fun (sym, _) -> 
       let ctype = find_ctype_from_bindings bindings sym in 
       let entry_fcall = generate_c_local_ownership_entry_fcall (sym, ctype) in 
       A.(AilSexpr entry_fcall))
@@ -109,12 +109,12 @@ let generate_c_local_ownership_exit (local_sym, local_ctype) =
   let local_ident = mk_expr A.(AilEident local_sym) in
   let arg1 = A.(AilEcast (empty_qualifiers, C.uintptr_t, mk_expr (AilEunary (Address, local_ident)))) in 
   let arg2 = A.(AilEsizeof (empty_qualifiers, local_ctype)) in 
-  A.(AilSexpr (mk_expr A.(AilEcall (mk_expr (AilEident c_remove_local_ownership_fn_sym), List.Old.map mk_expr [arg1; arg2]))))
+  A.(AilSexpr (mk_expr A.(AilEcall (mk_expr (AilEident c_remove_local_ownership_fn_sym), List.map ~f:mk_expr [arg1; arg2]))))
 
 
 let get_c_local_ownership_checking params = 
-  let entry_ownership_stats = List.Old.map (fun param -> A.(AilSexpr (generate_c_local_ownership_entry_fcall param))) params in 
-  let exit_ownership_stats = List.Old.map generate_c_local_ownership_exit params in 
+  let entry_ownership_stats = List.map ~f:(fun param -> A.(AilSexpr (generate_c_local_ownership_entry_fcall param))) params in 
+  let exit_ownership_stats = List.map ~f:generate_c_local_ownership_exit params in 
   (entry_ownership_stats, exit_ownership_stats)
 
 
@@ -125,7 +125,7 @@ let rec collect_visibles bindings = function
     List.Old.iter (fun (b_sym, _) -> Printf.printf "%s\n" (Sym.pp_string b_sym)) bindings;
     Printf.printf "Decl syms: \n" ;
     List.Old.iter (fun (decl_sym, _) -> Printf.printf "%s\n" (Sym.pp_string decl_sym)) decls; *)
-    let decl_syms_and_ctypes = List.Old.map (fun (sym, _) -> (sym, find_ctype_from_bindings bindings sym)) decls in 
+    let decl_syms_and_ctypes = List.map ~f:(fun (sym, _) -> (sym, find_ctype_from_bindings bindings sym)) decls in 
     decl_syms_and_ctypes @ collect_visibles bindings ss
   | _ :: ss -> collect_visibles bindings ss
 
@@ -159,15 +159,15 @@ let rec get_c_control_flow_block_unmaps_aux break_vars continue_vars return_vars
     | AilSlabel (_, s, _) -> get_c_control_flow_block_unmaps_aux break_vars continue_vars return_vars bindings s
     | AilSgoto _ -> [] (* TODO *)
     | AilSreturnVoid ->
-      [(loc, Some (None), [], List.Old.map generate_c_local_ownership_exit return_vars)]
+      [(loc, Some (None), [], List.map ~f:generate_c_local_ownership_exit return_vars)]
     | AilSreturn e -> 
-      [(loc, Some (Some e), [], List.Old.map generate_c_local_ownership_exit return_vars)]
+      [(loc, Some (Some e), [], List.map ~f:generate_c_local_ownership_exit return_vars)]
     | AilScontinue ->
       let loc_before_continue = get_start_loc loc in 
-      [(loc_before_continue, None, [], List.Old.map generate_c_local_ownership_exit continue_vars)]
+      [(loc_before_continue, None, [], List.map ~f:generate_c_local_ownership_exit continue_vars)]
     | AilSbreak -> 
       let loc_before_break = get_start_loc loc in 
-      [(loc_before_break, None, [], List.Old.map generate_c_local_ownership_exit break_vars)]
+      [(loc_before_break, None, [], List.map ~f:generate_c_local_ownership_exit break_vars)]
     | AilSskip 
     | AilSexpr _
     | AilSpar _
@@ -191,9 +191,9 @@ let rec get_c_block_entry_exit_injs_aux bindings A.(AnnotatedStatement (loc, _, 
       let injs' = get_c_block_entry_exit_injs_aux [] s in 
       inj @ injs'
     | (AilSblock (bs, ss)) ->
-      let exit_injs = List.Old.map (fun (b_sym, ((_, _, _), _, _, b_ctype)) -> (get_end_loc ~offset:(-1) loc, [generate_c_local_ownership_exit (b_sym, b_ctype)])) bs in 
-      let exit_injs' = List.Old.map (fun (loc, stats) -> (loc, [], stats)) exit_injs in 
-      let stat_injs = List.Old.map (fun s -> get_c_block_entry_exit_injs_aux  bs s) ss in 
+      let exit_injs = List.map ~f:(fun (b_sym, ((_, _, _), _, _, b_ctype)) -> (get_end_loc ~offset:(-1) loc, [generate_c_local_ownership_exit (b_sym, b_ctype)])) bs in 
+      let exit_injs' = List.map ~f:(fun (loc, stats) -> (loc, [], stats)) exit_injs in 
+      let stat_injs = List.map ~f:(fun s -> get_c_block_entry_exit_injs_aux  bs s) ss in 
       (List.Old.concat stat_injs) @ exit_injs'
     | (AilSif (_, s1, s2)) -> 
       let injs = get_c_block_entry_exit_injs_aux bindings s1 in 
@@ -219,7 +219,7 @@ let rec get_c_block_entry_exit_injs_aux bindings A.(AnnotatedStatement (loc, _, 
 
 let get_c_block_entry_exit_injs stat = 
   let injs = get_c_block_entry_exit_injs_aux [] stat in 
-  List.Old.map (fun (loc, bs, ss) -> (loc, None, bs, ss)) injs
+  List.map ~f:(fun (loc, bs, ss) -> (loc, None, bs, ss)) injs
 
 let rec combine_injs_over_location loc = function 
   | [] -> []
@@ -249,9 +249,9 @@ let get_c_block_local_ownership_checking_injs A.(AnnotatedStatement (_, _, fn_bl
     let injs = get_c_block_entry_exit_injs statement in 
     let injs' = get_c_control_flow_block_unmaps statement in
     let injs = injs @ injs' in 
-    let locs = List.Old.map (fun (l, _, _, _) -> l) injs in 
+    let locs = List.map ~f:(fun (l, _, _, _) -> l) injs in 
     let locs = remove_duplicates [] locs in 
-    let combined_injs = List.Old.map (fun l -> 
+    let combined_injs = List.map ~f:(fun l -> 
       let injs' = combine_injs_over_location l injs in 
       let (expr_opt_list, bs_list, stats_list) = Executable_spec_utils.list_split_three injs' in 
       let return_expr_opt = get_return_expr_opt expr_opt_list in 
@@ -265,7 +265,7 @@ let get_c_block_local_ownership_checking_injs A.(AnnotatedStatement (_, _, fn_bl
 let get_c_fn_local_ownership_checking_injs sym (sigm : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma) = 
   match (List.Old.assoc_opt Sym.equal sym sigm.function_definitions, List.Old.assoc_opt Sym.equal sym sigm.declarations) with 
     | (Some (_, _, _, param_syms, fn_body), Some (_, _, Decl_function (_, _, param_types, _, _, _))) -> 
-      let param_types = List.Old.map (fun (_, ctype, _) -> ctype) param_types in
+      let param_types = List.map ~f:(fun (_, ctype, _) -> ctype) param_types in
       let params = List.Old.combine param_syms param_types in
       let ownership_stats_pair = get_c_local_ownership_checking params in
       let block_ownership_injs = get_c_block_local_ownership_checking_injs fn_body in 

--- a/backend/cn/ownership_exec.ml
+++ b/backend/cn/ownership_exec.ml
@@ -140,7 +140,7 @@ let rec get_c_control_flow_block_unmaps_aux break_vars continue_vars return_vars
   match s_ with 
     | A.(AilSdeclaration _) -> []
     | (AilSblock (bs, ss)) ->
-      let injs = List.Old.mapi (fun i s ->
+      let injs = List.mapi ~f:(fun i s ->
         let ss_ = take (i + 1) ss in 
         let visibles = collect_visibles (bs @ bindings) ss_ in 
         get_c_control_flow_block_unmaps_aux (visibles @ break_vars) (visibles @ continue_vars) (visibles @ return_vars) (bs @ bindings) s 

--- a/backend/cn/ownership_exec.ml
+++ b/backend/cn/ownership_exec.ml
@@ -122,9 +122,9 @@ let rec collect_visibles bindings = function
   | [] -> []
   | A.(AnnotatedStatement (_, _, AilSdeclaration decls)) :: ss -> 
     (* Printf.printf "Bindings: \n" ;
-    List.Old.iter (fun (b_sym, _) -> Printf.printf "%s\n" (Sym.pp_string b_sym)) bindings;
+    List.iter ~f:(fun (b_sym, _) -> Printf.printf "%s\n" (Sym.pp_string b_sym)) bindings;
     Printf.printf "Decl syms: \n" ;
-    List.Old.iter (fun (decl_sym, _) -> Printf.printf "%s\n" (Sym.pp_string decl_sym)) decls; *)
+    List.iter ~f:(fun (decl_sym, _) -> Printf.printf "%s\n" (Sym.pp_string decl_sym)) decls; *)
     let decl_syms_and_ctypes = List.map ~f:(fun (sym, _) -> (sym, find_ctype_from_bindings bindings sym)) decls in 
     decl_syms_and_ctypes @ collect_visibles bindings ss
   | _ :: ss -> collect_visibles bindings ss

--- a/backend/cn/ownership_exec.ml
+++ b/backend/cn/ownership_exec.ml
@@ -145,7 +145,7 @@ let rec get_c_control_flow_block_unmaps_aux break_vars continue_vars return_vars
         let visibles = collect_visibles (bs @ bindings) ss_ in 
         get_c_control_flow_block_unmaps_aux (visibles @ break_vars) (visibles @ continue_vars) (visibles @ return_vars) (bs @ bindings) s 
       ) ss in 
-      List.Old.concat injs
+      List.concat injs
     | (AilSif (_, s1, s2)) -> 
       let injs = get_c_control_flow_block_unmaps_aux break_vars continue_vars return_vars bindings s1 in 
       let injs' = get_c_control_flow_block_unmaps_aux break_vars continue_vars return_vars bindings s2  in 
@@ -194,7 +194,7 @@ let rec get_c_block_entry_exit_injs_aux bindings A.(AnnotatedStatement (loc, _, 
       let exit_injs = List.map ~f:(fun (b_sym, ((_, _, _), _, _, b_ctype)) -> (get_end_loc ~offset:(-1) loc, [generate_c_local_ownership_exit (b_sym, b_ctype)])) bs in 
       let exit_injs' = List.map ~f:(fun (loc, stats) -> (loc, [], stats)) exit_injs in 
       let stat_injs = List.map ~f:(fun s -> get_c_block_entry_exit_injs_aux  bs s) ss in 
-      (List.Old.concat stat_injs) @ exit_injs'
+      (List.concat stat_injs) @ exit_injs'
     | (AilSif (_, s1, s2)) -> 
       let injs = get_c_block_entry_exit_injs_aux bindings s1 in 
       let injs' = get_c_block_entry_exit_injs_aux bindings s2  in 
@@ -255,7 +255,7 @@ let get_c_block_local_ownership_checking_injs A.(AnnotatedStatement (_, _, fn_bl
       let injs' = combine_injs_over_location l injs in 
       let (expr_opt_list, bs_list, stats_list) = Executable_spec_utils.list_split_three injs' in 
       let return_expr_opt = get_return_expr_opt expr_opt_list in 
-      (l, return_expr_opt, List.Old.concat bs_list, List.Old.concat stats_list))
+      (l, return_expr_opt, List.concat bs_list, List.concat stats_list))
     locs in 
     combined_injs
   | _ -> Printf.printf "Ownership_exec: function body is not a block"; []

--- a/backend/cn/ownership_exec.ml
+++ b/backend/cn/ownership_exec.ml
@@ -266,7 +266,7 @@ let get_c_fn_local_ownership_checking_injs sym (sigm : CF.GenTypes.genTypeCatego
   match (List.Old.assoc_opt Sym.equal sym sigm.function_definitions, List.Old.assoc_opt Sym.equal sym sigm.declarations) with 
     | (Some (_, _, _, param_syms, fn_body), Some (_, _, Decl_function (_, _, param_types, _, _, _))) -> 
       let param_types = List.map ~f:(fun (_, ctype, _) -> ctype) param_types in
-      let params = List.Old.combine param_syms param_types in
+      let params = List.zip_exn param_syms param_types in
       let ownership_stats_pair = get_c_local_ownership_checking params in
       let block_ownership_injs = get_c_block_local_ownership_checking_injs fn_body in 
       (Some ownership_stats_pair, block_ownership_injs)

--- a/backend/cn/pack.ml
+++ b/backend/cn/pack.ml
@@ -163,7 +163,7 @@ let extractable_one (* global *) prove_or_model (predicate_name, index) (ret, O 
             (P { name = ret.name;
                 pointer = pointer_offset_ (ret.pointer,
                     mul_ (cast_ Memory.uintptr_bt ret.step loc, cast_ Memory.uintptr_bt index loc) loc) loc;
-                iargs = List.Old.map (IT.subst su) ret.iargs; },
+                iargs = List.map ~f:(IT.subst su) ret.iargs; },
             O  (map_get_ o index loc))
           in
           let ret_reduced =

--- a/backend/cn/pack.ml
+++ b/backend/cn/pack.ml
@@ -50,7 +50,7 @@ let packing_ft loc global provable ret =
       | Owned (Struct tag, init) ->
           let layout = SymMap.find tag global.Global.struct_decls in
           let lrt, value =
-            List.fold_right (fun {offset; size; member_or_padding} (lrt, value) ->
+            List.Old.fold_right (fun {offset; size; member_or_padding} (lrt, value) ->
               match member_or_padding with
               | Some (member, mct) ->
                 let request =
@@ -99,7 +99,7 @@ let unpack_owned loc global (ct, init) pointer (O o) =
   | Struct tag ->
     let layout = SymMap.find tag global.Global.struct_decls in
     let res =
-      List.fold_right (fun {offset; size; member_or_padding} res ->
+      List.Old.fold_right (fun {offset; size; member_or_padding} res ->
         match member_or_padding with
         | Some (member, mct) ->
           let mresource =
@@ -163,7 +163,7 @@ let extractable_one (* global *) prove_or_model (predicate_name, index) (ret, O 
             (P { name = ret.name;
                 pointer = pointer_offset_ (ret.pointer,
                     mul_ (cast_ Memory.uintptr_bt ret.step loc, cast_ Memory.uintptr_bt index loc) loc) loc;
-                iargs = List.map (IT.subst su) ret.iargs; },
+                iargs = List.Old.map (IT.subst su) ret.iargs; },
             O  (map_get_ o index loc))
           in
           let ret_reduced =

--- a/backend/cn/parse.ml
+++ b/backend/cn/parse.ml
@@ -68,15 +68,15 @@ let function_spec (Attrs attributes) =
     | (Cn.CN_trusted loc), _ ->
        fail {loc; msg= Generic !^"Please specify 'trusted' before other conditions"}
     | (CN_accesses (loc, ids)), (trusted, accs, [], [], ex) ->
-       return (trusted, accs @ List.Old.map (fun id -> (loc, id)) ids, [], [], ex)
+       return (trusted, accs @ List.map ~f:(fun id -> (loc, id)) ids, [], [], ex)
     | (CN_accesses (loc, _)), _ ->
        fail { loc; msg= Generic !^"Please specify 'accesses' before any 'requires' and 'ensures'" }
     | (CN_requires (loc, cond)), (trusted, accs, reqs, [], ex) ->
-       return (trusted, accs, reqs @ List.Old.map (fun c -> (loc, c)) cond, [], ex)
+       return (trusted, accs, reqs @ List.map ~f:(fun c -> (loc, c)) cond, [], ex)
     | (CN_requires (loc, _)), _ ->
        fail {loc; msg = Generic !^"Please specify 'requires' before any 'ensures'"}
     | (CN_ensures (loc, cond)), (trusted, accs, reqs, enss, ex) ->
-       return (trusted, accs, reqs, enss @ List.Old.map (fun c -> (loc, c)) cond, ex)
+       return (trusted, accs, reqs, enss @ List.map ~f:(fun c -> (loc, c)) cond, ex)
     | (CN_mk_function (loc, nm)), (trusted, accs, reqs, enss, ex) ->
        return (trusted, accs, reqs, enss, ex @ [(loc, Mucore.Make_Logical_Function nm)])
     )

--- a/backend/cn/parse.ml
+++ b/backend/cn/parse.ml
@@ -58,7 +58,7 @@ let cn_statements annots =
 
 let function_spec (Attrs attributes) =
   let@ conditions =
-    [Aattrs (Attrs (List.Old.rev attributes))]
+    [Aattrs (Attrs (List.rev attributes))]
     |> get_cerb_magic_attr
     |> ListM.concat_mapM (parse C_parser.function_spec) in
   ListM.fold_leftM (fun acc cond ->

--- a/backend/cn/parse.ml
+++ b/backend/cn/parse.ml
@@ -58,7 +58,7 @@ let cn_statements annots =
 
 let function_spec (Attrs attributes) =
   let@ conditions =
-    [Aattrs (Attrs (List.rev attributes))]
+    [Aattrs (Attrs (List.Old.rev attributes))]
     |> get_cerb_magic_attr
     |> ListM.concat_mapM (parse C_parser.function_spec) in
   ListM.fold_leftM (fun acc cond ->
@@ -68,15 +68,15 @@ let function_spec (Attrs attributes) =
     | (Cn.CN_trusted loc), _ ->
        fail {loc; msg= Generic !^"Please specify 'trusted' before other conditions"}
     | (CN_accesses (loc, ids)), (trusted, accs, [], [], ex) ->
-       return (trusted, accs @ List.map (fun id -> (loc, id)) ids, [], [], ex)
+       return (trusted, accs @ List.Old.map (fun id -> (loc, id)) ids, [], [], ex)
     | (CN_accesses (loc, _)), _ ->
        fail { loc; msg= Generic !^"Please specify 'accesses' before any 'requires' and 'ensures'" }
     | (CN_requires (loc, cond)), (trusted, accs, reqs, [], ex) ->
-       return (trusted, accs, reqs @ List.map (fun c -> (loc, c)) cond, [], ex)
+       return (trusted, accs, reqs @ List.Old.map (fun c -> (loc, c)) cond, [], ex)
     | (CN_requires (loc, _)), _ ->
        fail {loc; msg = Generic !^"Please specify 'requires' before any 'ensures'"}
     | (CN_ensures (loc, cond)), (trusted, accs, reqs, enss, ex) ->
-       return (trusted, accs, reqs, enss @ List.map (fun c -> (loc, c)) cond, ex)
+       return (trusted, accs, reqs, enss @ List.Old.map (fun c -> (loc, c)) cond, ex)
     | (CN_mk_function (loc, nm)), (trusted, accs, reqs, enss, ex) ->
        return (trusted, accs, reqs, enss, ex @ [(loc, Mucore.Make_Logical_Function nm)])
     )

--- a/backend/cn/pp.ml
+++ b/backend/cn/pp.ml
@@ -155,7 +155,7 @@ let commas l = list (fun pp -> pp) l
 *)
 
 let list_filtered f l =
-  match List.filter_map f l with
+  match List.Old.filter_map f l with
   | [] -> !^"(empty)"
   | l -> flow (comma ^^ break 1) l
 
@@ -168,7 +168,7 @@ let option f none_msg opt = match opt with
 (*
 let nats n =
   let rec aux n = if n < 0 then [] else n :: aux (n - 1) in
-  List.rev (aux n)
+  List.Old.rev (aux n)
 *)
 
 (* module IntMap = Map.Make(Int) *)
@@ -270,7 +270,7 @@ let error (loc : Locations.t) (msg : document) extras =
                 format [Bold; Red] "error:" ^^^
                 format [Bold] @@ plain msg);
   if Locations.is_unknown_location loc then () else print stderr !^pos;
-  List.iter (fun pp -> print stderr pp) extras
+  List.Old.iter (fun pp -> print stderr pp) extras
 
 
 (* stealing some logic from pp_errors *)

--- a/backend/cn/pp.ml
+++ b/backend/cn/pp.ml
@@ -168,7 +168,7 @@ let option f none_msg opt = match opt with
 (*
 let nats n =
   let rec aux n = if n < 0 then [] else n :: aux (n - 1) in
-  List.Old.rev (aux n)
+  List.rev (aux n)
 *)
 
 (* module IntMap = Map.Make(Int) *)

--- a/backend/cn/pp.ml
+++ b/backend/cn/pp.ml
@@ -155,7 +155,7 @@ let commas l = list (fun pp -> pp) l
 *)
 
 let list_filtered f l =
-  match List.Old.filter_map f l with
+  match List.filter_map ~f:f l with
   | [] -> !^"(empty)"
   | l -> flow (comma ^^ break 1) l
 

--- a/backend/cn/pp.ml
+++ b/backend/cn/pp.ml
@@ -270,7 +270,7 @@ let error (loc : Locations.t) (msg : document) extras =
                 format [Bold; Red] "error:" ^^^
                 format [Bold] @@ plain msg);
   if Locations.is_unknown_location loc then () else print stderr !^pos;
-  List.Old.iter (fun pp -> print stderr pp) extras
+  List.iter ~f:(fun pp -> print stderr pp) extras
 
 
 (* stealing some logic from pp_errors *)

--- a/backend/cn/pp_mucore.ml
+++ b/backend/cn/pp_mucore.ml
@@ -386,7 +386,7 @@ module Make (Config: CONFIG) = struct
           | M_PEop (bop, pe1, pe2) ->
               pp_pexpr pe1 ^^^ pp_binop bop ^^^ pp_pexpr pe2
           | M_PEapply_fun (f, args) ->
-              Pp.c_app (pp_function f) (List.Old.map pp_pexpr args)
+              Pp.c_app (pp_function f) (List.map ~f:pp_pexpr args)
           | M_PEstruct (tag_sym, xs) ->
               P.parens (pp_const "struct" ^^^ pp_raw_symbol tag_sym) ^^
               P.braces (
@@ -629,7 +629,7 @@ module Make (Config: CONFIG) = struct
                 P.parens (comma_list pp_actype_or_pexpr (Right pe :: (map (fun pe -> Right pe)) pes))
           | M_CN_progs (_, stmts) -> pp_keyword "cn_prog" ^^ P.parens
               (* use the AST printer to at least print something, TODO improve *)
-              (Pp.list Pp_ast.pp_doc_tree (List.Old.map Cnprog.dtree stmts))
+              (Pp.list Pp_ast.pp_doc_tree (List.map ~f:Cnprog.dtree stmts))
           | M_Eunseq es ->
               pp_control "unseq" ^^ P.parens (comma_list pp es)
           | M_Elet (pat, pe1, e2) ->
@@ -662,7 +662,7 @@ module Make (Config: CONFIG) = struct
           | M_Ebound e ->
               Pp.c_app (pp_keyword "bound") [pp e]
           | M_Erun (sym, pes) ->
-              pp_keyword "run" ^^^ Pp.c_app (pp_symbol sym) (List.Old.map pp_pexpr pes)
+              pp_keyword "run" ^^^ Pp.c_app (pp_symbol sym) (List.map ~f:pp_pexpr pes)
         end
       end
       in pp budget expr

--- a/backend/cn/pp_mucore.ml
+++ b/backend/cn/pp_mucore.ml
@@ -386,7 +386,7 @@ module Make (Config: CONFIG) = struct
           | M_PEop (bop, pe1, pe2) ->
               pp_pexpr pe1 ^^^ pp_binop bop ^^^ pp_pexpr pe2
           | M_PEapply_fun (f, args) ->
-              Pp.c_app (pp_function f) (List.map pp_pexpr args)
+              Pp.c_app (pp_function f) (List.Old.map pp_pexpr args)
           | M_PEstruct (tag_sym, xs) ->
               P.parens (pp_const "struct" ^^^ pp_raw_symbol tag_sym) ^^
               P.braces (
@@ -518,7 +518,7 @@ module Make (Config: CONFIG) = struct
 
   let pp_annots annots =
     Pp.flow_map (Pp.break 0) (fun annot -> !^"{-#" ^^ annot ^^ !^"#-}")
-      (List.concat_map pp_str_annot annots)
+      (List.Old.concat_map pp_str_annot annots)
 
   let do_annots annot doc = pp_annots annot ^^ doc
 
@@ -629,7 +629,7 @@ module Make (Config: CONFIG) = struct
                 P.parens (comma_list pp_actype_or_pexpr (Right pe :: (map (fun pe -> Right pe)) pes))
           | M_CN_progs (_, stmts) -> pp_keyword "cn_prog" ^^ P.parens
               (* use the AST printer to at least print something, TODO improve *)
-              (Pp.list Pp_ast.pp_doc_tree (List.map Cnprog.dtree stmts))
+              (Pp.list Pp_ast.pp_doc_tree (List.Old.map Cnprog.dtree stmts))
           | M_Eunseq es ->
               pp_control "unseq" ^^ P.parens (comma_list pp es)
           | M_Elet (pat, pe1, e2) ->
@@ -662,7 +662,7 @@ module Make (Config: CONFIG) = struct
           | M_Ebound e ->
               Pp.c_app (pp_keyword "bound") [pp e]
           | M_Erun (sym, pes) ->
-              pp_keyword "run" ^^^ Pp.c_app (pp_symbol sym) (List.map pp_pexpr pes)
+              pp_keyword "run" ^^^ Pp.c_app (pp_symbol sym) (List.Old.map pp_pexpr pes)
         end
       end
       in pp budget expr
@@ -764,7 +764,7 @@ module Make (Config: CONFIG) = struct
     )
 
   let pp_globs budget globs =
-    List.fold_left (fun acc (sym, decl) ->
+    List.Old.fold_left (fun acc (sym, decl) ->
         match decl with
         | M_GlobalDef (gt, e) ->
           acc ^^ pp_keyword "glob" ^^^ pp_symbol sym ^^ P.colon ^^^

--- a/backend/cn/pp_mucore.ml
+++ b/backend/cn/pp_mucore.ml
@@ -518,7 +518,7 @@ module Make (Config: CONFIG) = struct
 
   let pp_annots annots =
     Pp.flow_map (Pp.break 0) (fun annot -> !^"{-#" ^^ annot ^^ !^"#-}")
-      (List.Old.concat_map pp_str_annot annots)
+      (List.concat_map ~f:pp_str_annot annots)
 
   let do_annots annot doc = pp_annots annot ^^ doc
 

--- a/backend/cn/pp_mucore_ast.ml
+++ b/backend/cn/pp_mucore_ast.ml
@@ -46,7 +46,7 @@ module PP = struct
         Dleaf (pp_pure_ctor "OVpointer" ^^^ Impl_mem.pp_pointer_value ptrval)
     | M_OVarray lvals ->
         Dnode ( pp_pure_ctor "OVarray"
-              , List.map dtree_of_object_value lvals)
+              , List.Old.map dtree_of_object_value lvals)
     | M_OVstruct (_tag_sym, _xs) ->
         Dleaf (pp_pure_ctor "OVstruct" ^^^ !^ (ansi_format [Red] "TODO"))
     | M_OVunion (_tag_sym, _membr_ident, _mval) ->
@@ -91,7 +91,7 @@ module PP = struct
         | M_PEconstrained _xs ->
             Dleaf (pp_ctor "PEconstrained" ^^^ !^ (ansi_format [Red] "TODO"))
         | M_PEctor (ctor, pes) ->
-            Dnode (pp_ctor "PEctor", [Dleaf (Pp_mucore.Basic.pp_ctor ctor)] @ List.map self pes)
+            Dnode (pp_ctor "PEctor", [Dleaf (Pp_mucore.Basic.pp_ctor ctor)] @ List.Old.map self pes)
         | M_PEarray_shift (_pe1, _ty, _pe2) ->
             Dleaf (pp_ctor "PEarray_shift" ^^^ !^ (ansi_format [Red] "TODO"))
         | M_PEmember_shift (_pe, _sym, _ident) ->
@@ -121,8 +121,8 @@ module PP = struct
         | [], dtree -> dtree
         | annots, Dnode (nm, xs) ->
             Dnode (nm, xs @ [Dnode (pp_ctor "Annot",
-                List.map (fun ann -> Dleaf ann)
-                    (List.concat_map Pp_mucore.Basic.pp_str_annot annots))])
+                List.Old.map (fun ann -> Dleaf ann)
+                    (List.Old.concat_map Pp_mucore.Basic.pp_str_annot annots))])
         | _, dtree -> dtree
     in
     self pexpr
@@ -244,7 +244,7 @@ module PP = struct
                                     ; dtree_of_expr e2 ] )
       | M_Erun (_l, asyms) ->
          Dnode ( pp_pure_ctor "Erun"
-               , List.map dtree_of_pexpr asyms)
+               , List.Old.map dtree_of_pexpr asyms)
 
       | M_Ebound e ->
           Dnode (pp_ctor "Ebound", [dtree_of_expr e])
@@ -264,7 +264,7 @@ module PP = struct
     let aux (sym, tagDef) =
       Pp_ail_ast.dtree_of_tag_definition (sym, (Cerb_location.unknown, Annot.no_attributes, tagDef)) in
     Dnode ( pp_field ".tagDefs"
-          , List.map aux (Pmap.bindings_list xs) )
+          , List.Old.map aux (Pmap.bindings_list xs) )
 
   let dtree_of_funinfo xs =
     let pp_ctype (Ctype.Ctype (annots, _) as ty) =
@@ -296,7 +296,7 @@ module PP = struct
              pp_ctype ty)
     in
     Dnode ( pp_field ".funinfo"
-          , List.map aux (Pmap.bindings_list xs) )
+          , List.Old.map aux (Pmap.bindings_list xs) )
 
   let dtree_of_globs xs =
     let aux (sym, glob) =
@@ -308,7 +308,7 @@ module PP = struct
           Dnode ( pp_field "GlobalDecl" ^^^ pp_symbol sym
                 , [Dleaf (Pp_typ.pp_ct ct)] )
     in
-    Dnode (pp_field ".globs", List.map aux xs)
+    Dnode (pp_field ".globs", List.Old.map aux xs)
 
   let dtree_of_label l def =
     match def with
@@ -338,7 +338,7 @@ module PP = struct
             Dleaf ( pp_field "ProcDecl" ^^^ pp_symbol sym (* TODO: spec *))
     in
     Dnode ( pp_field ".funs"
-          , List.map aux (Pmap.bindings_list xs) )
+          , List.Old.map aux (Pmap.bindings_list xs) )
 
   let pp_file file =
     pp_doc_tree begin

--- a/backend/cn/pp_mucore_ast.ml
+++ b/backend/cn/pp_mucore_ast.ml
@@ -46,7 +46,7 @@ module PP = struct
         Dleaf (pp_pure_ctor "OVpointer" ^^^ Impl_mem.pp_pointer_value ptrval)
     | M_OVarray lvals ->
         Dnode ( pp_pure_ctor "OVarray"
-              , List.Old.map dtree_of_object_value lvals)
+              , List.map ~f:dtree_of_object_value lvals)
     | M_OVstruct (_tag_sym, _xs) ->
         Dleaf (pp_pure_ctor "OVstruct" ^^^ !^ (ansi_format [Red] "TODO"))
     | M_OVunion (_tag_sym, _membr_ident, _mval) ->
@@ -91,7 +91,7 @@ module PP = struct
         | M_PEconstrained _xs ->
             Dleaf (pp_ctor "PEconstrained" ^^^ !^ (ansi_format [Red] "TODO"))
         | M_PEctor (ctor, pes) ->
-            Dnode (pp_ctor "PEctor", [Dleaf (Pp_mucore.Basic.pp_ctor ctor)] @ List.Old.map self pes)
+            Dnode (pp_ctor "PEctor", [Dleaf (Pp_mucore.Basic.pp_ctor ctor)] @ List.map ~f:self pes)
         | M_PEarray_shift (_pe1, _ty, _pe2) ->
             Dleaf (pp_ctor "PEarray_shift" ^^^ !^ (ansi_format [Red] "TODO"))
         | M_PEmember_shift (_pe, _sym, _ident) ->
@@ -121,7 +121,7 @@ module PP = struct
         | [], dtree -> dtree
         | annots, Dnode (nm, xs) ->
             Dnode (nm, xs @ [Dnode (pp_ctor "Annot",
-                List.Old.map (fun ann -> Dleaf ann)
+                List.map ~f:(fun ann -> Dleaf ann)
                     (List.Old.concat_map Pp_mucore.Basic.pp_str_annot annots))])
         | _, dtree -> dtree
     in
@@ -244,7 +244,7 @@ module PP = struct
                                     ; dtree_of_expr e2 ] )
       | M_Erun (_l, asyms) ->
          Dnode ( pp_pure_ctor "Erun"
-               , List.Old.map dtree_of_pexpr asyms)
+               , List.map ~f:dtree_of_pexpr asyms)
 
       | M_Ebound e ->
           Dnode (pp_ctor "Ebound", [dtree_of_expr e])
@@ -264,7 +264,7 @@ module PP = struct
     let aux (sym, tagDef) =
       Pp_ail_ast.dtree_of_tag_definition (sym, (Cerb_location.unknown, Annot.no_attributes, tagDef)) in
     Dnode ( pp_field ".tagDefs"
-          , List.Old.map aux (Pmap.bindings_list xs) )
+          , List.map ~f:aux (Pmap.bindings_list xs) )
 
   let dtree_of_funinfo xs =
     let pp_ctype (Ctype.Ctype (annots, _) as ty) =
@@ -296,7 +296,7 @@ module PP = struct
              pp_ctype ty)
     in
     Dnode ( pp_field ".funinfo"
-          , List.Old.map aux (Pmap.bindings_list xs) )
+          , List.map ~f:aux (Pmap.bindings_list xs) )
 
   let dtree_of_globs xs =
     let aux (sym, glob) =
@@ -308,7 +308,7 @@ module PP = struct
           Dnode ( pp_field "GlobalDecl" ^^^ pp_symbol sym
                 , [Dleaf (Pp_typ.pp_ct ct)] )
     in
-    Dnode (pp_field ".globs", List.Old.map aux xs)
+    Dnode (pp_field ".globs", List.map ~f:aux xs)
 
   let dtree_of_label l def =
     match def with
@@ -338,7 +338,7 @@ module PP = struct
             Dleaf ( pp_field "ProcDecl" ^^^ pp_symbol sym (* TODO: spec *))
     in
     Dnode ( pp_field ".funs"
-          , List.Old.map aux (Pmap.bindings_list xs) )
+          , List.map ~f:aux (Pmap.bindings_list xs) )
 
   let pp_file file =
     pp_doc_tree begin

--- a/backend/cn/pp_mucore_ast.ml
+++ b/backend/cn/pp_mucore_ast.ml
@@ -122,7 +122,7 @@ module PP = struct
         | annots, Dnode (nm, xs) ->
             Dnode (nm, xs @ [Dnode (pp_ctor "Annot",
                 List.map ~f:(fun ann -> Dleaf ann)
-                    (List.Old.concat_map Pp_mucore.Basic.pp_str_annot annots))])
+                    (List.concat_map ~f:Pp_mucore.Basic.pp_str_annot annots))])
         | _, dtree -> dtree
     in
     self pexpr

--- a/backend/cn/report.ml
+++ b/backend/cn/report.ml
@@ -649,7 +649,7 @@ let read_file filename =
     | _ -> None
 
 let make filename source_filename_opt (report: report) =
-  let n_pages = List.Old.length report.trace in
+  let n_pages = List.length report.trace in
   assert (n_pages > 0);
 
   let _menu = div ~id:"menu"

--- a/backend/cn/report.ml
+++ b/backend/cn/report.ml
@@ -64,10 +64,10 @@ let div ?clss ?id elements =
 (* let pre code = enclose "pre" code *)
 (* let body elements = enclose "body" (list elements) *)
 let h i title body = list [enclose ("h"^string_of_int i) title; body]
-let table_row cols = enclose "tr" (list (List.Old.map (enclose "td") cols))
-let table_head_row cols = enclose "tr" (list (List.Old.map (enclose "th") cols))
+let table_row cols = enclose "tr" (list (List.map ~f:(enclose "td") cols))
+let table_head_row cols = enclose "tr" (list (List.map ~f:(enclose "th") cols))
 let table_head cols = enclose "thead" (table_head_row cols)
-let table_body rows = enclose "tbody" (list (List.Old.map table_row rows))
+let table_body rows = enclose "tbody" (list (List.map ~f:table_row rows))
 let table head rows = enclose "table" (list [table_head head; table_body rows])
 let table_without_head rows = enclose "table" (list [table_body rows])
 let details summary more = enclose "details" (list [enclose "summary" summary; more])
@@ -122,7 +122,7 @@ let make_predicate_hints predicate_hints =
   lguard predicate_hints (fun predicate_hints ->
     h 1 "Possibly relevant predicate clauses" (
       table ["condition"; "clause"]
-        (List.Old.map (fun pce -> [Pp.plain pce.cond; Pp.plain pce.clause]) predicate_hints)
+        (List.map ~f:(fun pce -> [Pp.plain pce.cond; Pp.plain pce.clause]) predicate_hints)
     )
   )
 
@@ -132,7 +132,7 @@ let make_predicate_hints predicate_hints =
 (*     | [] -> "(no available resources)" *)
 (*     | _ -> *)
 (*       table ["resource"; "byte span and match"] *)
-(*         (List.Old.map (fun re -> [Pp.plain re.res; Pp.plain re.res_span]) resources) *)
+(*         (List.map ~f:(fun re -> [Pp.plain re.res; Pp.plain re.res_span]) resources) *)
 (*   ) *)
 
 
@@ -150,7 +150,7 @@ let interesting_uninteresting
 
 
 let make_resources (interesting, uninteresting) =
-  let make = List.Old.map (fun re -> [Pp.plain re; (* Pp.plain re.res_span *)]) in
+  let make = List.map ~f:(fun re -> [Pp.plain re; (* Pp.plain re.res_span *)]) in
   let interesting_table = table_without_head (make interesting) in
   let uninteresting_table = table_without_head (make uninteresting) in
   h 1 "Available resources" (
@@ -162,7 +162,7 @@ let make_resources (interesting, uninteresting) =
 
 
 let make_terms (interesting, uninteresting) =
-  let make = List.Old.map (fun v -> [Pp.plain v.term; Pp.plain v.value]) in
+  let make = List.map ~f:(fun v -> [Pp.plain v.term; Pp.plain v.value]) in
   let interesting_table = table ["term"; "value"] (make interesting) in
   let uninteresting_table = table ["term"; "value"] (make uninteresting) in
   h 1 "Terms" 
@@ -171,7 +171,7 @@ let make_terms (interesting, uninteresting) =
        (uninteresting_table, uninteresting))
 
 let make_constraints (interesting, uninteresting) =
-  let make = List.Old.map (fun c -> [Pp.plain c]) in
+  let make = List.map ~f:(fun c -> [Pp.plain c]) in
   let interesting_table = table_without_head (make interesting) in
   let uninteresting_table = table_without_head (make uninteresting) in
   h 1 "Constraints"
@@ -659,7 +659,7 @@ let make filename source_filename_opt (report: report) =
     ; {|<input type="button" value="last" onclick="goto_page(|} ^ string_of_int n_pages ^ {|)"/>|} ] in
 
   let pages = div ~id:"pages" begin
-    List.Old.map (fun state ->
+    List.map ~f:(fun state ->
       make_state
         state
         report.requested

--- a/backend/cn/report.ml
+++ b/backend/cn/report.ml
@@ -64,10 +64,10 @@ let div ?clss ?id elements =
 (* let pre code = enclose "pre" code *)
 (* let body elements = enclose "body" (list elements) *)
 let h i title body = list [enclose ("h"^string_of_int i) title; body]
-let table_row cols = enclose "tr" (list (List.map (enclose "td") cols))
-let table_head_row cols = enclose "tr" (list (List.map (enclose "th") cols))
+let table_row cols = enclose "tr" (list (List.Old.map (enclose "td") cols))
+let table_head_row cols = enclose "tr" (list (List.Old.map (enclose "th") cols))
 let table_head cols = enclose "thead" (table_head_row cols)
-let table_body rows = enclose "tbody" (list (List.map table_row rows))
+let table_body rows = enclose "tbody" (list (List.Old.map table_row rows))
 let table head rows = enclose "table" (list [table_head head; table_body rows])
 let table_without_head rows = enclose "table" (list [table_body rows])
 let details summary more = enclose "details" (list [enclose "summary" summary; more])
@@ -122,7 +122,7 @@ let make_predicate_hints predicate_hints =
   lguard predicate_hints (fun predicate_hints ->
     h 1 "Possibly relevant predicate clauses" (
       table ["condition"; "clause"]
-        (List.map (fun pce -> [Pp.plain pce.cond; Pp.plain pce.clause]) predicate_hints)
+        (List.Old.map (fun pce -> [Pp.plain pce.cond; Pp.plain pce.clause]) predicate_hints)
     )
   )
 
@@ -132,7 +132,7 @@ let make_predicate_hints predicate_hints =
 (*     | [] -> "(no available resources)" *)
 (*     | _ -> *)
 (*       table ["resource"; "byte span and match"] *)
-(*         (List.map (fun re -> [Pp.plain re.res; Pp.plain re.res_span]) resources) *)
+(*         (List.Old.map (fun re -> [Pp.plain re.res; Pp.plain re.res_span]) resources) *)
 (*   ) *)
 
 
@@ -150,7 +150,7 @@ let interesting_uninteresting
 
 
 let make_resources (interesting, uninteresting) =
-  let make = List.map (fun re -> [Pp.plain re; (* Pp.plain re.res_span *)]) in
+  let make = List.Old.map (fun re -> [Pp.plain re; (* Pp.plain re.res_span *)]) in
   let interesting_table = table_without_head (make interesting) in
   let uninteresting_table = table_without_head (make uninteresting) in
   h 1 "Available resources" (
@@ -162,7 +162,7 @@ let make_resources (interesting, uninteresting) =
 
 
 let make_terms (interesting, uninteresting) =
-  let make = List.map (fun v -> [Pp.plain v.term; Pp.plain v.value]) in
+  let make = List.Old.map (fun v -> [Pp.plain v.term; Pp.plain v.value]) in
   let interesting_table = table ["term"; "value"] (make interesting) in
   let uninteresting_table = table ["term"; "value"] (make uninteresting) in
   h 1 "Terms" 
@@ -171,7 +171,7 @@ let make_terms (interesting, uninteresting) =
        (uninteresting_table, uninteresting))
 
 let make_constraints (interesting, uninteresting) =
-  let make = List.map (fun c -> [Pp.plain c]) in
+  let make = List.Old.map (fun c -> [Pp.plain c]) in
   let interesting_table = table_without_head (make interesting) in
   let uninteresting_table = table_without_head (make uninteresting) in
   h 1 "Constraints"
@@ -649,7 +649,7 @@ let read_file filename =
     | _ -> None
 
 let make filename source_filename_opt (report: report) =
-  let n_pages = List.length report.trace in
+  let n_pages = List.Old.length report.trace in
   assert (n_pages > 0);
 
   let _menu = div ~id:"menu"
@@ -659,7 +659,7 @@ let make filename source_filename_opt (report: report) =
     ; {|<input type="button" value="last" onclick="goto_page(|} ^ string_of_int n_pages ^ {|)"/>|} ] in
 
   let pages = div ~id:"pages" begin
-    List.map (fun state ->
+    List.Old.map (fun state ->
       make_state
         state
         report.requested

--- a/backend/cn/resourceInference.ml
+++ b/backend/cn/resourceInference.ml
@@ -223,7 +223,7 @@ module General = struct
                     debug_failure
                       (Solver.model ())
                       "couldn't use resource"
-                      (and_ (eq_ (requested.pointer, p'.pointer) here :: List.Old.tl pmatch) here);
+                      (and_ (eq_ (requested.pointer, p'.pointer) here :: List.tl_exn pmatch) here);
                     continue
                   end
                 end

--- a/backend/cn/resourceInference.ml
+++ b/backend/cn/resourceInference.ml
@@ -188,7 +188,7 @@ module General = struct
                 let here = Locations.other __FUNCTION__ in
                 let pmatch =
                   eq_ ((pointerToIntegerCast_ requested.pointer) here, (pointerToIntegerCast_ p'.pointer here)) here
-                  :: List.Old.map2 (fun x y -> eq__ x y here) requested.iargs p'.iargs
+                  :: List.map2_exn ~f:(fun x y -> eq__ x y here) requested.iargs p'.iargs
                 in
                 let took = and_ pmatch here in
                 let prov =
@@ -293,7 +293,7 @@ module General = struct
                 let p' = alpha_rename_qpredicate_type_ (fst requested.q) p' in
                 let here = Locations.other __FUNCTION__ in
                 let pmatch = eq_ (requested.pointer, p'.pointer) here in
-                let iarg_match = and_ (List.Old.map2 (fun x y -> eq__ x y here) requested.iargs p'.iargs) here in
+                let iarg_match = and_ (List.map2_exn ~f:(fun x y -> eq__ x y here) requested.iargs p'.iargs) here in
                 let took = and_ [iarg_match; requested.permission; p'.permission] here in
                 begin match provable (LC.Forall (requested.q, not_ took here)) with
                 | `True -> continue

--- a/backend/cn/resourceInference.ml
+++ b/backend/cn/resourceInference.ml
@@ -334,7 +334,7 @@ module General = struct
                          pointer = pointer_offset_ (requested.pointer,
                              (mul_ (cast_ Memory.uintptr_bt requested.step here,
                                  cast_ Memory.uintptr_bt index here) here)) here;
-                         iargs = List.Old.map (IT.subst su) requested.iargs;
+                         iargs = List.map ~f:(IT.subst su) requested.iargs;
                        }
                    in
                    match o_re_index with

--- a/backend/cn/resourceInference.ml
+++ b/backend/cn/resourceInference.ml
@@ -76,12 +76,12 @@ module General = struct
   let cases_to_map loc (situation, requests) a_bt item_bt (C cases) =
     let here = Locations.other __FUNCTION__ in
     let update_with_ones base_array ones =
-      List.fold_left (fun m {one_index; value} ->
+      List.Old.fold_left (fun m {one_index; value} ->
           map_set_ m (one_index, value) here
         ) base_array ones
     in
     let ones, manys =
-      List.partition_map (function One c -> Left c | Many c -> Right c) cases in
+      List.Old.partition_map (function One c -> Left c | Many c -> Right c) cases in
     let@ base_value =
       match manys, item_bt with
       | [{many_guard = _; value}], _ ->
@@ -188,7 +188,7 @@ module General = struct
                 let here = Locations.other __FUNCTION__ in
                 let pmatch =
                   eq_ ((pointerToIntegerCast_ requested.pointer) here, (pointerToIntegerCast_ p'.pointer here)) here
-                  :: List.map2 (fun x y -> eq__ x y here) requested.iargs p'.iargs
+                  :: List.Old.map2 (fun x y -> eq__ x y here) requested.iargs p'.iargs
                 in
                 let took = and_ pmatch here in
                 let prov =
@@ -223,7 +223,7 @@ module General = struct
                     debug_failure
                       (Solver.model ())
                       "couldn't use resource"
-                      (and_ (eq_ (requested.pointer, p'.pointer) here :: List.tl pmatch) here);
+                      (and_ (eq_ (requested.pointer, p'.pointer) here :: List.Old.tl pmatch) here);
                     continue
                   end
                 end
@@ -293,7 +293,7 @@ module General = struct
                 let p' = alpha_rename_qpredicate_type_ (fst requested.q) p' in
                 let here = Locations.other __FUNCTION__ in
                 let pmatch = eq_ (requested.pointer, p'.pointer) here in
-                let iarg_match = and_ (List.map2 (fun x y -> eq__ x y here) requested.iargs p'.iargs) here in
+                let iarg_match = and_ (List.Old.map2 (fun x y -> eq__ x y here) requested.iargs p'.iargs) here in
                 let took = and_ [iarg_match; requested.permission; p'.permission] here in
                 begin match provable (LC.Forall (requested.q, not_ took here)) with
                 | `True -> continue
@@ -334,7 +334,7 @@ module General = struct
                          pointer = pointer_offset_ (requested.pointer,
                              (mul_ (cast_ Memory.uintptr_bt requested.step here,
                                  cast_ Memory.uintptr_bt index here) here)) here;
-                         iargs = List.map (IT.subst su) requested.iargs;
+                         iargs = List.Old.map (IT.subst su) requested.iargs;
                        }
                    in
                    match o_re_index with

--- a/backend/cn/resourcePredicates.ml
+++ b/backend/cn/resourcePredicates.ml
@@ -66,7 +66,7 @@ let instantiate_clauses def ptr_arg iargs = match def.clauses with
   | Some clauses ->
     let subst = IT.make_subst (
         (def.pointer, ptr_arg) ::
-        List.Old.map2 (fun (def_ia, _) ia -> (def_ia, ia)) def.iargs iargs
+        List.map2_exn ~f:(fun (def_ia, _) ia -> (def_ia, ia)) def.iargs iargs
       )
     in
     Some (List.map ~f:(subst_clause subst) clauses)

--- a/backend/cn/resourcePredicates.ml
+++ b/backend/cn/resourcePredicates.ml
@@ -66,10 +66,10 @@ let instantiate_clauses def ptr_arg iargs = match def.clauses with
   | Some clauses ->
     let subst = IT.make_subst (
         (def.pointer, ptr_arg) ::
-        List.map2 (fun (def_ia, _) ia -> (def_ia, ia)) def.iargs iargs
+        List.Old.map2 (fun (def_ia, _) ia -> (def_ia, ia)) def.iargs iargs
       )
     in
-    Some (List.map (subst_clause subst) clauses)
+    Some (List.Old.map (subst_clause subst) clauses)
   | None -> None
 
 

--- a/backend/cn/resourcePredicates.ml
+++ b/backend/cn/resourcePredicates.ml
@@ -69,7 +69,7 @@ let instantiate_clauses def ptr_arg iargs = match def.clauses with
         List.Old.map2 (fun (def_ia, _) ia -> (def_ia, ia)) def.iargs iargs
       )
     in
-    Some (List.Old.map (subst_clause subst) clauses)
+    Some (List.map ~f:(subst_clause subst) clauses)
   | None -> None
 
 

--- a/backend/cn/resourceTypes.ml
+++ b/backend/cn/resourceTypes.ml
@@ -78,7 +78,7 @@ let pp_maybe_oargs = function
 
 
 let pp_predicate_type_aux (p : predicate_type) oargs =
-  let args = List.map IT.pp (p.pointer :: p.iargs) in
+  let args = List.Old.map IT.pp (p.pointer :: p.iargs) in
   c_app (pp_predicate_name p.name) args
   ^^ pp_maybe_oargs oargs
 
@@ -91,7 +91,7 @@ let pp_qpredicate_type_aux (p : qpredicate_type) oargs =
     ^^^ star
     ^^^ IT.pp p.step
   in
-  let args = pointer :: List.map IT.pp (p.iargs) in
+  let args = pointer :: List.Old.map IT.pp (p.iargs) in
 
   !^"each" ^^
     parens (BT.pp (snd p.q) ^^^ Sym.pp (fst p.q) ^^ semi ^^^ IT.pp p.permission)
@@ -129,7 +129,7 @@ let alpha_rename_qpredicate_type_ (q' : Sym.t) (qp : qpredicate_type) =
     q_loc = qp.q_loc;
     step = qp.step;
     permission = IT.subst subst qp.permission;
-    iargs = List.map (IT.subst subst) qp.iargs;
+    iargs = List.Old.map (IT.subst subst) qp.iargs;
   }
 
 let alpha_rename_qpredicate_type qp =
@@ -140,7 +140,7 @@ let subst_predicate_type substitution (p : predicate_type) =
   {
     name = p.name;
     pointer = IT.subst substitution p.pointer;
-    iargs = List.map (IT.subst substitution) p.iargs;
+    iargs = List.Old.map (IT.subst substitution) p.iargs;
   }
 
 let subst_qpredicate_type substitution (qp : qpredicate_type) =
@@ -156,7 +156,7 @@ let subst_qpredicate_type substitution (qp : qpredicate_type) =
     q_loc = qp.q_loc;
     step = IT.subst substitution qp.step;
     permission = IT.subst substitution qp.permission;
-    iargs = List.map (IT.subst substitution) qp.iargs;
+    iargs = List.Old.map (IT.subst substitution) qp.iargs;
   }
 
 
@@ -222,7 +222,7 @@ let dtree_of_predicate_type (pred : predicate_type) =
   Dnode (pp_ctor "pred",
         dtree_of_predicate_name pred.name ::
         IT.dtree pred.pointer ::
-        List.map IT.dtree pred.iargs)
+        List.Old.map IT.dtree pred.iargs)
 
 let dtree_of_qpredicate_type (pred : qpredicate_type) =
   Dnode (pp_ctor "qpred",
@@ -231,7 +231,7 @@ let dtree_of_qpredicate_type (pred : qpredicate_type) =
         IT.dtree pred.permission ::
         dtree_of_predicate_name pred.name ::
         IT.dtree pred.pointer ::
-        List.map IT.dtree pred.iargs)
+        List.Old.map IT.dtree pred.iargs)
 
 
 let dtree = function

--- a/backend/cn/resourceTypes.ml
+++ b/backend/cn/resourceTypes.ml
@@ -78,7 +78,7 @@ let pp_maybe_oargs = function
 
 
 let pp_predicate_type_aux (p : predicate_type) oargs =
-  let args = List.Old.map IT.pp (p.pointer :: p.iargs) in
+  let args = List.map ~f:IT.pp (p.pointer :: p.iargs) in
   c_app (pp_predicate_name p.name) args
   ^^ pp_maybe_oargs oargs
 
@@ -91,7 +91,7 @@ let pp_qpredicate_type_aux (p : qpredicate_type) oargs =
     ^^^ star
     ^^^ IT.pp p.step
   in
-  let args = pointer :: List.Old.map IT.pp (p.iargs) in
+  let args = pointer :: List.map ~f:IT.pp (p.iargs) in
 
   !^"each" ^^
     parens (BT.pp (snd p.q) ^^^ Sym.pp (fst p.q) ^^ semi ^^^ IT.pp p.permission)
@@ -129,7 +129,7 @@ let alpha_rename_qpredicate_type_ (q' : Sym.t) (qp : qpredicate_type) =
     q_loc = qp.q_loc;
     step = qp.step;
     permission = IT.subst subst qp.permission;
-    iargs = List.Old.map (IT.subst subst) qp.iargs;
+    iargs = List.map ~f:(IT.subst subst) qp.iargs;
   }
 
 let alpha_rename_qpredicate_type qp =
@@ -140,7 +140,7 @@ let subst_predicate_type substitution (p : predicate_type) =
   {
     name = p.name;
     pointer = IT.subst substitution p.pointer;
-    iargs = List.Old.map (IT.subst substitution) p.iargs;
+    iargs = List.map ~f:(IT.subst substitution) p.iargs;
   }
 
 let subst_qpredicate_type substitution (qp : qpredicate_type) =
@@ -156,7 +156,7 @@ let subst_qpredicate_type substitution (qp : qpredicate_type) =
     q_loc = qp.q_loc;
     step = IT.subst substitution qp.step;
     permission = IT.subst substitution qp.permission;
-    iargs = List.Old.map (IT.subst substitution) qp.iargs;
+    iargs = List.map ~f:(IT.subst substitution) qp.iargs;
   }
 
 
@@ -222,7 +222,7 @@ let dtree_of_predicate_type (pred : predicate_type) =
   Dnode (pp_ctor "pred",
         dtree_of_predicate_name pred.name ::
         IT.dtree pred.pointer ::
-        List.Old.map IT.dtree pred.iargs)
+        List.map ~f:IT.dtree pred.iargs)
 
 let dtree_of_qpredicate_type (pred : qpredicate_type) =
   Dnode (pp_ctor "qpred",
@@ -231,7 +231,7 @@ let dtree_of_qpredicate_type (pred : qpredicate_type) =
         IT.dtree pred.permission ::
         dtree_of_predicate_name pred.name ::
         IT.dtree pred.pointer ::
-        List.Old.map IT.dtree pred.iargs)
+        List.map ~f:IT.dtree pred.iargs)
 
 
 let dtree = function

--- a/backend/cn/resources.ml
+++ b/backend/cn/resources.ml
@@ -61,7 +61,7 @@ let pointer_facts =
   let rec aux acc = function
     | [] -> acc
     | r :: rs ->
-       let acc = derived_lc1 r @ (List.Old.concat_map (derived_lc2 r) rs) @ acc in
+       let acc = derived_lc1 r @ (List.concat_map ~f:(derived_lc2 r) rs) @ acc in
        aux acc rs
   in
   fun resources -> aux [] resources

--- a/backend/cn/resources.ml
+++ b/backend/cn/resources.ml
@@ -61,7 +61,7 @@ let pointer_facts =
   let rec aux acc = function
     | [] -> acc
     | r :: rs ->
-       let acc = derived_lc1 r @ (List.concat_map (derived_lc2 r) rs) @ acc in
+       let acc = derived_lc1 r @ (List.Old.concat_map (derived_lc2 r) rs) @ acc in
        aux acc rs
   in
   fun resources -> aux [] resources

--- a/backend/cn/sctypes.ml
+++ b/backend/cn/sctypes.ml
@@ -135,7 +135,7 @@ let rec to_ctype (ct_ : ctype) =
        Struct t
     | Function ((ret_q,ret_ct), args, variadic) ->
        let args =
-         List.Old.map (fun (arg_ct, is_reg) ->
+         List.map ~f:(fun (arg_ct, is_reg) ->
              (Ctype.no_qualifiers, to_ctype arg_ct, is_reg)
            ) args
        in

--- a/backend/cn/sctypes.ml
+++ b/backend/cn/sctypes.ml
@@ -135,7 +135,7 @@ let rec to_ctype (ct_ : ctype) =
        Struct t
     | Function ((ret_q,ret_ct), args, variadic) ->
        let args =
-         List.map (fun (arg_ct, is_reg) ->
+         List.Old.map (fun (arg_ct, is_reg) ->
              (Ctype.no_qualifiers, to_ctype arg_ct, is_reg)
            ) args
        in

--- a/backend/cn/setup.ml
+++ b/backend/cn/setup.ml
@@ -14,13 +14,13 @@ let cpp_str macros_def incl_dirs incl_files =
       "-I " ^ Cerb_runtime.in_runtime "libcore";
       "-include " ^ Cerb_runtime.in_runtime "libc/include/builtins.h"
      ]
-     @ List.map (function
+     @ List.Old.map (function
         | (str1, None)      -> "-D" ^ str1
         | (str1, Some str2) -> "-D" ^ str1 ^ "=" ^ str2
       ) macros_def @
 
-       List.map (fun str -> "-I " ^ str) incl_dirs
-     @ List.map (fun str -> "-include " ^ str) incl_files
+       List.Old.map (fun str -> "-I " ^ str) incl_dirs
+     @ List.Old.map (fun str -> "-include " ^ str) incl_files
      @
        [" -DDEBUG -DCN_MODE";]
 

--- a/backend/cn/setup.ml
+++ b/backend/cn/setup.ml
@@ -14,13 +14,13 @@ let cpp_str macros_def incl_dirs incl_files =
       "-I " ^ Cerb_runtime.in_runtime "libcore";
       "-include " ^ Cerb_runtime.in_runtime "libc/include/builtins.h"
      ]
-     @ List.Old.map (function
+     @ List.map ~f:(function
         | (str1, None)      -> "-D" ^ str1
         | (str1, Some str2) -> "-D" ^ str1 ^ "=" ^ str2
       ) macros_def @
 
-       List.Old.map (fun str -> "-I " ^ str) incl_dirs
-     @ List.Old.map (fun str -> "-include " ^ str) incl_files
+       List.map ~f:(fun str -> "-I " ^ str) incl_dirs
+     @ List.map ~f:(fun str -> "-include " ^ str) incl_files
      @
        [" -DDEBUG -DCN_MODE";]
 

--- a/backend/cn/simple_smt.ml
+++ b/backend/cn/simple_smt.ml
@@ -638,7 +638,7 @@ let get_model s =
             | [] -> ()
            in
         arrange (List.map ~f:(fun (x,_,_) -> x) defs);
-        list (List.Old.rev !decls)
+        list (List.rev !decls)
 
 (** Get the values of some s-expressions. Only valid after a [Sat] result.
     Throws {!UnexpectedSolverResponse}. *)
@@ -747,7 +747,7 @@ let to_array (exp0: sexp): (sexp * sexp) list * sexp =
   let rec loop is exp =
       match exp with
       | Sexp.List [ Sexp.List [Sexp.Atom "as"; Sexp.Atom "const"; _]; k ] ->
-        (List.Old.rev is, k)
+        (List.rev is, k)
       | Sexp.List [Sexp.Atom "store"; a; i; v] ->
         loop ((i,v)::is) a
       | _ -> bad ()

--- a/backend/cn/simple_smt.ml
+++ b/backend/cn/simple_smt.ml
@@ -822,7 +822,7 @@ let model_eval (cfg: solver_config) (m: sexp) =
   | Sexp.Atom _ -> bad ()
   | Sexp.List defs ->
     let s = new_solver cfg in
-    List.Old.iter (ack_command s) defs;
+    List.iter ~f:(ack_command s) defs;
     let have_model = ref false in
     let get_model () =
           if !have_model
@@ -838,7 +838,7 @@ let model_eval (cfg: solver_config) (m: sexp) =
         let cleanup () = ack_command s (pop 1); have_model := false in
         ack_command s (push 1);
         let mk_def (f,ps,r,d) = ack_command s (define_fun f ps r d) in
-        List.Old.iter mk_def defs;
+        List.iter ~f:mk_def defs;
         have_model := false;
         if get_model ()
           then begin let res = get_expr s e in cleanup(); res end

--- a/backend/cn/simple_smt.ml
+++ b/backend/cn/simple_smt.ml
@@ -476,7 +476,7 @@ let declare_datatypes tys =
     | _  -> app_ "par" [ List (List.map ~f:atom type_params); mk_cons cons ]
   in
   let arity (name,ty_params,_) =
-        let n = List.Old.length ty_params in
+        let n = List.length ty_params in
         list [atom name; atom (string_of_int n) ]
   in
   app_ "declare-datatypes" [ list (List.map ~f:arity tys)

--- a/backend/cn/simplify.ml
+++ b/backend/cn/simplify.ml
@@ -459,11 +459,11 @@ module IndexTerms = struct
        | t3, IT (ITE _, _, _) when is_c t3 -> aux (eq_ (b, a) the_loc)
        | IT (Tuple items1, _, _),
          IT (Tuple items2, _, _)  ->
-          aux (and_ (List.Old.map2 (fun a b -> eq__ a b the_loc) items1 items2) the_loc)
+          aux (and_ (List.map2_exn ~f:(fun a b -> eq__ a b the_loc) items1 items2) the_loc)
        | IT (Record members1, _, _),
          IT (Record members2, _, _)  ->
           assert (List.Old.for_all2 (fun x y -> Id.equal (fst x) (fst y)) members1 members2);
-          aux (and_ (List.Old.map2 (fun x y -> eq_ (snd x, snd y) the_loc) members1 members2) the_loc)
+          aux (and_ (List.map2_exn ~f:(fun x y -> eq_ (snd x, snd y) the_loc) members1 members2) the_loc)
        | _, _ ->
           eq_ (a, b) the_loc
        end

--- a/backend/cn/simplify.ml
+++ b/backend/cn/simplify.ml
@@ -462,7 +462,7 @@ module IndexTerms = struct
           aux (and_ (List.map2_exn ~f:(fun a b -> eq__ a b the_loc) items1 items2) the_loc)
        | IT (Record members1, _, _),
          IT (Record members2, _, _)  ->
-          assert (List.Old.for_all2 (fun x y -> Id.equal (fst x) (fst y)) members1 members2);
+          assert (List.for_all2_exn ~f:(fun x y -> Id.equal (fst x) (fst y)) members1 members2);
           aux (and_ (List.map2_exn ~f:(fun x y -> eq_ (snd x, snd y) the_loc) members1 members2) the_loc)
        | _, _ ->
           eq_ (a, b) the_loc

--- a/backend/cn/simplify.ml
+++ b/backend/cn/simplify.ml
@@ -138,7 +138,7 @@ module IndexTerms = struct
   let rec tuple_nth_reduce it n item_bt =
     let loc = IT.loc it in
     match IT.term it with
-      | Tuple items -> List.Old.nth items n
+      | Tuple items -> List.nth_exn items n
       | ITE (cond, it1, it2) ->
         ite_ (cond, tuple_nth_reduce it1 n item_bt, tuple_nth_reduce it2 n item_bt) loc
       | _ -> IT.nthTuple_ ~item_bt (n, it) loc

--- a/backend/cn/simplify.ml
+++ b/backend/cn/simplify.ml
@@ -127,7 +127,7 @@ module IndexTerms = struct
   (*   match IT.term it with *)
   (*     | DatatypeCons (nm, members_rec) -> *)
   (*       let members = BT.record_bt (IT.bt members_rec) in *)
-  (*       if List.Old.exists (Id.equal member) (List.map ~f:fst members) *)
+  (*       if List.exists ~f:(Id.equal member) (List.map ~f:fst members) *)
   (*       then record_member_reduce members_rec member *)
   (*       else IT.IT (DatatypeMember (it, member), member_bt) *)
   (*     | ITE (cond, it1, it2) -> *)

--- a/backend/cn/simplify.ml
+++ b/backend/cn/simplify.ml
@@ -83,7 +83,7 @@ module IndexTerms = struct
       let b_elems = dest_int_addition (true, ITSet.empty) b |> fst |> List.map ~f:fst in
       let repeated = List.Old.sort IT.compare (a_elems @ b_elems)
           |> group IT.equal
-          |> List.Old.filter (fun xs -> List.length xs >= 2)
+          |> List.filter ~f:(fun xs -> List.length xs >= 2)
           |> List.map ~f:List.Old.hd |> ITSet.of_list in
       let (a_xs, a_r) = dest_int_addition (false, repeated) a in
       let (b_xs, b_r) = dest_int_addition (false, repeated) b in
@@ -91,7 +91,7 @@ module IndexTerms = struct
       let xs = List.Old.sort (fun a b -> IT.compare (fst a) (fst b)) (a_xs_neg @ b_xs)
           |> group (fun a b -> IT.equal (fst a) (fst b))
           |> List.map ~f:(fun xs -> (fst (List.Old.hd xs), List.Old.fold_left Z.add Z.zero (List.map ~f:snd xs)))
-          |> List.Old.filter (fun t -> not (Z.equal (snd t) Z.zero))
+          |> List.filter ~f:(fun t -> not (Z.equal (snd t) Z.zero))
       in
       let mul_z t i = if Z.equal i Z.one then t
           else if IT.equal z1 t then z_ i loc else mul_ (t, z_ i loc) loc in

--- a/backend/cn/simplify.ml
+++ b/backend/cn/simplify.ml
@@ -84,13 +84,13 @@ module IndexTerms = struct
       let repeated = List.Old.sort IT.compare (a_elems @ b_elems)
           |> group IT.equal
           |> List.filter ~f:(fun xs -> List.length xs >= 2)
-          |> List.map ~f:List.Old.hd |> ITSet.of_list in
+          |> List.map ~f:List.hd_exn |> ITSet.of_list in
       let (a_xs, a_r) = dest_int_addition (false, repeated) a in
       let (b_xs, b_r) = dest_int_addition (false, repeated) b in
       let a_xs_neg = List.map ~f:(fun (it, i) -> (it, Z.sub Z.zero i)) a_xs in
       let xs = List.Old.sort (fun a b -> IT.compare (fst a) (fst b)) (a_xs_neg @ b_xs)
           |> group (fun a b -> IT.equal (fst a) (fst b))
-          |> List.map ~f:(fun xs -> (fst (List.Old.hd xs), List.Old.fold_left Z.add Z.zero (List.map ~f:snd xs)))
+          |> List.map ~f:(fun xs -> (fst (List.hd_exn xs), List.Old.fold_left Z.add Z.zero (List.map ~f:snd xs)))
           |> List.filter ~f:(fun t -> not (Z.equal (snd t) Z.zero))
       in
       let mul_z t i = if Z.equal i Z.one then t

--- a/backend/cn/simplify.ml
+++ b/backend/cn/simplify.ml
@@ -83,7 +83,7 @@ module IndexTerms = struct
       let b_elems = dest_int_addition (true, ITSet.empty) b |> fst |> List.map ~f:fst in
       let repeated = List.Old.sort IT.compare (a_elems @ b_elems)
           |> group IT.equal
-          |> List.Old.filter (fun xs -> List.Old.length xs >= 2)
+          |> List.Old.filter (fun xs -> List.length xs >= 2)
           |> List.map ~f:List.Old.hd |> ITSet.of_list in
       let (a_xs, a_r) = dest_int_addition (false, repeated) a in
       let (b_xs, b_r) = dest_int_addition (false, repeated) b in

--- a/backend/cn/simplify.ml
+++ b/backend/cn/simplify.ml
@@ -483,7 +483,7 @@ module IndexTerms = struct
        begin match members with
        | (_, IT (StructMember (str, _), _, _)) :: _ when
               BT.equal (Struct tag) (IT.bt str) &&
-              List.Old.for_all (function
+              List.for_all ~f:(function
                   | (mem, IT (StructMember (str', mem'), _, _)) ->
                     Id.equal mem mem' && IT.equal str str'
                   | _ -> false

--- a/backend/cn/solver.ml
+++ b/backend/cn/solver.ml
@@ -414,7 +414,7 @@ and
   | Struct tag ->
     let (_con,vals) = SMT.to_con sexp in
     let decl = SymMap.find tag gs.struct_decls in
-    let fields = List.Old.filter_map (fun x -> x.Memory.member_or_padding) decl in
+    let fields = List.filter_map ~f:(fun x -> x.Memory.member_or_padding) decl in
     let mk_field (l,t) v = (l,get_ivalue gs ctys (Memory.bt_of_sct t) v) in
     Struct (tag, List.Old.map2 mk_field fields vals)
 
@@ -973,7 +973,7 @@ let rec translate_term s iterm =
           match_pat new_v nested in
 
         let (conds,defs) = List.Old.split (List.map ~f:field fs) in
-        let nested_cond = SMT.bool_ands (List.Old.filter_map (fun x -> x) conds) in
+        let nested_cond = SMT.bool_ands (List.filter_map ~f:(fun x -> x) conds) in
         let cname = CN_Names.datatype_con_name c in
         let cond  = SMT.bool_and (SMT.is_con cname v) nested_cond in
         (Some cond, List.concat defs)
@@ -1121,7 +1121,7 @@ let rec declare_struct s done_struct name decl =
            (SMT.declare_datatype
               (CN_Names.struct_name name) []
                 [ ( CN_Names.struct_con_name name
-                  , List.Old.filter_map mk_piece decl
+                  , List.filter_map ~f:mk_piece decl
                   )
                 ]
            )

--- a/backend/cn/solver.ml
+++ b/backend/cn/solver.ml
@@ -886,7 +886,7 @@ let rec translate_term s iterm =
 
   | NthList (x,y,z) ->
     let arg x   = (translate_base_type (IT.basetype x), translate_term s x) in
-    let (arg_ts,args) = List.Old.split (List.map ~f:arg [x;y;z]) in
+    let (arg_ts,args) = List.unzip  (List.map ~f:arg [x;y;z]) in
     let bt      = IT.basetype iterm in
     let res_t   = translate_base_type bt in
     let f = declare_bt_uninterpreted s CN_Constant.nth_list bt arg_ts res_t in
@@ -894,7 +894,7 @@ let rec translate_term s iterm =
 
   | ArrayToList (x,y,z) ->
     let arg x   = (translate_base_type (IT.basetype x), translate_term s x) in
-    let (arg_ts,args) = List.Old.split (List.map ~f:arg [x;y;z]) in
+    let (arg_ts,args) = List.unzip  (List.map ~f:arg [x;y;z]) in
     let bt      = IT.basetype iterm in
     let res_t   = translate_base_type bt in
     let f = declare_bt_uninterpreted s
@@ -972,7 +972,7 @@ let rec translate_term s iterm =
           let new_v = SMT.app_ (CN_Names.datatype_field_name f) [v] in
           match_pat new_v nested in
 
-        let (conds,defs) = List.Old.split (List.map ~f:field fs) in
+        let (conds,defs) = List.unzip  (List.map ~f:field fs) in
         let nested_cond = SMT.bool_ands (List.filter_map ~f:(fun x -> x) conds) in
         let cname = CN_Names.datatype_con_name c in
         let cond  = SMT.bool_and (SMT.is_con cname v) nested_cond in

--- a/backend/cn/solver.ml
+++ b/backend/cn/solver.ml
@@ -409,14 +409,14 @@ and
 
   | Tuple bts ->
     let (_con,vals) = SMT.to_con sexp in
-    Tuple (List.Old.map2 (get_ivalue gs ctys) bts vals)
+    Tuple (List.map2_exn ~f:(get_ivalue gs ctys) bts vals)
 
   | Struct tag ->
     let (_con,vals) = SMT.to_con sexp in
     let decl = SymMap.find tag gs.struct_decls in
     let fields = List.filter_map ~f:(fun x -> x.Memory.member_or_padding) decl in
     let mk_field (l,t) v = (l,get_ivalue gs ctys (Memory.bt_of_sct t) v) in
-    Struct (tag, List.Old.map2 mk_field fields vals)
+    Struct (tag, List.map2_exn ~f:mk_field fields vals)
 
   | Datatype tag ->
     let (con,vals) = SMT.to_con sexp in
@@ -424,7 +424,7 @@ and
     let do_con c =
           let fields = (SymMap.find c gs.datatype_constrs).c_params in
           let mk_field (l,t) v = (l, get_ivalue gs ctys t v) in
-          Constructor (c, List.Old.map2 mk_field fields vals) in
+          Constructor (c, List.map2_exn ~f:mk_field fields vals) in
     let try_con c =
           if String.equal con (CN_Names.datatype_con_name c) then Some (do_con c) else None
     in
@@ -436,7 +436,7 @@ and
   | Record members  ->
     let (_con,vals) = SMT.to_con sexp in
     let mk_field (l,bt) e = (l, get_ivalue gs ctys bt e) in
-    Record (List.Old.map2 mk_field members vals)
+    Record (List.map2_exn ~f:mk_field members vals)
 
 
 (** {1 Term to SMT} *)

--- a/backend/cn/solver.ml
+++ b/backend/cn/solver.ml
@@ -100,7 +100,7 @@ module Debug = struct
   let _dump_solver solver =
     Printf.printf "| Start Solver Dump\n%!";
     dump_frame !(solver.cur_frame);
-    List.Old.iter dump_frame !(solver.prev_frames);
+    List.iter ~f:dump_frame !(solver.prev_frames);
     Printf.printf "| End Solver Dump\n%!"
 end
 
@@ -129,7 +129,7 @@ let get_ctype_table s =
   let table         = Int_Table.create 50 in
   let add_entry t n = Int_Table.add table n t in
   let do_frame f    = CTypeMap.iter add_entry f.ctypes in
-  List.Old.iter do_frame (!(s.cur_frame) :: !(s.prev_frames));
+  List.iter ~f:do_frame (!(s.cur_frame) :: !(s.prev_frames));
   table
 
 
@@ -1141,7 +1141,7 @@ let declare_solver_basics s =
      datatypes may depend on other datatypes and structs. *)
   let done_strcuts = ref SymSet.empty in
   SymMap.iter (declare_struct s done_strcuts) s.globals.struct_decls;
-  List.Old.iter (declare_datatype_group s) (Option.get s.globals.datatype_order)
+  List.iter ~f:(declare_datatype_group s) (Option.get s.globals.datatype_order)
 
 
 
@@ -1263,7 +1263,7 @@ let model_evaluator solver mo =
                     ; globals = gs
                     } in
     declare_solver_basics evaluator;
-    List.Old.iter (SMT.ack_command s) defs;
+    List.iter ~f:(SMT.ack_command s) defs;
 
     fun e ->
       push evaluator;
@@ -1334,7 +1334,7 @@ let provable ~loc ~solver ~global ~assumptions ~simp_ctxt ~pointer_facts lc =
 (*
         let () = Z3.Solver.reset solver.non_incremental in
         let () =
-          List.Old.iter (fun lc ->
+          List.iter ~f:(fun lc ->
             Z3.Solver.add solver.non_incremental [lc]
             ) (nlc :: extra @ existing_scs)
         in

--- a/backend/cn/solver.ml
+++ b/backend/cn/solver.ml
@@ -976,7 +976,7 @@ let rec translate_term s iterm =
         let nested_cond = SMT.bool_ands (List.Old.filter_map (fun x -> x) conds) in
         let cname = CN_Names.datatype_con_name c in
         let cond  = SMT.bool_and (SMT.is_con cname v) nested_cond in
-        (Some cond, List.Old.concat defs)
+        (Some cond, List.concat defs)
     in
     let rec do_alts v alts =
       match alts with

--- a/backend/cn/solver.ml
+++ b/backend/cn/solver.ml
@@ -158,7 +158,7 @@ let pop s n =
       drop n !(s.prev_frames)
     end
 
-let num_scopes s = List.Old.length !(s.prev_frames)
+let num_scopes s = List.length !(s.prev_frames)
 
 (** Do an ack_style command. These are logged. *)
 let ack_command s cmd =
@@ -224,7 +224,7 @@ module CN_Tuple = struct
 
   (** A tuple type with the given name *)
   let t tys =
-    let arity = List.Old.length tys in
+    let arity = List.length tys in
     SMT.app_ (name arity) tys
 
   (** Declare a datatype for a struct *)
@@ -238,7 +238,7 @@ module CN_Tuple = struct
 
   (** Make a tuple value *)
   let con es =
-    let arity = List.Old.length es in
+    let arity = List.length es in
     SMT.app_ (name arity) es
 
   (** Get a field of a tuple *)
@@ -777,7 +777,7 @@ let rec translate_term s iterm =
   | Tuple es -> CN_Tuple.con (List.map ~f:(translate_term s) es)
   | NthTuple (n, e1) ->
     begin match IT.basetype e1 with
-    | Tuple ts ->  CN_Tuple.get (List.Old.length ts) n (translate_term s e1)
+    | Tuple ts ->  CN_Tuple.get (List.length ts) n (translate_term s e1)
     | _ -> failwith "NthTuple: not a tuple"
     end
 
@@ -822,7 +822,7 @@ let rec translate_term s iterm =
     begin match IT.basetype e1 with
     | Record members ->
         let check (x,_) = Id.equal f x in
-        let arity       = List.Old.length members in
+        let arity       = List.length members in
         begin match List.Old.find_index check members with
         | Some n -> CN_Tuple.get arity n (translate_term s e1)
         | None -> failwith "Missing record field."

--- a/backend/cn/source_injection.ml
+++ b/backend/cn/source_injection.ml
@@ -317,7 +317,7 @@ let pre_post_injs pre_post is_void is_main (A.AnnotatedStatement (loc, _, _)) =
       | AilSblock (_bindings, []) ->
           Pos.of_location loc
       | AilSblock (_bindings, ss) ->
-          let first = List.Old.hd ss in
+          let first = List.hd_exn ss in
           let last = Lem_list_extra.last ss in
           let* (pre_pos, _) = posOf_stmt first in
           let* (_, post_pos) = posOf_stmt last in

--- a/backend/cn/source_injection.ml
+++ b/backend/cn/source_injection.ml
@@ -304,7 +304,7 @@ let in_stmt_injs xs num_headers =
       ; kind= InStmt (List.length strs, String.concat "\n" strs) }
   )
   xs
-  (* (List.Old.filter (fun (loc, _) -> Cerb_location.from_main_file loc) xs) *)
+  (* (List.filter ~f:(fun (loc, _) -> Cerb_location.from_main_file loc) xs) *)
 
 (* build the injections for the pre/post conditions of a C function *)
 let pre_post_injs pre_post is_void is_main (A.AnnotatedStatement (loc, _, _)) =

--- a/backend/cn/source_injection.ml
+++ b/backend/cn/source_injection.ml
@@ -187,7 +187,7 @@ let inject st inj =
         do_output st str
     | Pre (strs, ret_ty, is_main) ->
         let indent = String.make (st.last_indent + 2) ' ' in
-        let indented_strs = List.Old.map (fun str -> str ^ indent) strs in
+        let indented_strs = List.map ~f:(fun str -> str ^ indent) strs in
         let str = List.Old.fold_left (^) "" indented_strs in
         do_output st begin
           "\n" ^ indent ^ "/* EXECUTABLE CN PRECONDITION */" ^
@@ -205,7 +205,7 @@ let inject st inj =
     | Post (strs, ret_ty) ->
         let indent = String.make st.last_indent ' ' in
         let epilogue_indent = String.make (st.last_indent + 2) ' ' in
-        let indented_strs = List.Old.map (fun str -> 
+        let indented_strs = List.map ~f:(fun str -> 
           let indent = if (String.contains str '{') then indent else epilogue_indent in
           "\n" ^ indent ^ str) 
         strs 
@@ -240,7 +240,7 @@ let sort_injects xs =
         | InStmt (n,  str) ->
             "InStmt["^ string_of_int n ^ "] ==> '" ^ String.escaped str ^ "'"
         | Pre (strs, _, _) ->
-            "Pre ==> [" ^ String.concat "," (List.Old.map (fun s -> "\"" ^ String.escaped s ^ "\"" ) strs) ^ "]"
+            "Pre ==> [" ^ String.concat "," (List.map ~f:(fun s -> "\"" ^ String.escaped s ^ "\"" ) strs) ^ "]"
         | Post _ ->
             "Post"
       end
@@ -296,7 +296,7 @@ let in_stmt_injs xs num_headers =
     (* Printf.fprintf stderr "IN_STMT_INJS[%s], start: %s -- end: %s ---> [%s]\n"
       (Cerb_location.location_to_string loc)
       (Pos.to_string start_pos) (Pos.to_string end_pos)
-      (String.concat "; " (List.Old.map (fun str -> "'" ^ String.escaped str ^ "'") strs)); *)
+      (String.concat "; " (List.map ~f:(fun str -> "'" ^ String.escaped str ^ "'") strs)); *)
     Ok
       { footprint=
           { start_pos= Pos.increment_line start_pos num_headers
@@ -406,7 +406,7 @@ let get_magics_of_statement stmt =
         let open Annot in
         match (attr.attr_ns, attr.attr_id, attr.attr_args) with
           | (Some (Symbol.Identifier (_, "cerb")), Symbol.Identifier (_, "magic"), xs) ->
-              List.Old.map (fun (loc, str, _) -> (loc, str)) xs :: acc
+              List.map ~f:(fun (loc, str, _) -> (loc, str)) xs :: acc
          | _ ->
             acc
       ) acc xs in

--- a/backend/cn/source_injection.ml
+++ b/backend/cn/source_injection.ml
@@ -301,7 +301,7 @@ let in_stmt_injs xs num_headers =
       { footprint=
           { start_pos= Pos.increment_line start_pos num_headers
           ; end_pos= Pos.v (end_pos.line + num_headers) end_pos.col }
-      ; kind= InStmt (List.Old.length strs, String.concat "\n" strs) }
+      ; kind= InStmt (List.length strs, String.concat "\n" strs) }
   )
   xs
   (* (List.Old.filter (fun (loc, _) -> Cerb_location.from_main_file loc) xs) *)

--- a/backend/cn/subst.ml
+++ b/backend/cn/subst.ml
@@ -19,7 +19,7 @@ let pp ppf subst =
 
 let make free_vars replace =
   let relevant =
-    List.fold_right (fun (s, r) acc ->
+    List.Old.fold_right (fun (s, r) acc ->
         SymSet.union (free_vars r) (SymSet.add s acc)
       ) replace SymSet.empty
   in

--- a/backend/cn/surfaceBaseTypes.ml
+++ b/backend/cn/surfaceBaseTypes.ml
@@ -136,10 +136,10 @@ let rec of_basetype = function
   | BT.Loc -> Loc None
   | BT.Struct tag -> Struct tag
   | BT.Datatype tag -> Datatype tag
-  | BT.Record member_types -> Record (List.map_snd of_basetype member_types)
+  | BT.Record member_types -> Record (List.Old.map_snd of_basetype member_types)
   | BT.Map (bt1, bt2) -> Map (of_basetype bt1, of_basetype bt2)
   | BT.List bt -> List (of_basetype bt)
-  | BT.Tuple bts -> Tuple (List.map of_basetype bts)
+  | BT.Tuple bts -> Tuple (List.Old.map of_basetype bts)
   | BT.Set bt -> Set (of_basetype bt)
 
 
@@ -154,8 +154,8 @@ let rec to_basetype = function
   | Loc _ -> BT.Loc
   | Struct tag -> BT.Struct tag
   | Datatype tag -> BT.Datatype tag
-  | Record member_types -> BT.Record (List.map_snd to_basetype member_types)
+  | Record member_types -> BT.Record (List.Old.map_snd to_basetype member_types)
   | Map (bt1, bt2) -> BT.Map (to_basetype bt1, to_basetype bt2)
   | List bt -> BT.List (to_basetype bt)
-  | Tuple bts -> BT.Tuple (List.map to_basetype bts)
+  | Tuple bts -> BT.Tuple (List.Old.map to_basetype bts)
   | Set bt -> BT.Set (to_basetype bt)

--- a/backend/cn/surfaceBaseTypes.ml
+++ b/backend/cn/surfaceBaseTypes.ml
@@ -139,7 +139,7 @@ let rec of_basetype = function
   | BT.Record member_types -> Record (List.Old.map_snd of_basetype member_types)
   | BT.Map (bt1, bt2) -> Map (of_basetype bt1, of_basetype bt2)
   | BT.List bt -> List (of_basetype bt)
-  | BT.Tuple bts -> Tuple (List.Old.map of_basetype bts)
+  | BT.Tuple bts -> Tuple (List.map ~f:of_basetype bts)
   | BT.Set bt -> Set (of_basetype bt)
 
 
@@ -157,5 +157,5 @@ let rec to_basetype = function
   | Record member_types -> BT.Record (List.Old.map_snd to_basetype member_types)
   | Map (bt1, bt2) -> BT.Map (to_basetype bt1, to_basetype bt2)
   | List bt -> BT.List (to_basetype bt)
-  | Tuple bts -> BT.Tuple (List.Old.map to_basetype bts)
+  | Tuple bts -> BT.Tuple (List.map ~f:to_basetype bts)
   | Set bt -> BT.Set (to_basetype bt)

--- a/backend/cn/terms.ml
+++ b/backend/cn/terms.ml
@@ -320,7 +320,7 @@ let pp : 'bt 'a. ?atomic:bool -> ?f:('bt term -> Pp.document -> Pp.document) -> 
        | MapDef ((s,_), t) ->
           brackets (Sym.pp s ^^^ !^"->" ^^^ aux false t)
     | Apply (name, args) ->
-       c_app (Sym.pp name) (List.map (aux false) args)
+       c_app (Sym.pp name) (List.Old.map (aux false) args)
     | Let ((name, x1), x2) ->
        parens (!^ "let" ^^^ Sym.pp name ^^^ Pp.equals ^^^
                  aux false x1 ^^^ !^ "in" ^^^ aux false x2)
@@ -361,7 +361,7 @@ let rec dtree_of_pat (Pat (pat_, _bt, _)) =
   | PConstructor (s, pats) ->
      Dnode (pp_ctor "PConstructor",
             Dleaf (Sym.pp s) ::
-              List.map (fun (id, pat) ->
+              List.Old.map (fun (id, pat) ->
                   Dnode (pp_ctor "Arg", [Dleaf (Id.pp id); dtree_of_pat pat])
                 ) pats
        )
@@ -405,12 +405,12 @@ let rec dtree (IT (it_, bt, loc)) =
            dtree body
        ])
   | Tuple its ->
-     Dnode (pp_ctor "Tuple", List.map dtree its)
+     Dnode (pp_ctor "Tuple", List.Old.map dtree its)
   | NthTuple (i, t) ->
      Dnode (pp_ctor "NthTuple", [Dleaf !^(string_of_int i); dtree t])
   | Struct (tag, members) ->
      Dnode (pp_ctor ("Struct("^Sym.pp_string tag^")"),
-            List.map (fun (member,e) ->
+            List.Old.map (fun (member,e) ->
                 Dnode (pp_ctor "Member", [Dleaf (Id.pp member); dtree e])
               ) members)
   | StructMember (e, member) ->
@@ -422,7 +422,7 @@ let rec dtree (IT (it_, bt, loc)) =
        ])
   | Record members ->
      Dnode (pp_ctor "Record",
-            List.map (fun (member,e) ->
+            List.Old.map (fun (member,e) ->
                 Dnode (pp_ctor "Member", [Dleaf (Id.pp member); dtree e])
               ) members)
   | RecordMember (e, member) ->
@@ -452,18 +452,18 @@ let rec dtree (IT (it_, bt, loc)) =
   | MapDef ((s, _bt), t) ->
      Dnode (pp_ctor "MapDef", [Dleaf (Sym.pp s); dtree t])
   | Apply (f, args) ->
-     Dnode (pp_ctor "Apply", (Dleaf (Sym.pp f) :: List.map dtree args))
+     Dnode (pp_ctor "Apply", (Dleaf (Sym.pp f) :: List.Old.map dtree args))
   | Constructor (s, args) ->
      Dnode (pp_ctor "Constructor",
            Dleaf (Sym.pp s) ::
-           List.map (fun (id, t) ->
+           List.Old.map (fun (id, t) ->
                Dnode (pp_ctor "Arg", [Dleaf (Id.pp id); dtree t])
              ) args
        )
   | Match (t, pats) ->
      Dnode (pp_ctor "Match",
             dtree t ::
-              List.map (fun (pat, body) ->
+              List.Old.map (fun (pat, body) ->
                   Dnode (pp_ctor "Case", [dtree_of_pat pat; dtree body])
                 ) pats
        )

--- a/backend/cn/terms.ml
+++ b/backend/cn/terms.ml
@@ -320,7 +320,7 @@ let pp : 'bt 'a. ?atomic:bool -> ?f:('bt term -> Pp.document -> Pp.document) -> 
        | MapDef ((s,_), t) ->
           brackets (Sym.pp s ^^^ !^"->" ^^^ aux false t)
     | Apply (name, args) ->
-       c_app (Sym.pp name) (List.Old.map (aux false) args)
+       c_app (Sym.pp name) (List.map ~f:(aux false) args)
     | Let ((name, x1), x2) ->
        parens (!^ "let" ^^^ Sym.pp name ^^^ Pp.equals ^^^
                  aux false x1 ^^^ !^ "in" ^^^ aux false x2)
@@ -361,7 +361,7 @@ let rec dtree_of_pat (Pat (pat_, _bt, _)) =
   | PConstructor (s, pats) ->
      Dnode (pp_ctor "PConstructor",
             Dleaf (Sym.pp s) ::
-              List.Old.map (fun (id, pat) ->
+              List.map ~f:(fun (id, pat) ->
                   Dnode (pp_ctor "Arg", [Dleaf (Id.pp id); dtree_of_pat pat])
                 ) pats
        )
@@ -405,12 +405,12 @@ let rec dtree (IT (it_, bt, loc)) =
            dtree body
        ])
   | Tuple its ->
-     Dnode (pp_ctor "Tuple", List.Old.map dtree its)
+     Dnode (pp_ctor "Tuple", List.map ~f:dtree its)
   | NthTuple (i, t) ->
      Dnode (pp_ctor "NthTuple", [Dleaf !^(string_of_int i); dtree t])
   | Struct (tag, members) ->
      Dnode (pp_ctor ("Struct("^Sym.pp_string tag^")"),
-            List.Old.map (fun (member,e) ->
+            List.map ~f:(fun (member,e) ->
                 Dnode (pp_ctor "Member", [Dleaf (Id.pp member); dtree e])
               ) members)
   | StructMember (e, member) ->
@@ -422,7 +422,7 @@ let rec dtree (IT (it_, bt, loc)) =
        ])
   | Record members ->
      Dnode (pp_ctor "Record",
-            List.Old.map (fun (member,e) ->
+            List.map ~f:(fun (member,e) ->
                 Dnode (pp_ctor "Member", [Dleaf (Id.pp member); dtree e])
               ) members)
   | RecordMember (e, member) ->
@@ -452,18 +452,18 @@ let rec dtree (IT (it_, bt, loc)) =
   | MapDef ((s, _bt), t) ->
      Dnode (pp_ctor "MapDef", [Dleaf (Sym.pp s); dtree t])
   | Apply (f, args) ->
-     Dnode (pp_ctor "Apply", (Dleaf (Sym.pp f) :: List.Old.map dtree args))
+     Dnode (pp_ctor "Apply", (Dleaf (Sym.pp f) :: List.map ~f:dtree args))
   | Constructor (s, args) ->
      Dnode (pp_ctor "Constructor",
            Dleaf (Sym.pp s) ::
-           List.Old.map (fun (id, t) ->
+           List.map ~f:(fun (id, t) ->
                Dnode (pp_ctor "Arg", [Dleaf (Id.pp id); dtree t])
              ) args
        )
   | Match (t, pats) ->
      Dnode (pp_ctor "Match",
             dtree t ::
-              List.Old.map (fun (pat, body) ->
+              List.map ~f:(fun (pat, body) ->
                   Dnode (pp_ctor "Case", [dtree_of_pat pat; dtree body])
                 ) pats
        )

--- a/backend/cn/typeErrors.ml
+++ b/backend/cn/typeErrors.ml
@@ -244,7 +244,7 @@ let pp_message te =
   | Missing_resource {requests; situation; ctxt; model; } ->
      let short = !^"Missing resource" ^^^ for_situation situation in
      let descr = request_chain_description requests in
-     let orequest = Option.map (fun r -> r.resource) (List.Old.nth_opt (List.Old.rev requests) 0) in
+     let orequest = Option.map (fun r -> r.resource) (List.Old.nth_opt (List.rev requests) 0) in
      let state = trace ctxt model Explain.{no_ex with request = orequest} in
      { short; descr = descr; state = Some state; }
   | Merging_multiple_arrays {requests; situation; ctxt; model} ->
@@ -253,7 +253,7 @@ let pp_message te =
          !^"It requires merging multiple arrays."
      in
      let descr = request_chain_description requests in
-     let orequest = Option.map (fun r -> r.resource) (List.Old.nth_opt (List.Old.rev requests) 0) in
+     let orequest = Option.map (fun r -> r.resource) (List.Old.nth_opt (List.rev requests) 0) in
      let state = trace ctxt model Explain.{no_ex with request = orequest} in
      { short; descr = descr; state = Some state;  }
   | Unused_resource {resource; ctxt; model; } ->

--- a/backend/cn/typeErrors.ml
+++ b/backend/cn/typeErrors.ml
@@ -244,7 +244,7 @@ let pp_message te =
   | Missing_resource {requests; situation; ctxt; model; } ->
      let short = !^"Missing resource" ^^^ for_situation situation in
      let descr = request_chain_description requests in
-     let orequest = Option.map (fun r -> r.resource) (List.nth_opt (List.rev requests) 0) in
+     let orequest = Option.map (fun r -> r.resource) (List.Old.nth_opt (List.Old.rev requests) 0) in
      let state = trace ctxt model Explain.{no_ex with request = orequest} in
      { short; descr = descr; state = Some state; }
   | Merging_multiple_arrays {requests; situation; ctxt; model} ->
@@ -253,7 +253,7 @@ let pp_message te =
          !^"It requires merging multiple arrays."
      in
      let descr = request_chain_description requests in
-     let orequest = Option.map (fun r -> r.resource) (List.nth_opt (List.rev requests) 0) in
+     let orequest = Option.map (fun r -> r.resource) (List.Old.nth_opt (List.Old.rev requests) 0) in
      let state = trace ctxt model Explain.{no_ex with request = orequest} in
      { short; descr = descr; state = Some state;  }
   | Unused_resource {resource; ctxt; model; } ->

--- a/backend/cn/typeErrors.ml
+++ b/backend/cn/typeErrors.ml
@@ -244,7 +244,7 @@ let pp_message te =
   | Missing_resource {requests; situation; ctxt; model; } ->
      let short = !^"Missing resource" ^^^ for_situation situation in
      let descr = request_chain_description requests in
-     let orequest = Option.map (fun r -> r.resource) (List.Old.nth_opt (List.rev requests) 0) in
+     let orequest = Option.map (fun r -> r.resource) (List.nth (List.rev requests) 0) in
      let state = trace ctxt model Explain.{no_ex with request = orequest} in
      { short; descr = descr; state = Some state; }
   | Merging_multiple_arrays {requests; situation; ctxt; model} ->
@@ -253,7 +253,7 @@ let pp_message te =
          !^"It requires merging multiple arrays."
      in
      let descr = request_chain_description requests in
-     let orequest = Option.map (fun r -> r.resource) (List.Old.nth_opt (List.rev requests) 0) in
+     let orequest = Option.map (fun r -> r.resource) (List.nth (List.rev requests) 0) in
      let state = trace ctxt model Explain.{no_ex with request = orequest} in
      { short; descr = descr; state = Some state;  }
   | Unused_resource {resource; ctxt; model; } ->

--- a/backend/cn/typing.ml
+++ b/backend/cn/typing.ml
@@ -436,7 +436,7 @@ let add_c_internal lc =
   let lc = Simplify.LogicalConstraints.simp simp_ctxt lc in
   let s = Context.add_c lc s in
   let () = Solver.add_assumption solver s.global lc in
-  let@ _ = add_sym_eqs (List.Old.filter_map (LC.is_sym_lhs_equality) [lc]) in
+  let@ _ = add_sym_eqs (List.filter_map ~f:(LC.is_sym_lhs_equality) [lc]) in
   let@ _ = add_found_equalities lc in
   let@ () = set_typing_context s in
   return ()
@@ -530,7 +530,7 @@ let do_check_model loc m prop =
     |> List.map ~f:(fun (nm, (bt_or_v, (loc, _))) -> IT.sym_ (nm, bt_of bt_or_v, loc))
   ) in
   let here = Locations.other __FUNCTION__ in
-  let eqs = List.Old.filter_map (fun v -> match Solver.eval global (fst m) v with
+  let eqs = List.filter_map ~f:(fun v -> match Solver.eval global (fst m) v with
     | None -> None
     | Some x -> Some (IT.eq_ (v, x) here)
   ) vs in

--- a/backend/cn/typing.ml
+++ b/backend/cn/typing.ml
@@ -547,7 +547,7 @@ let cond_check_model loc m prop =
 let model_with_internal loc prop =
   let@ ms = get_just_models () in
   let@ has_prop = model_has_prop () in
-  match List.Old.find_opt (has_prop prop) ms with
+  match List.find ~f:(has_prop prop) ms with
     | Some m -> return (Some m)
     | None -> begin
       let@ prover = provable_internal loc in

--- a/backend/cn/typing.ml
+++ b/backend/cn/typing.ml
@@ -526,7 +526,7 @@ let do_check_model loc m prop =
   let@ global = get_global () in
   let vs = Context.(
     (SymMap.bindings ctxt.computational @ SymMap.bindings ctxt.logical)
-    |> List.Old.filter (fun (_, (bt_or_v, _)) -> not (has_value bt_or_v))
+    |> List.filter ~f:(fun (_, (bt_or_v, _)) -> not (has_value bt_or_v))
     |> List.map ~f:(fun (nm, (bt_or_v, (loc, _))) -> IT.sym_ (nm, bt_of bt_or_v, loc))
   ) in
   let here = Locations.other __FUNCTION__ in
@@ -782,7 +782,7 @@ let prev_models_with loc prop =
   let@ () = sync_unfold_resources loc in
   let@ ms = get_just_models () in
   let@ has_prop = model_has_prop () in
-  return (List.Old.filter (has_prop prop) ms)
+  return (List.filter ~f:(has_prop prop) ms)
 
 let model_with loc prop =
   let@ () = sync_unfold_resources loc in

--- a/backend/cn/typing.ml
+++ b/backend/cn/typing.ml
@@ -809,7 +809,7 @@ let test_value_eqs loc guard x ys =
     | y :: ys ->
       let@ has_prop = model_has_prop () in
       let counterex = has_prop (IT.not_ (IT.eq_ (x, y) here) here) in
-      if ITSet.mem y group || List.Old.exists counterex ms
+      if ITSet.mem y group || List.exists ~f:counterex ms
       then loop group ms ys
       else match prover (prop y) with
         | `True ->

--- a/backend/cn/typing.ml
+++ b/backend/cn/typing.ml
@@ -266,7 +266,7 @@ let get_member_type loc _tag member layout : (Sctypes.t) m =
   let member_types = Memory.member_types layout in
   match List.Old.assoc_opt Id.equal member member_types with
   | Some membertyp -> return membertyp
-  | None -> fail (fun _ -> {loc; msg = Unexpected_member (List.Old.map fst member_types, member)})
+  | None -> fail (fun _ -> {loc; msg = Unexpected_member (List.map ~f:fst member_types, member)})
 
 let get_struct_member_type loc tag member =
   let@ decl = get_struct_decl loc tag in
@@ -496,7 +496,7 @@ let model () =
 
 let get_just_models () =
   let@ ms = get_past_models () in
-  return (List.Old.map fst ms)
+  return (List.map ~f:fst ms)
 
 let model_has_prop () =
   let@ global = get_global () in
@@ -527,7 +527,7 @@ let do_check_model loc m prop =
   let vs = Context.(
     (SymMap.bindings ctxt.computational @ SymMap.bindings ctxt.logical)
     |> List.Old.filter (fun (_, (bt_or_v, _)) -> not (has_value bt_or_v))
-    |> List.Old.map (fun (nm, (bt_or_v, (loc, _))) -> IT.sym_ (nm, bt_of bt_or_v, loc))
+    |> List.map ~f:(fun (nm, (bt_or_v, (loc, _))) -> IT.sym_ (nm, bt_of bt_or_v, loc))
   ) in
   let here = Locations.other __FUNCTION__ in
   let eqs = List.Old.filter_map (fun v -> match Solver.eval global (fst m) v with
@@ -582,7 +582,7 @@ let make_return_record loc (record_name:string) record_members =
   let@ () = add_l record_s record_bt (loc, lazy (Sym.pp record_s)) in
   let record_it = IT.sym_ (record_s, record_bt, loc) in
   let member_its =
-    List.Old.map (fun (s, member_bt) ->
+    List.map ~f:(fun (s, member_bt) ->
         IT.recordMember_ ~member_bt (record_it, s) loc
       ) record_members
   in
@@ -690,7 +690,7 @@ let map_and_fold_resources_internal loc
 
 
 (* let get_movable_indices () = *)
-(*   inspect (fun s -> List.Old.map (fun (pred, nm, _verb) -> (pred, nm)) s.movable_indices) *)
+(*   inspect (fun s -> List.map ~f:(fun (pred, nm, _verb) -> (pred, nm)) s.movable_indices) *)
 
 
 (* the main inference loop *)

--- a/backend/cn/wellTyped.ml
+++ b/backend/cn/wellTyped.ml
@@ -271,7 +271,7 @@ module WIT = struct
   let rec cases_complete loc (bts : BT.t list) (cases : ((BT.t pattern) list) list) =
     match bts with
     | [] ->
-       assert (List.Old.for_all (function [] -> true | _ -> false) cases);
+       assert (List.for_all ~f:(function [] -> true | _ -> false) cases);
        begin match cases with
        | [] -> fail (fun _ -> {loc; msg = Generic !^"Incomplete pattern"})
        | _ -> return ()
@@ -279,7 +279,7 @@ module WIT = struct
        (* | _::_::_ -> fail (fun _ -> {loc; msg = Generic !^"Duplicate pattern"}) *)
        end
     | bt::bts ->
-       if List.Old.for_all leading_sym_or_wild cases then
+       if List.for_all ~f:leading_sym_or_wild cases then
          cases_complete loc bts (List.map ~f:List.Old.tl cases)
        else
          begin match bt with

--- a/backend/cn/wellTyped.ml
+++ b/backend/cn/wellTyped.ml
@@ -1433,7 +1433,7 @@ let rec infer_value : 'TY. Locations.t -> 'TY mu_value -> (BT.t mu_value) m =
       return (Loc, M_Vfunction_addr sym)
    | M_Vlist (item_cbt, vals) ->
       let@ vals = ListM.mapM (infer_value loc) vals in
-      let item_bt = bt_of_value (List.Old.hd vals) in
+      let item_bt = bt_of_value (List.hd_exn vals) in
       return (List item_bt, M_Vlist (item_cbt, vals))
    | M_Vtuple vals ->
       let@ vals = ListM.mapM (infer_value loc) vals in
@@ -1607,7 +1607,7 @@ let rec infer_pexpr : 'TY. 'TY mu_pexpr -> BT.t mu_pexpr m =
            end
         | M_Ctuple -> return (BT.Tuple (List.map ~f:bt_of_pexpr pes))
         | M_Carray -> 
-           let ibt = bt_of_pexpr (List.Old.hd pes) in
+           let ibt = bt_of_pexpr (List.hd_exn pes) in
            let@ () = ListM.iterM (fun pe -> ensure_base_type loc ~expect:ibt (bt_of_pexpr pe)) pes in
            return (Map (Memory.uintptr_bt, ibt))
         in

--- a/backend/cn/wellTyped.ml
+++ b/backend/cn/wellTyped.ml
@@ -309,7 +309,7 @@ module WIT = struct
       | _, _ -> false
     in
     let@ _ = ListM.fold_leftM (fun prev (Pat (_, _, pat_loc) as pat) ->
-      match List.Old.find_opt (fun p1 -> covers p1 pat) prev with
+      match List.find ~f:(fun p1 -> covers p1 pat) prev with
       | None -> return (pat :: prev)
       | Some (Pat (case, _, p1_loc)) ->
         let (prev_head, prev_pos) = Locations.head_pos_of_location p1_loc in

--- a/backend/cn/wellTyped.ml
+++ b/backend/cn/wellTyped.ml
@@ -258,7 +258,7 @@ module WIT = struct
        Some (List.map ~f:(fun (_m, bt) -> Pat (PWild, bt, loc)) constr_info.c_params @ pats)
     | Pat (PConstructor (constr', args), _, _) :: pats
          when Sym.equal constr constr' ->
-       assert (List.Old.for_all2 (fun (m,_) (m',_) -> Id.equal m m') constr_info.c_params args);
+       assert (List.for_all2_exn ~f:(fun (m,_) (m',_) -> Id.equal m m') constr_info.c_params args);
        Some (List.map ~f:snd args @ pats)
     | Pat (PConstructor (_constr', _args), _, _) :: _pats ->
        None
@@ -305,7 +305,7 @@ module WIT = struct
       | Pat (PSym _, _, _), _ -> true
       | Pat (PConstructor (s1, ps1), _, _), Pat (PConstructor (s2, ps2), _, _)
         when (Sym.equal s1 s2 && List.Old.equal Id.equal (List.map ~f:fst ps1) (List.map ~f:fst ps2)) ->
-          List.Old.for_all2 covers (List.map ~f:snd ps1) (List.map ~f:snd ps2)
+          List.for_all2_exn ~f:covers (List.map ~f:snd ps1) (List.map ~f:snd ps2)
       | _, _ -> false
     in
     let@ _ = ListM.fold_leftM (fun prev (Pat (_, _, pat_loc) as pat) ->

--- a/backend/cn/wellTyped.ml
+++ b/backend/cn/wellTyped.ml
@@ -583,7 +583,7 @@ module WIT = struct
          let@ t' = infer t' in
          let@ item_bt = match IT.bt t' with
            | Tuple bts ->
-              begin match List.Old.nth_opt bts n with
+              begin match List.nth bts n with
               | Some t -> return t
               | None ->
                  let expected = string_of_int n ^ "-tuple" in

--- a/backend/cn/wellTyped.ml
+++ b/backend/cn/wellTyped.ml
@@ -291,7 +291,7 @@ module WIT = struct
             ListM.iterM (fun constr ->
                 let@ constr_info = get_datatype_constr loc constr  in
                 let relevant_cases =
-                  List.Old.filter_map (expand_constr (constr, constr_info)) cases in
+                  List.filter_map ~f:(expand_constr (constr, constr_info)) cases in
                 let member_bts = List.map ~f:snd constr_info.c_params in
                 cases_complete loc (member_bts @ bts) relevant_cases
               ) dt_info.dt_constrs
@@ -1460,7 +1460,7 @@ let is_integer_annot = function
 
 
 let integer_annot annots =
-  match List.Old.sort_uniq CF.IntegerType.setElemCompare_integerType (List.Old.filter_map is_integer_annot annots) with
+  match List.Old.sort_uniq CF.IntegerType.setElemCompare_integerType (List.filter_map ~f:is_integer_annot annots) with
   | [] -> None
   | [ity] -> Some ity
   | _ -> assert false
@@ -2329,7 +2329,7 @@ module WDT = struct
     List.Old.concat_map bts_in_dt_case cases
 
   let dts_in_dt_definition dt_def =
-    List.Old.filter_map BT.is_datatype_bt (bts_in_dt_definition dt_def)
+    List.filter_map ~f:BT.is_datatype_bt (bts_in_dt_definition dt_def)
 
 
   let check_recursion_ok datatypes =
@@ -2361,7 +2361,7 @@ module WDT = struct
                   ListM.iterM (fun (id, bt) ->
                       let indirect_deps =
                         SymSet.of_list
-                          (List.Old.filter_map BT.is_datatype_bt (BT.contained bt))
+                          (List.filter_map ~f:BT.is_datatype_bt (BT.contained bt))
                       in
                       let bad = SymSet.inter indirect_deps scc_set in
                       begin match SymSet.elements bad with

--- a/backend/cn/wellTyped.ml
+++ b/backend/cn/wellTyped.ml
@@ -1467,7 +1467,7 @@ let integer_annot annots =
 
 
 let remove_integer_annot annots =
-  List.Old.filter (fun a -> Option.is_none (is_integer_annot a)) annots
+  List.filter ~f:(fun a -> Option.is_none (is_integer_annot a)) annots
 
 let remove_integer_annot_expr (M_Expr (loc, annots, bty, e_)) =
   M_Expr (loc, remove_integer_annot annots, bty, e_)

--- a/backend/cn/wellTyped.ml
+++ b/backend/cn/wellTyped.ml
@@ -112,7 +112,7 @@ let correct_members_sorted_annotated loc spec have =
   let@ () = correct_members loc spec have in
   let have = List.Old.sort compare_by_fst_id have in
   let have_annotated =
-    List.Old.map2 (fun (id,bt) (id',x) ->
+    List.map2_exn ~f:(fun (id,bt) (id',x) ->
         assert (Id.equal id id');
         (bt, (id', x))
       ) spec have

--- a/backend/cn/wellTyped.ml
+++ b/backend/cn/wellTyped.ml
@@ -2296,7 +2296,7 @@ module WDT = struct
               assert false
           else
              return (IdSet.add id already)
-        ) IdSet.empty (List.Old.concat_map snd cases)
+        ) IdSet.empty (List.concat_map ~f:snd cases)
     in
     let@ cases =
       ListM.mapM (fun (c, args) ->
@@ -2323,10 +2323,10 @@ module WDT = struct
     bt :: BT.contained bt
 
   let bts_in_dt_case (_constr, args) =
-    List.Old.concat_map bts_in_dt_constructor_argument args
+    List.concat_map ~f:bts_in_dt_constructor_argument args
 
   let bts_in_dt_definition { loc = _; cases } =
-    List.Old.concat_map bts_in_dt_case cases
+    List.concat_map ~f:bts_in_dt_case cases
 
   let dts_in_dt_definition dt_def =
     List.filter_map ~f:BT.is_datatype_bt (bts_in_dt_definition dt_def)

--- a/backend/cn/wellTyped.ml
+++ b/backend/cn/wellTyped.ml
@@ -280,7 +280,7 @@ module WIT = struct
        end
     | bt::bts ->
        if List.for_all ~f:leading_sym_or_wild cases then
-         cases_complete loc bts (List.map ~f:List.Old.tl cases)
+         cases_complete loc bts (List.map ~f:List.tl_exn cases)
        else
          begin match bt with
          | (Unit|Bool|Integer|Bits _|Real|Alloc_id|Loc|CType|Struct _|


### PR DESCRIPTION
This PR demonstrates that we can migrate over to using the [Base](https://opensource.janestreet.com/base/) if we wanted to, and bring with it the benefits of a safer, more full-featured and more consistent library. The biggest change would be to `List`, though I've found myself wanting many `Option` functions (e.g. `value_map`) too.

It took less than an hour (though I did have a false start last Friday) to get to this point and would be finished in about another hour's work; the following functions remain:
```
15:01 ➜  cerberus git:(cn-base-list) grep 'List\.Old\.\w\+' -R backend/cn -o | awk -F':' '{ print $2; }' | sort | uniq -c | sort
      1 List.Old.compare
      1 List.Old.find
      1 List.Old.find_map
      1 List.Old.fold_left_map
      1 List.Old.iter2
      1 List.Old.last
      1 List.Old.map_split
      1 List.Old.nth_list
      1 List.Old.partition_map
      2 List.Old.is_empty
      2 List.Old.iteri
      2 List.Old.sorted_and_unique
      3 List.Old.sort_uniq
      4 List.Old.add
      4 List.Old.equal
      6 List.Old.init
      7 List.Old.map_snd
      7 List.Old.mem
      9 List.Old.sort
     13 List.Old.assoc
     13 List.Old.assoc_opt
     26 List.Old.fold_right
     40 List.Old.fold_left
```