### PR TITLE
CN-exec: Add support for leak-checking and free

### DIFF
--- a/backend/cn/executable_spec_internal.ml
+++ b/backend/cn/executable_spec_internal.ml
@@ -77,7 +77,9 @@ let generate_c_pres_and_posts_internal with_ownership_checking (instrumentation 
       | Some (entry_ownership_stats, exit_ownership_stats) -> 
          let entry_ownership_str = generate_ail_stat_strs ([], entry_ownership_stats) in 
          let exit_ownership_str = generate_ail_stat_strs ([], exit_ownership_stats) in 
-         let pre_post_pair = (pre_str @ ("\n\t/* C OWNERSHIP */\n\n" :: entry_ownership_str), post_str @ ("\n\t/* C OWNERSHIP */\n\n" :: exit_ownership_str)) in 
+         let pre_post_pair = (pre_str @ ("\n\t/* C OWNERSHIP */\n\n" :: entry_ownership_str),
+                              (* TODO - revisit this Dhruv over-confident change *)
+                              ("\n\t/* C OWNERSHIP */\n\n" :: exit_ownership_str) @ post_str) in
          (pre_post_pair, block_ownership_injs)
       | None -> ((pre_str, post_str), []))
   else 

--- a/backend/cn/executable_spec_internal.ml
+++ b/backend/cn/executable_spec_internal.ml
@@ -78,7 +78,7 @@ let generate_c_pres_and_posts_internal with_ownership_checking (instrumentation 
          let entry_ownership_str = generate_ail_stat_strs ([], entry_ownership_stats) in 
          let exit_ownership_str = generate_ail_stat_strs ([], exit_ownership_stats) in 
          let pre_post_pair = (pre_str @ ("\n\t/* C OWNERSHIP */\n\n" :: entry_ownership_str),
-                              (* TODO - revisit this Dhruv over-confident change *)
+                              (* NOTE - the nesting pre - entry - exit - post *)
                               ("\n\t/* C OWNERSHIP */\n\n" :: exit_ownership_str) @ post_str) in
          (pre_post_pair, block_ownership_injs)
       | None -> ((pre_str, post_str), []))

