### PR TITLE
[CN] Properly define/select HTML output menu bar elements

### DIFF
--- a/backend/cn/report.ml
+++ b/backend/cn/report.ml
@@ -420,7 +420,7 @@ th {
 
 let script = {|
 var current_page = 1
-const menu = document.getElementById("menu1").children
+const menu = document.getElementById("menu1").getElementsByTagName("li")
 const pageinfo = document.getElementById("pageinfo")
 const pages = document.getElementById("pages").children
 const cn_code = document.getElementById("cn_code")


### PR DESCRIPTION
I believe CN's state HTML output intends to show only one information "block" (the information unit consisting of "Available resources", "Terms", and "Constraints" sections) when a given "snapshot" (the information window that users move forward and backward with the "first"/"prev"/"next"/"last" buttons) is in view. However, at the moment, all such blocks are displayed at once when a state file is first opened.

This PR solves this problem by correctly defining the JavaScript `menu` variable. Its erroneous definition, and a subsequent attempt to index it, causes initialization (via the function `init`) to abort early, before it can hide the rest of the information blocks.