### PR TITLE
Add a --version flag generated from git hash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,15 +23,6 @@ else
     DUNEFLAGS=
 endif
 
-# Default hash in case git is not available
-DEFAULT_HASH := "unknown"
-GIT_HASH := $(shell if command -v git >/dev/null 2>&1 && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then git rev-parse --short HEAD; else echo $(DEFAULT_HASH); fi)
-CN_VERSION_FILE := backend/cn/version.ml
-
-.PHONY: cn-version
-cn-version: 
-	echo "let git_hash = \"$(GIT_HASH)\"" > $(CN_VERSION_FILE)
-
 .PHONY: normal
 normal: cerberus
 
@@ -83,7 +74,7 @@ rustic: prelude-src
 	$(Q)dune build $(DUNEFLAGS) cerberus.install rustic.install
 
 .PHONY: cn
-cn: prelude-src cn-version
+cn: prelude-src
 	@echo "[DUNE] $@"
 	$(Q)dune build $(DUNEFLAGS) cerberus.install cn.install
 	@echo "\nDONE"

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,15 @@ else
     DUNEFLAGS=
 endif
 
+# Default hash in case git is not available
+DEFAULT_HASH := "unknown"
+GIT_HASH := $(shell if command -v git >/dev/null 2>&1 && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then git rev-parse --short HEAD; else echo $(DEFAULT_HASH); fi)
+CN_VERSION_FILE := backend/cn/version.ml
+
+.PHONY: cn-version
+cn-version: 
+	echo "let git_hash = \"$(GIT_HASH)\"" > $(CN_VERSION_FILE)
+
 .PHONY: normal
 normal: cerberus
 
@@ -74,7 +83,7 @@ rustic: prelude-src
 	$(Q)dune build $(DUNEFLAGS) cerberus.install rustic.install
 
 .PHONY: cn
-cn: prelude-src
+cn: prelude-src cn-version
 	@echo "[DUNE] $@"
 	$(Q)dune build $(DUNEFLAGS) cerberus.install cn.install
 	@echo "\nDONE"

--- a/backend/cn/main.ml
+++ b/backend/cn/main.ml
@@ -3,6 +3,7 @@ module CF=Cerb_frontend
 module CB=Cerb_backend
 open CB.Pipeline
 open Setup
+open Version 
 
 module A=CF.AilSyntax
 
@@ -460,5 +461,7 @@ let () =
       no_inherit_loc $
       magic_comment_char_dollar
   in
-  Stdlib.exit @@ Cmd.(eval (v (info "cn") check_t))
+  let version_str = "CN v." ^ git_hash ^ "\n(Computed automatically from git hash)" in 
+  let cn_info = Cmd.info "cn" ~version:version_str in 
+  Stdlib.exit @@ Cmd.(eval (v cn_info check_t))
 

--- a/backend/cn/main.ml
+++ b/backend/cn/main.ml
@@ -3,7 +3,6 @@ module CF=Cerb_frontend
 module CB=Cerb_backend
 open CB.Pipeline
 open Setup
-open Version 
 
 module A=CF.AilSyntax
 
@@ -461,7 +460,7 @@ let () =
       no_inherit_loc $
       magic_comment_char_dollar
   in
-  let version_str = "CN v." ^ git_hash ^ "\n(Computed automatically from git hash)" in 
+  let version_str = "CN version: " ^ Cerb_frontend.Version.version in 
   let cn_info = Cmd.info "cn" ~version:version_str in 
   Stdlib.exit @@ Cmd.(eval (v cn_info check_t))
 


### PR DESCRIPTION
We should eventually add proper version numbers for CN, but as a stop-gap, it'd be useful to know the provenance of every `cn` binary. This PR builds a hash with every binary, and makes it available through the `--version` command line argument. (This idea proposed by @yav) 

How it works: 
* Generate a hash by calling `git rev-parse --short HEAD` in the top level Makefile
* Store the result in `backend/cn/version.ml`
* Modify the `cn` command-line options using the `Cmd.info ~version:XX` capability from `CmdLiner`