--- a/runtime/libcn/dune
+++ b/runtime/libcn/dune
@@ -5,7 +5,7 @@
        (:src (glob_files src/*.c)))
  (action
   (progn
-   (run cc -Iinclude/ -c %{src})
+   (run cc -Iinclude/ -c -g %{src})
    (run ar -rcs %{target} alloc.o hash_table.o utils.o))))
 
 (install

--- a/runtime/libcn/include/cn-executable/utils.h
+++ b/runtime/libcn/include/cn-executable/utils.h
@@ -100,11 +100,10 @@ void ghost_stack_depth_incr(void);
 void ghost_stack_depth_decr(void);
 
 
-/* malloc, free (eventually) */
+/* malloc, free */
 void *cn_aligned_alloc(size_t align, size_t size) ;
 void *cn_malloc(unsigned long size) ;
 void *cn_calloc(size_t num, size_t size) ;
-// TODO - revisit this Dhruv over-confident change
 void cn_free_sized(void*, size_t len);
 
 void cn_print_nr_u64(int i, unsigned long u) ;

--- a/runtime/libcn/include/cn-executable/utils.h
+++ b/runtime/libcn/include/cn-executable/utils.h
@@ -104,8 +104,12 @@ void ghost_stack_depth_decr(void);
 void *cn_aligned_alloc(size_t align, size_t size) ;
 void *cn_malloc(unsigned long size) ;
 void *cn_calloc(size_t num, size_t size) ;
+// TODO - revisit this Dhruv over-confident change
+void cn_free_sized(void*, size_t len);
+
 void cn_print_nr_u64(int i, unsigned long u) ;
 void cn_print_u64(const char *str, unsigned long u) ;
+
 
 /* Conversion functions */
 

--- a/runtime/libcn/src/utils.c
+++ b/runtime/libcn/src/utils.c
@@ -105,12 +105,12 @@ void ghost_stack_depth_decr(void) {
     cn_stack_depth--;
     // update_error_message_info(0);
     print_error_msg_info();
-    // TODO - revisit this Dhruv over-confident change
+    // leak checking
     hash_table_iterator it = ht_iterator(cn_ownership_global_ghost_state);
     printf("CN pointers leaked at (%ld) stack-depth: ", cn_stack_depth);
     _Bool leaked = false;
     while (ht_next(&it)) {
-        uintptr_t *key = it.key;
+        intptr_t *key = it.key;
         int *depth = it.value;
         _Bool fine = *depth <= cn_stack_depth;
         if (!fine) {
@@ -193,7 +193,7 @@ void cn_put_ownership(uintptr_t generic_c_ptr, size_t size) {
 }
 
 void cn_assume_ownership(void *generic_c_ptr, unsigned long size, char *fun) {
-    printf("[CN: assuming ownership] " FMT_PTR_2 ", size: %lu\n", (uintptr_t) generic_c_ptr, size);
+    printf("[CN: assuming ownership (%s)] " FMT_PTR_2 ", size: %lu\n", fun, (uintptr_t) generic_c_ptr, size);
     //print_error_msg_info();
     for (int i = 0; i < size; i++) { 
         signed long *address_key = alloc(sizeof(long));
@@ -244,7 +244,7 @@ void c_remove_local_from_ghost_state(uintptr_t ptr_to_local, size_t size) {
 
 void c_ownership_check(uintptr_t generic_c_ptr, int offset) {
     signed long address_key = 0;
-    printf("C: Checking ownership for [ " FMT_PTR " .. " FMT_PTR " [ -- ", generic_c_ptr, generic_c_ptr + offset);
+    printf("C: Checking ownership for [ " FMT_PTR " .. " FMT_PTR " ] -- ", generic_c_ptr, generic_c_ptr + offset);
     for (int i = 0; i<offset; i++) {
       address_key = generic_c_ptr + i;
       int curr_depth = ownership_ghost_state_get(&address_key);
@@ -446,7 +446,6 @@ void *cn_calloc(size_t num, size_t size)
   }
 }
 
-// TODO - revisit this Dhruv over-confident change *)
 void cn_free_sized(void* malloced_ptr, size_t size)
 {
   printf("[CN: freeing ownership] " FMT_PTR ", size: %lu\n", (uintptr_t) malloced_ptr, size);

--- a/tests/cn-runtime/cn-runtime-single-file.sh
+++ b/tests/cn-runtime/cn-runtime-single-file.sh
@@ -65,7 +65,7 @@ else
   cd $EXEC_DIR
   echo -n "Compiling... "
 
-  if ! clang-18 -c -I$RUNTIME_PREFIX/include/ *.c $OWNERSHIP_C_FILE_OPT $RUNTIME_PREFIX/libcn.a
+  if ! clang-18 -g -c -I$RUNTIME_PREFIX/include/ *.c $OWNERSHIP_C_FILE_OPT $RUNTIME_PREFIX/libcn.a
   then
     echo "compiling failed."
   else 

--- a/tests/cn-runtime/cn-runtime-single-file.sh
+++ b/tests/cn-runtime/cn-runtime-single-file.sh
@@ -65,13 +65,13 @@ else
   cd $EXEC_DIR
   echo -n "Compiling... "
 
-  if ! clang-18 -g -c -I$RUNTIME_PREFIX/include/ *.c $OWNERSHIP_C_FILE_OPT $RUNTIME_PREFIX/libcn.a
+  if ! cc -g -c -I$RUNTIME_PREFIX/include/ *.c $OWNERSHIP_C_FILE_OPT $RUNTIME_PREFIX/libcn.a
   then
     echo "compiling failed."
   else 
     echo "done!"
     echo "Linking..."
-    if ! clang-18 -I$RUNTIME_PREFIX/include/ -o $INPUT_BASENAME-exec-output.bin *.o $OWNERSHIP_OBJECT_FILE_OPT $RUNTIME_PREFIX/libcn.a
+    if ! cc -I$RUNTIME_PREFIX/include/ -o $INPUT_BASENAME-exec-output.bin *.o $OWNERSHIP_OBJECT_FILE_OPT $RUNTIME_PREFIX/libcn.a
     then 
       echo "linking failed."
     else 

--- a/tests/cn/double_free.error.runtime.c
+++ b/tests/cn/double_free.error.runtime.c
@@ -1,5 +1,3 @@
-// TODO - revisit this Dhruv over-confident change
-
 #ifndef CN_UTILS
 void *cn_malloc(unsigned long long);
 void cn_free_sized(void*, unsigned long long);

--- a/tests/cn/double_free.error.runtime.c
+++ b/tests/cn/double_free.error.runtime.c
@@ -1,0 +1,32 @@
+// TODO - revisit this Dhruv over-confident change
+
+#ifndef CN_UTILS
+void *cn_malloc(unsigned long long);
+void cn_free_sized(void*, unsigned long long);
+#endif
+
+unsigned int deref(unsigned int *p)
+/*@ trusted;
+requires
+    take v1_ = Owned(p);
+ensures
+    take v2 = Owned(p);
+    v1_ == v2;
+    return == v1_;
+@*/
+{
+  return *p;
+}
+
+int main()
+/*@ trusted; @*/
+{
+    unsigned int *p = cn_malloc(sizeof(unsigned int));
+    *p = 5;
+    unsigned int x = deref(p);
+    /*@ assert (x == 5u32); @*/
+    /*@ assert (*p == 5u32); @*/
+    cn_free_sized(p, sizeof(unsigned int));
+    // double free
+    cn_free_sized(p, sizeof(unsigned int));
+}

--- a/tests/cn/down_malloc_up_free.runtime.c
+++ b/tests/cn/down_malloc_up_free.runtime.c
@@ -1,0 +1,28 @@
+// TODO - revisit this Dhruv over-confident change
+
+#ifndef CN_UTILS
+void *cn_malloc(unsigned long long);
+void cn_free_sized(void* p, unsigned long long x);
+#endif
+
+unsigned int read_and_free(unsigned int *p)
+/*@ trusted;
+requires
+    take v1_ = Owned(p);
+ensures
+    return == v1_;
+@*/
+{
+  unsigned int result = *p;
+  cn_free_sized(p, sizeof(unsigned int));
+  return result;
+}
+
+int main()
+/*@ trusted; @*/
+{
+    unsigned int *x = cn_malloc(sizeof(unsigned int));
+    *x = 5;
+    unsigned int res = read_and_free(x);
+    /*@ assert (res == 5u32); @*/
+}

--- a/tests/cn/down_malloc_up_free.runtime.c
+++ b/tests/cn/down_malloc_up_free.runtime.c
@@ -1,5 +1,3 @@
-// TODO - revisit this Dhruv over-confident change
-
 #ifndef CN_UTILS
 void *cn_malloc(unsigned long long);
 void cn_free_sized(void* p, unsigned long long x);

--- a/tests/cn/leaky.error.runtime.c
+++ b/tests/cn/leaky.error.runtime.c
@@ -1,5 +1,3 @@
-// TODO - revisit this Dhruv over-confident change
-
 #ifndef CN_UTILS
 void *cn_malloc(unsigned long long);
 void cn_free_sized(void*, unsigned long long);

--- a/tests/cn/leaky.error.runtime.c
+++ b/tests/cn/leaky.error.runtime.c
@@ -1,0 +1,25 @@
+// TODO - revisit this Dhruv over-confident change
+
+#ifndef CN_UTILS
+void *cn_malloc(unsigned long long);
+void cn_free_sized(void*, unsigned long long);
+#endif
+
+unsigned int leaky_get (unsigned int *p)
+/*@ trusted;
+requires
+    take v1_ = Owned(p);
+ensures
+    return == v1_;
+@*/
+{
+  return *p;
+}
+
+int main()
+/*@ trusted; @*/
+{
+    unsigned int *x = cn_malloc(sizeof(unsigned int));
+    *x = 5;
+    unsigned int res = leaky_get(x);
+}

--- a/tests/cn/leaky_main.runtime.c
+++ b/tests/cn/leaky_main.runtime.c
@@ -1,5 +1,3 @@
-// TODO - revisit this Dhruv over-confident change
-
 #ifndef CN_UTILS
 void *cn_malloc(unsigned long long);
 void cn_free_sized(void*, unsigned long long);

--- a/tests/cn/leaky_main.runtime.c
+++ b/tests/cn/leaky_main.runtime.c
@@ -1,0 +1,29 @@
+// TODO - revisit this Dhruv over-confident change
+
+#ifndef CN_UTILS
+void *cn_malloc(unsigned long long);
+void cn_free_sized(void*, unsigned long long);
+#endif
+
+unsigned int *mkref(unsigned int x)
+/*@ trusted;
+requires
+    true;
+ensures
+    take v1_ = Owned(return);
+    v1_ == x;
+@*/
+{
+  unsigned int *p = cn_malloc(sizeof(unsigned int));
+  *p = x;
+  return p;
+}
+
+int main()
+/*@ trusted; @*/
+{
+    unsigned int *p = mkref(5);
+    /*@ assert (*p == 5u32); @*/
+    // TODO - consider decrementing stack-depth for main too?
+    // or it doesn't matter? main can be called multiple times.
+}

--- a/tests/cn/return_owned_local.error.runtime.c
+++ b/tests/cn/return_owned_local.error.runtime.c
@@ -1,5 +1,3 @@
-// TODO - revisit this Dhruv over-confident change
-
 #ifndef CN_UTILS
 void *cn_malloc(unsigned long long);
 void cn_free_sized(void*, unsigned long long);

--- a/tests/cn/return_owned_local.error.runtime.c
+++ b/tests/cn/return_owned_local.error.runtime.c
@@ -1,0 +1,46 @@
+// TODO - revisit this Dhruv over-confident change
+
+#ifndef CN_UTILS
+void *cn_malloc(unsigned long long);
+void cn_free_sized(void*, unsigned long long);
+#endif
+
+unsigned int get (unsigned int *p)
+/*@
+requires
+    take v1_ = Owned(p);
+ensures
+    take v2 = Owned(p);
+    v2 == v1_; return == v1_;
+@*/
+{
+  return *p;
+}
+
+
+unsigned int **bad(unsigned int *p)
+/*@ trusted;
+requires
+    take v1_ = Owned(p);
+ensures
+    take v2 = Owned(p);
+    take p2 = Owned(return);
+    ptr_eq(p, p2);
+    v1_ == v2;
+@*/
+{
+    return &p;
+}
+
+int main()
+/*@ trusted; @*/
+{
+    unsigned int *x = cn_malloc(sizeof(unsigned int));
+    *x = 5;
+    unsigned int res = get(x);
+    /*@ assert (res == 5u32); @*/
+    *x = 6;
+    /*@ assert (*x == 6u32); @*/
+
+    unsigned int **p = bad(x);
+}

--- a/tests/cn/same_func_malloc_free.runtime.c
+++ b/tests/cn/same_func_malloc_free.runtime.c
@@ -1,5 +1,3 @@
-// TODO - revisit this Dhruv over-confident change
-
 #ifndef CN_UTILS
 void *cn_malloc(unsigned long long);
 void cn_free_sized(void*, unsigned long long);

--- a/tests/cn/same_func_malloc_free.runtime.c
+++ b/tests/cn/same_func_malloc_free.runtime.c
@@ -1,0 +1,30 @@
+// TODO - revisit this Dhruv over-confident change
+
+#ifndef CN_UTILS
+void *cn_malloc(unsigned long long);
+void cn_free_sized(void*, unsigned long long);
+#endif
+
+unsigned int deref(unsigned int *p)
+/*@ trusted;
+requires
+    take v1_ = Owned(p);
+ensures
+    take v2 = Owned(p);
+    v1_ == v2;
+    return == v1_;
+@*/
+{
+  return *p;
+}
+
+int main()
+/*@ trusted; @*/
+{
+    unsigned int *p = cn_malloc(sizeof(unsigned int));
+    *p = 5;
+    unsigned int x = deref(p);
+    /*@ assert (x == 5u32); @*/
+    /*@ assert (*p == 5u32); @*/
+    cn_free_sized(p, sizeof(unsigned int));
+}

--- a/tests/cn/swap_array.runtime.c
+++ b/tests/cn/swap_array.runtime.c
@@ -1,0 +1,36 @@
+void swap_array (int *p, int n, int i, int j)
+/* --BEGIN-- */
+/*@ requires take a1 = each(i32 k; 0i32 <= k && k < n) { Owned<int>(array_shift<int>(p,k)) };
+             0i32 <= i && i < n;
+             0i32 <= j && j < n;
+             j != i;
+    ensures take a2 = each(i32 k; 0i32 <= k && k < n) { Owned<int>(array_shift<int>(p,k)) };
+            a2 == a1[i: a1[j], j: a1[i]];
+@*/
+/* --END-- */
+{
+/* --BEGIN-- */
+  /*@ extract Owned<int>, i; @*/
+/* --END-- */
+  int tmp = p[i];
+/* --BEGIN-- */
+  /*@ extract Owned<int>, j; @*/
+/* --END-- */
+  p[i] = p[j];
+  p[j] = tmp;
+}
+
+int main()
+/*@ trusted; @*/
+{
+    int a[3] = { 0, 1, 2 };
+
+    swap_array(a, 3, 0, 2);
+    int *first = a;
+    int *third = a + 2;
+    /*@ assert (*third == 0i32); @*/
+    /*@ assert (*first == 2i32); @*/
+
+    // uncomment for failure
+    // swap_array(a, 3, 1, 1);
+}

--- a/tests/cn/up_malloc_down_free.runtime.c
+++ b/tests/cn/up_malloc_down_free.runtime.c
@@ -1,5 +1,3 @@
-// TODO - revisit this Dhruv over-confident change
-
 #ifndef CN_UTILS
 void *cn_malloc(unsigned long long);
 void cn_free_sized(void*, unsigned long long);

--- a/tests/cn/up_malloc_down_free.runtime.c
+++ b/tests/cn/up_malloc_down_free.runtime.c
@@ -1,0 +1,28 @@
+// TODO - revisit this Dhruv over-confident change
+
+#ifndef CN_UTILS
+void *cn_malloc(unsigned long long);
+void cn_free_sized(void*, unsigned long long);
+#endif
+
+unsigned int *mkref(unsigned int x)
+/*@ trusted;
+requires
+    true;
+ensures
+    take v1_ = Owned(return);
+    v1_ == x;
+@*/
+{
+  unsigned int *p = cn_malloc(sizeof(unsigned int));
+  *p = x;
+  return p;
+}
+
+int main()
+/*@ trusted; @*/
+{
+    unsigned int *p = mkref(5);
+    /*@ assert (*p == 5u32); @*/
+    cn_free_sized(p, sizeof(unsigned int));
+}


### PR DESCRIPTION
Adding support for frees doesn't make sense without also adding support for leak checking.

This commit adds both, and a few tests cases to check behaviour is as expected. Notably, it swaps the order of the post-condition checking and locals unmapping (if this were not done,
return_owned_local.error.runtime.c would erroneously pass runtime testing).

It's a fairly rushed commit for the POPL deadline and hopefully doesn't cause too much carnage.