### PR TITLE
[CN] Make CN run both Z3 and CVC5 in CI, tidy up runner CI script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     
     - name: Restore cached opam
       id: cache-opam-restore
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       with:
         path: ~/.opam
         key: ${{ matrix.version }}
@@ -53,7 +53,7 @@ jobs:
     - name: Save cached opam
       if: steps.cache-opam-restore.outputs.cache-hit != 'true'
       id: cache-opam-save
-      uses: actions/cache/save@v3
+      uses: actions/cache/save@v4
       with:
         path: ~/.opam
         key: ${{ steps.cache-opam-restore.outputs.cache-primary-key }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,19 @@ jobs:
         cd tests; USE_OPAM='' ./run-ci.sh
         cd ..
 
+    - name: Download cvc5 release 
+      uses: robinraju/release-downloader@v1 
+      with: 
+        repository: cvc5/cvc5
+        tag: cvc5-1.1.2
+        fileName: cvc5-Linux-static.zip
+
+    - name: Unzip and install cvc5
+      run: |
+        unzip cvc5-Linux-static.zip
+        chmod +x cvc5-Linux-static/bin/cvc5
+        sudo cp cvc5-Linux-static/bin/cvc5 /usr/local/bin/
+
     - name: Install CN
       run: |
         opam switch ${{ matrix.version }}
@@ -85,9 +98,7 @@ jobs:
       with: 
         repository: rems-project/cn-tutorial
         path: cn-tutorial
-        # ref: fix-semicolon-syntax
 
-    # copying 'Run Cerberus CI tests'
     - name: Run CN CI tests
       run: |
         opam switch ${{ matrix.version }}
@@ -95,13 +106,11 @@ jobs:
         cd tests; USE_OPAM='' ./run-cn.sh
         cd ..
 
-    # copying 'Run Cerberus CI tests'
     - name: Run CN Tutorial CI tests
       run: |
         opam switch ${{ matrix.version }}
         eval $(opam env --switch=${{ matrix.version }})
         USE_OPAM='' tests/run-cn-tutorial-ci.sh cn-tutorial
-
 
     - name: Install Cerberus-CHERI
       if: ${{ matrix.version == '4.14.1' }}

--- a/tests/run-cn-tutorial-ci.sh
+++ b/tests/run-cn-tutorial-ci.sh
@@ -22,56 +22,38 @@ HERE=$(pwd)
 
 cd "$TUTORIAL_PATH"/src/example-archive/
 
-if [ -f ./check-all.sh ]; then
-    ./check-all.sh $CN
-    exit $?
-fi
-
 FAILURE=0
 
-cd dafny-tutorial
-../check.sh $CN
+# Check the example archive 
+./check-all.sh "$CN --solver-type=cvc5"
 if [ $? != 0 ] 
 then
    FAILURE=1
 fi
-cd ..
 
-cd SAW
-../check.sh $CN
+./check-all.sh "$CN --solver-type=z3"
 if [ $? != 0 ] 
 then
    FAILURE=1
 fi
-cd ..
-
-cd c-testsuite
-../check.sh $CN
-if [ $? != 0 ] 
-then
-   FAILURE=1
-fi
-cd ..
-
-cd simple-examples
-../check.sh $CN
-if [ $? != 0 ] 
-then
-   FAILURE=1
-fi
-cd ..
 
 
+# Check the tutorial examples 
 cd ../..
-./check.sh $CN
+
+./check.sh "$CN --solver-type=cvc5"
+if [ $? != 0 ] 
+then
+   FAILURE=1
+fi
+
+./check.sh "$CN --solver-type=z3"
 if [ $? != 0 ] 
 then
    FAILURE=1
 fi
 
 cd $HERE
-
-
 
 if [ $FAILURE == 0 ]
 then

--- a/tests/run-cn-tutorial-ci.sh
+++ b/tests/run-cn-tutorial-ci.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-
 TUTORIAL_PATH=$1
 
 if [ -n "$TUTORIAL_PATH" ] 
@@ -11,8 +10,6 @@ else
     exit 1
 fi
 
-
-
 # copying from run-ci.sh
 export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:`ocamlfind query z3`
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`ocamlfind query z3`
@@ -20,38 +17,15 @@ CN=$OPAM_SWITCH_PREFIX/bin/cn
 
 HERE=$(pwd)
 
-cd "$TUTORIAL_PATH"/src/example-archive/
+cd "$TUTORIAL_PATH"
 
 FAILURE=0
 
-# Check the example archive 
-./check-all.sh "$CN --solver-type=cvc5"
-if [ $? != 0 ] 
-then
-   FAILURE=1
-fi
+make check CN_PATH="$CN --solver-type=cvc5"
+FAILURE+=$?
 
-./check-all.sh "$CN --solver-type=z3"
-if [ $? != 0 ] 
-then
-   FAILURE=1
-fi
-
-
-# Check the tutorial examples 
-cd ../..
-
-./check.sh "$CN --solver-type=cvc5"
-if [ $? != 0 ] 
-then
-   FAILURE=1
-fi
-
-./check.sh "$CN --solver-type=z3"
-if [ $? != 0 ] 
-then
-   FAILURE=1
-fi
+make check CN_PATH="$CN --solver-type=z3"
+FAILURE+=$?
 
 cd $HERE
 


### PR DESCRIPTION
NOTE: depends on [this PR](https://github.com/rems-project/cn-tutorial/pull/37) in the `cn-tutorial` repo, which fixes a bug in the runner script handling of `cn` arguments. 

This PR also significantly tides up the runner script and shifts most of the logic over to the `cn-tutorial` MakeFile, and fixes a bug that was stopping some tests from running. 