### PR TITLE
[CN-Test-Gen] Purely unfolding implementation

### DIFF
--- a/backend/cn/main.ml
+++ b/backend/cn/main.ml
@@ -125,11 +125,11 @@ let check_input_file filename =
     if not (ext ".c" || ext ".h") then
       CF.Pp_errors.fatal ("file \""^filename^"\" has wrong file extension")
 
-let maybe_generate_tests output_test_dir filename test_max_depth testing_framework ail_prog prog5 =
+let maybe_generate_tests output_test_dir filename max_unfolds testing_framework ail_prog prog5 =
   Option.iter (fun output_dir ->
     let (_, sigma) = ail_prog in
     Cerb_colour.without_colour (fun () ->
-      TestGeneration.main output_dir filename test_max_depth sigma prog5 testing_framework)
+      TestGeneration.main ~output_dir ~filename ~max_unfolds sigma prog5 testing_framework)
     ())
     output_test_dir
 
@@ -171,7 +171,7 @@ let main
       no_inherit_loc
       magic_comment_char_dollar
       output_test_dir
-      test_max_depth
+      test_max_unfolds
       testing_framework
   =
   if json then begin
@@ -228,7 +228,7 @@ let main
       print_log_file ("mucore", MUCORE prog5);
       let paused = Typing.run_to_pause Context.empty (Check.check_decls_lemmata_fun_specs prog5) in
       Result.iter_error handle_error (Typing.pause_to_result paused);
-      maybe_generate_tests output_test_dir filename test_max_depth testing_framework ail_prog prog5;
+      maybe_generate_tests output_test_dir filename test_max_unfolds testing_framework ail_prog prog5;
       begin match output_decorated with
       | None ->
         Typing.run_from_pause (fun paused -> Check.check paused lemmata) paused
@@ -445,14 +445,14 @@ let lemmata =
 
 end
 
-module TestGenerationFlags = struct
+module Test_Generation_Flags = struct
 let output_test_dir =
   let doc = "[Experimental] Generate test suites and place them in the provided directory" in
   Arg.(value & opt (some string) None & info ["output-test-dir"] ~docv:"FILE" ~doc)
 
-let test_max_depth =
-  let doc = "[Experimental] Set the maximum depth of test suite generation" in
-  Arg.(value & opt int 5 & info ["test-max-depth"] ~docv:"FILE" ~doc)
+let test_max_unfolds =
+  let doc = "[Experimental] Set the maximum number of unfolds for test suite generation" in
+  Arg.(value & opt int 5 & info ["test-max-unfolds"] ~docv:"FILE" ~doc)
 
 let testing_framework =
   let doc = "[Experimental] Specify the testing framework for test suite generation " in
@@ -500,9 +500,9 @@ let () =
       Verify_flags.batch $
       Common_flags.no_inherit_loc $
       Common_flags.magic_comment_char_dollar $
-      TestGenerationFlags.output_test_dir $
-      TestGenerationFlags.test_max_depth $
-      TestGenerationFlags.testing_framework
+      Test_Generation_Flags.output_test_dir $
+      Test_Generation_Flags.test_max_unfolds $
+      Test_Generation_Flags.testing_framework
   in
   let version_str = "CN version: " ^ Cn_version.git_version in
   let cn_info = Cmd.info "cn" ~version:version_str in

--- a/backend/cn/main.ml
+++ b/backend/cn/main.ml
@@ -125,6 +125,14 @@ let check_input_file filename =
     if not (ext ".c" || ext ".h") then
       CF.Pp_errors.fatal ("file \""^filename^"\" has wrong file extension")
 
+let maybe_generate_tests output_test_dir filename test_max_depth testing_framework ail_prog prog5 =
+  Option.iter (fun output_dir ->
+    let (_, sigma) = ail_prog in
+    Cerb_colour.without_colour (fun () ->
+      TestGeneration.main output_dir filename test_max_depth sigma prog5 testing_framework)
+    ())
+    output_test_dir
+
 let main
       filename
       macros
@@ -162,6 +170,9 @@ let main
       batch
       no_inherit_loc
       magic_comment_char_dollar
+      output_test_dir
+      test_max_depth
+      testing_framework
   =
   if json then begin
       if debug_level > 0 then
@@ -217,6 +228,7 @@ let main
       print_log_file ("mucore", MUCORE prog5);
       let paused = Typing.run_to_pause Context.empty (Check.check_decls_lemmata_fun_specs prog5) in
       Result.iter_error handle_error (Typing.pause_to_result paused);
+      maybe_generate_tests output_test_dir filename test_max_depth testing_framework ail_prog prog5;
       begin match output_decorated with
       | None ->
         Typing.run_from_pause (fun paused -> Check.check paused lemmata) paused
@@ -433,6 +445,20 @@ let lemmata =
 
 end
 
+module TestGenerationFlags = struct
+let output_test_dir =
+  let doc = "[Experimental] Generate test suites and place them in the provided directory" in
+  Arg.(value & opt (some string) None & info ["output-test-dir"] ~docv:"FILE" ~doc)
+
+let test_max_depth =
+  let doc = "[Experimental] Set the maximum depth of test suite generation" in
+  Arg.(value & opt int 5 & info ["test-max-depth"] ~docv:"FILE" ~doc)
+
+let testing_framework =
+  let doc = "[Experimental] Specify the testing framework for test suite generation " in
+  Arg.(value & opt (enum ["gtest", TestGeneration.GTest]) GTest & info ["testing-framework"] ~doc)
+
+end
 
 let () =
   let open Term in
@@ -473,7 +499,10 @@ let () =
       Verify_flags.use_peval $
       Verify_flags.batch $
       Common_flags.no_inherit_loc $
-      Common_flags.magic_comment_char_dollar
+      Common_flags.magic_comment_char_dollar $
+      TestGenerationFlags.output_test_dir $
+      TestGenerationFlags.test_max_depth $
+      TestGenerationFlags.testing_framework
   in
   let version_str = "CN version: " ^ Cn_version.git_version in
   let cn_info = Cmd.info "cn" ~version:version_str in

--- a/backend/cn/solver.ml
+++ b/backend/cn/solver.ml
@@ -1285,6 +1285,8 @@ let model_evaluator solver mo =
 type model = IT.t -> IT.t option
 type model_with_q = model * (Sym.t * LogicalSorts.t) list
 
+let empty_model = (fun it -> Some it)
+
 type model_state =
   | Model of model_with_q
   | No_model

--- a/backend/cn/solver.mli
+++ b/backend/cn/solver.mli
@@ -2,6 +2,7 @@ type solver
 type model
 type model_with_q = model * (Sym.t * LogicalSorts.t) list
 
+val empty_model : model
 val random_seed : int ref
 val log_to_temp : bool ref
 val log_dir     : (string option) ref

--- a/backend/cn/testGeneration.ml
+++ b/backend/cn/testGeneration.ml
@@ -9,7 +9,7 @@ module LAT = LogicalArgumentTypes
 module CF = Cerb_frontend
 open CF
 
-let _weak_sym_equal s1 s2 =
+let weak_sym_equal s1 s2 =
   String.equal (Pp_symbol.to_string_pretty s1) (Pp_symbol.to_string_pretty s2)
 ;;
 
@@ -102,6 +102,180 @@ let _string_of_goal ((vars, ms, locs, cs) : goal) : string =
   ^ "Cs: "
   ^ string_of_constraints cs
   ^ "\n"
+;;
+
+let bt_of_ctype (loc : Cerb_location.t) (ty : Ctype.ctype) : BT.t =
+  BT.of_sct
+    AilTypesAux.is_signed_ity
+    Memory.size_of_integer_type
+    (Sctypes.of_ctype_unsafe loc ty)
+;;
+
+let add_to_vars_ms
+  (sigma : GenTypes.genTypeCategory AilSyntax.sigma)
+  (sym : Symbol.sym)
+  (ty : Ctype.ctype)
+  (vars : variables)
+  (ms : members)
+  : variables * members
+  =
+  match ty with
+  | Ctype (_, Struct n) ->
+    (match List.assoc weak_sym_equal n sigma.tag_definitions with
+     | _, _, StructDef (membs, _) ->
+       let f (Symbol.Identifier (_, id), (_, _, _, ty)) =
+         let sym' = Symbol.fresh () in
+         ( ( sym'
+           , ( ty
+             , IT.IT
+                 ( Sym sym'
+                 , bt_of_ctype (Cerb_location.other __FUNCTION__) ty
+                 , Cerb_location.other __FUNCTION__ ) ) )
+         , (id, (ty, sym')) )
+       in
+       let vars', member_data = List.split (List.map f membs) in
+       ( (( sym
+          , ( ty
+            , IT.IT
+                ( Sym sym
+                , bt_of_ctype (Cerb_location.other __FUNCTION__) ty
+                , Cerb_location.other __FUNCTION__ ) ) )
+          :: vars)
+         @ vars'
+       , (sym, member_data) :: ms )
+     | _ -> failwith ("No struct '" ^ Pp_symbol.to_string_pretty n ^ "' defined"))
+  | _ ->
+    ( ( sym
+      , ( ty
+        , IT.fresh_named
+            (bt_of_ctype (Cerb_location.other __FUNCTION__) ty)
+            (Pp_symbol.to_string_pretty sym)
+            (Cerb_location.other __FUNCTION__)
+          |> snd ) )
+      :: vars
+    , ms )
+;;
+
+let ( >>= ) (x : 'a list) (f : 'a -> 'b list) : 'b list = List.flatten (List.map f x)
+let return (x : 'a) : 'a list = [ x ]
+
+let collect_lc (vars : variables) (ms : members) (lc : LC.t)
+  : (variables * members * locations * constraints) list
+  =
+  match lc with
+  | T it -> return (vars, ms, [], [ it ])
+  | Forall _ -> failwith "`each` not supported"
+;;
+
+let rec collect_clauses
+  (max_depth : int)
+  (sigma : _ AilSyntax.sigma)
+  (prog5 : unit Mucore.mu_file)
+  (vars : variables)
+  (ms : members)
+  (cs : RP.clause list)
+  : (IT.t * variables * members * locations * constraints) list
+  =
+  match cs with
+  | c :: cs' ->
+    let rest =
+      List.map
+        (fun (v, vars, ms, locs, cs) ->
+          ( v
+          , vars
+          , ms
+          , locs
+          , IT.IT (Unop (Not, c.guard), BT.Bool, Cerb_location.other __FUNCTION__) :: cs ))
+        (collect_clauses max_depth sigma prog5 vars ms cs')
+    in
+    collect_lat_it max_depth sigma prog5 vars ms c.packing_ft
+    >>= fun (v, vars, ms, locs, cs) -> (v, vars, ms, locs, c.guard :: cs) :: rest
+  | [] -> []
+
+and collect_ret
+  (max_depth : int)
+  (sigma : _ AilSyntax.sigma)
+  (prog5 : unit Mucore.mu_file)
+  (vars : variables)
+  (ms : members)
+  (ret : RET.t)
+  : (IT.t * variables * members * locations * constraints) list
+  =
+  match ret with
+  | P { name = Owned (ty, _); pointer; iargs = [] } ->
+    let sym = Symbol.fresh () in
+    let ty = Sctypes.to_ctype ty in
+    let vars, ms = add_to_vars_ms sigma sym ty vars ms in
+    let l = Cerb_location.other __FUNCTION__ in
+    return (IT.IT (Sym sym, bt_of_ctype l ty, l), vars, ms, [ pointer, sym ], [])
+  | P { name = Owned (_, _); _ } -> failwith "Incorrect number of arguments for `Owned`"
+  | P { name = PName psym; pointer; iargs } ->
+    if max_depth <= 0
+    then []
+    else (
+      let pred = List.assoc weak_sym_equal psym prog5.mu_resource_predicates in
+      let args = List.combine (List.map fst pred.iargs) iargs in
+      let clauses =
+        Option.get pred.clauses
+        |> List.map (RP.subst_clause (IT.make_subst [ pred.pointer, pointer ]))
+        |> List.map
+             (List.fold_right
+                (fun (x, v) acc -> RP.subst_clause (IT.make_subst [ x, v ]) acc)
+                args)
+      in
+      collect_clauses (max_depth - 1) sigma prog5 vars ms clauses)
+  | Q _ -> failwith "`each` not supported"
+
+and collect_lat_it
+  (max_depth : int)
+  (sigma : _ AilSyntax.sigma)
+  (prog5 : unit Mucore.mu_file)
+  (vars : variables)
+  (ms : members)
+  (lat : IT.t LAT.t)
+  : (IT.t * variables * members * locations * constraints) list
+  =
+  let lat_subst x v e = LAT.subst IT.subst (IT.make_subst [ x, v ]) e in
+  match lat with
+  | Define ((x, tm), _, lat') ->
+    collect_lat_it max_depth sigma prog5 vars ms (lat_subst x tm lat')
+  | Resource ((x, (ret, _)), _, lat') ->
+    collect_ret max_depth sigma prog5 vars ms ret
+    >>= fun (v, vars, ms, locs, cs) ->
+    collect_lat_it max_depth sigma prog5 vars ms (lat_subst x v lat')
+    >>= fun (v', vars, ms, locs', cs') -> return (v', vars, ms, locs @ locs', cs @ cs')
+  | Constraint (lc, _, lat') ->
+    collect_lc vars ms lc
+    >>= fun (vars, ms, locs, cs) ->
+    collect_lat_it max_depth sigma prog5 vars ms lat'
+    >>= fun (v, vars, ms, locs', cs') -> return (v, vars, ms, locs @ locs', cs @ cs')
+  | I it -> return (it, vars, ms, [], [])
+;;
+
+let rec _collect_lat
+  (max_depth : int)
+  (sigma : _ AilSyntax.sigma)
+  (prog5 : unit Mucore.mu_file)
+  (vars : variables)
+  (ms : members)
+  (lat : unit LAT.t)
+  : (variables * members * locations * constraints) list
+  =
+  let lat_subst x v e = LAT.subst (fun _ x -> x) (IT.make_subst [ x, v ]) e in
+  match lat with
+  | Define ((x, tm), _, lat') ->
+    _collect_lat max_depth sigma prog5 vars ms (lat_subst x tm lat')
+  | Resource ((x, (ret, _)), _, lat') ->
+    collect_ret max_depth sigma prog5 vars ms ret
+    >>= fun (v, vars, ms, locs, cs) ->
+    _collect_lat max_depth sigma prog5 vars ms (lat_subst x v lat')
+    >>= fun (vars, ms, locs', cs') -> return (vars, ms, locs @ locs', cs @ cs')
+  | Constraint (lc, _, lat') ->
+    collect_lc vars ms lc
+    >>= fun (vars, ms, locs, cs) ->
+    _collect_lat max_depth sigma prog5 vars ms lat'
+    >>= fun (vars, ms, locs', cs') -> return (vars, ms, locs @ locs', cs @ cs')
+  | I _ -> return (vars, ms, [], [])
 ;;
 
 type test_framework = GTest

--- a/backend/cn/testGeneration.ml
+++ b/backend/cn/testGeneration.ml
@@ -729,6 +729,151 @@ let _compile ((vars, ms, locs, cs) : goal) : gen_context =
 
 type test_framework = GTest
 
+let rec codify_it_ (e : BT.t IT.term_) : string =
+  match e with
+  | Const Null -> "nullptr"
+  | Const (Bits ((Signed, bits), n)) when bits <= 16 -> Int64.to_string (Z.to_int64 n)
+  | Const (Bits ((Unsigned, bits), n)) when bits <= 16 ->
+    Int64.to_string (Z.to_int64 n) ^ "U"
+  | Const (Bits ((Signed, bits), n)) when bits <= 32 ->
+    Int64.to_string (Z.to_int64 n) ^ "L"
+  | Const (Bits ((Unsigned, bits), n)) when bits <= 32 ->
+    string_of_int (Z.to_int n) ^ "UL"
+  | Const (Bits ((Signed, bits), n)) when bits <= 64 ->
+    Int64.to_string (Z.to_int64 n) ^ "LL"
+  | Const (Bits ((Unsigned, bits), n)) when bits <= 64 ->
+    Int64.to_string (Z.to_int64 n) ^ "ULL"
+  | Const (Bool b) -> string_of_bool b
+  | Sym x -> Sym.pp_string x
+  | Unop (Not, e') -> "(!" ^ codify_it e' ^ ")"
+  | Unop (Negate, e') -> "(-" ^ codify_it e' ^ ")"
+  | Binop (And, e1, e2) -> "(" ^ codify_it e1 ^ " && " ^ codify_it e2 ^ ")"
+  | Binop (Or, e1, e2) -> codify_it e1 ^ " || " ^ codify_it e2 ^ ")"
+  | Binop (Implies, e1, e2) -> "((!" ^ codify_it e1 ^ ") || " ^ codify_it e2 ^ ")"
+  | Binop (Add, e1, e2) -> "(" ^ codify_it e1 ^ " + " ^ codify_it e2 ^ ")"
+  | Binop (Sub, e1, e2) -> "(" ^ codify_it e1 ^ " - " ^ codify_it e2 ^ ")"
+  | Binop (Mul, e1, e2) | Binop (MulNoSMT, e1, e2) ->
+    "(" ^ codify_it e1 ^ " * " ^ codify_it e2 ^ ")"
+  | Binop (Div, e1, e2) | Binop (DivNoSMT, e1, e2) ->
+    "(" ^ codify_it e1 ^ " / " ^ codify_it e2 ^ ")"
+  | Binop (XORNoSMT, e1, e2) -> "(" ^ codify_it e1 ^ " ^ " ^ codify_it e2 ^ ")"
+  | Binop (BWAndNoSMT, e1, e2) -> "(" ^ codify_it e1 ^ " & " ^ codify_it e2 ^ ")"
+  | Binop (BWOrNoSMT, e1, e2) -> "(" ^ codify_it e1 ^ " | " ^ codify_it e2 ^ ")"
+  | Binop (ShiftLeft, e1, e2) -> "(" ^ codify_it e1 ^ " << " ^ codify_it e2 ^ ")"
+  | Binop (ShiftRight, e1, e2) -> "(" ^ codify_it e1 ^ " >> " ^ codify_it e2 ^ ")"
+  | Binop (LT, e1, e2) | Binop (LTPointer, e1, e2) ->
+    "(" ^ codify_it e1 ^ " < " ^ codify_it e2 ^ ")"
+  | Binop (LE, e1, e2) | Binop (LEPointer, e1, e2) ->
+    "(" ^ codify_it e1 ^ " <= " ^ codify_it e2 ^ ")"
+  | Binop (EQ, e1, e2) -> "(" ^ codify_it e1 ^ " == " ^ codify_it e2 ^ ")"
+  | Binop (Mod, e1, e2) -> "(" ^ codify_it e1 ^ " % " ^ codify_it e2 ^ ")"
+  | ITE (e1, e2, e3) ->
+    "(" ^ codify_it e1 ^ " ? " ^ codify_it e2 ^ " : " ^ codify_it e3 ^ ")"
+  (* *)
+  | _ -> failwith "unsupported operation"
+
+and codify_it (e : IT.t) : string =
+  let (IT (e_, _, _)) = e in
+  try codify_it_ e_ with
+  | Failure _ ->
+    failwith ("unsupported operation" ^ Pp_utils.to_plain_pretty_string (IT.pp e))
+;;
+
+let rec codify_gen' (g : gen) : string =
+  match g with
+  | Arbitrary ty -> "rc::gen::arbitrary<" ^ string_of_ctype ty ^ ">()"
+  | Return (ty, e) -> "rc::gen::just<" ^ string_of_ctype ty ^ ">(" ^ codify_it e ^ ")"
+  | Filter (x', ty, e, g') ->
+    let gen = codify_gen' g' in
+    "rc::gen::suchThat("
+    ^ gen
+    ^ ", [=]("
+    ^ string_of_ctype ty
+    ^ " "
+    ^ Pp_symbol.to_string_pretty x'
+    ^ "){ return "
+    ^ codify_it e
+    ^ "; })"
+  | Map (x', ty, e, g') ->
+    let gen = codify_gen' g' in
+    "rc::gen::map("
+    ^ gen
+    ^ ", [=]("
+    ^ string_of_ctype ty
+    ^ " "
+    ^ Pp_symbol.to_string_pretty x'
+    ^ "){ return "
+    ^ codify_it e
+    ^ "; })"
+  | Alloc (ty, x) ->
+    "rc::gen::just<" ^ string_of_ctype ty ^ ">(&" ^ Pp_symbol.to_string_pretty x ^ ")"
+  | Struct (ty, ms) ->
+    "rc::gen::just<"
+    ^ string_of_ctype ty
+    ^ ">({ "
+    ^ String.concat
+        ", "
+        (List.map (fun (x, y) -> "." ^ x ^ " = " ^ Pp_symbol.to_string_pretty y) ms)
+    ^ "})"
+;;
+
+
+let codify_gen (x : Sym.sym) (g : gen) : string =
+  "/* "
+  ^ string_of_gen g
+  ^ " */\n"
+  ^ "auto "
+  ^ Pp_symbol.to_string_pretty x
+  ^ " = *"
+  ^ codify_gen' g
+  ^ ";\n"
+;;
+
+let rec codify_gen_context (gtx : gen_context) : string =
+  match gtx with
+  | (x, g) :: gtx' -> codify_gen x g ^ codify_gen_context gtx'
+  | [] -> ""
+;;
+
+let codify_pbt_header
+  (tf : test_framework)
+  (suite : string)
+  (test : string)
+  (oc : out_channel)
+  : unit
+  =
+  match tf with
+  | GTest ->
+    output_string
+      oc
+      ("\nRC_GTEST_PROP(Test" ^ String.capitalize_ascii suite ^ ", " ^ test ^ ", ()){\n")
+;;
+
+let _codify_pbt
+  (tf : test_framework)
+  (instrumentation : Core_to_mucore.instrumentation)
+  (args : (Symbol.sym * Ctype.ctype) list)
+  (index : int)
+  (oc : out_channel)
+  (gtx : gen_context)
+  : unit
+  =
+  codify_pbt_header
+    tf
+    (Pp_symbol.to_string_pretty instrumentation.fn)
+    ("Test" ^ string_of_int index)
+    oc;
+  output_string oc (codify_gen_context gtx);
+  output_string oc (Pp_symbol.to_string_pretty instrumentation.fn);
+  output_string oc "(";
+  output_string
+    oc
+    (args |> List.map fst |> List.map Pp_symbol.to_string_pretty |> String.concat ", ");
+  output_string oc ");\n";
+  match tf with
+  | GTest -> output_string oc "}\n\n"
+;;
+
 let main
   (_output_dir : string)
   (_filename : string)

--- a/backend/cn/testGeneration.ml
+++ b/backend/cn/testGeneration.ml
@@ -1,0 +1,16 @@
+module CF = Cerb_frontend
+open CF
+
+type test_framework = GTest
+
+let main
+  (_output_dir : string)
+  (_filename : string)
+  (_max_depth : int)
+  (_sigma : _ AilSyntax.sigma)
+  (_prog5 : unit Mucore.mu_file)
+  (_tf : test_framework)
+  : unit
+  =
+  ()
+;;

--- a/backend/cn/testGeneration.ml
+++ b/backend/cn/testGeneration.ml
@@ -731,6 +731,7 @@ let compile ((vars, ms, locs, cs) : goal) : gen_context =
 type test_framework = GTest
 
 let rec codify_it_ (e : BT.t IT.term_) : string option =
+  let exception Unsupported_codify_it in
   try
     Some
       (match e with
@@ -774,9 +775,9 @@ let rec codify_it_ (e : BT.t IT.term_) : string option =
        | ITE (e1, e2, e3) ->
          "(" ^ codify_it e1 ^ " ? " ^ codify_it e2 ^ " : " ^ codify_it e3 ^ ")"
        (* *)
-       | _ -> failwith __FUNCTION__)
+       | _ -> raise Unsupported_codify_it)
   with
-  | Failure str when String.equal __FUNCTION__ str -> None
+  | Unsupported_codify_it -> None
 
 and codify_it (e : IT.t) : string =
   let (IT (e_, _, _)) = e in

--- a/backend/cn/testGeneration.ml
+++ b/backend/cn/testGeneration.ml
@@ -1,5 +1,108 @@
+module AT = ArgumentTypes
+module BT = BaseTypes
+module RP = ResourcePredicates
+module IT = IndexTerms
+module LS = LogicalSorts
+module RET = ResourceTypes
+module LC = LogicalConstraints
+module LAT = LogicalArgumentTypes
 module CF = Cerb_frontend
 open CF
+
+let _weak_sym_equal s1 s2 =
+  String.equal (Pp_symbol.to_string_pretty s1) (Pp_symbol.to_string_pretty s2)
+;;
+
+let string_of_ctype (ty : Ctype.ctype) : string =
+  Cerb_colour.do_colour := false;
+  let tmp = String_ail.string_of_ctype ~is_human:true Ctype.no_qualifiers ty ^ " " in
+  Cerb_colour.do_colour := true;
+  tmp
+;;
+
+type variables = (Symbol.sym * (Ctype.ctype * IT.t)) list
+
+let string_of_variables (vars : variables) : string =
+  "{ "
+  ^ String.concat
+      "; "
+      (List.map
+         (fun (x, (ty, e)) ->
+           Pp_symbol.to_string_pretty x
+           ^ " -> ("
+           ^ string_of_ctype ty
+           ^ ", "
+           ^ Pp_utils.to_plain_pretty_string (IT.pp e)
+           ^ ")")
+         vars)
+  ^ " }"
+;;
+
+type locations = (IT.t * Symbol.sym) list
+
+let string_of_locations (locs : locations) : string =
+  "{ "
+  ^ String.concat
+      "; "
+      (List.map
+         (fun (e, x) ->
+           "(*"
+           ^ Pp_utils.to_plain_pretty_string (IT.pp e)
+           ^ ") -> "
+           ^ Pp_symbol.to_string_pretty x)
+         locs)
+  ^ " }"
+;;
+
+type members = (Symbol.sym * (string * (Ctype.ctype * Symbol.sym)) list) list
+
+let string_of_members (ms : members) : string =
+  "{ "
+  ^ String.concat
+      "; "
+      (List.map
+         (fun (x, ms) ->
+           Pp_symbol.to_string_pretty x
+           ^ " -> {"
+           ^ String.concat
+               ", "
+               (List.map
+                  (fun (y, (ty, z)) ->
+                    "."
+                    ^ y
+                    ^ ": "
+                    ^ string_of_ctype ty
+                    ^ " = "
+                    ^ Pp_symbol.to_string_pretty z)
+                  ms))
+         ms)
+  ^ " }"
+;;
+
+type constraints = IT.t list
+
+let string_of_constraints (cs : constraints) : string =
+  "{ "
+  ^ String.concat "; " (List.map (fun e -> Pp_utils.to_plain_pretty_string (IT.pp e)) cs)
+  ^ " }"
+;;
+
+type goal = variables * members * locations * constraints
+
+let _string_of_goal ((vars, ms, locs, cs) : goal) : string =
+  "Vars: "
+  ^ string_of_variables vars
+  ^ "\n"
+  ^ "Ms: "
+  ^ string_of_members ms
+  ^ "\n"
+  ^ "Locs: "
+  ^ string_of_locations locs
+  ^ "\n"
+  ^ "Cs: "
+  ^ string_of_constraints cs
+  ^ "\n"
+;;
 
 type test_framework = GTest
 

--- a/backend/cn/testGeneration.ml
+++ b/backend/cn/testGeneration.ml
@@ -568,7 +568,7 @@ let _string_of_gen_context (gtx : gen_context) : string =
   ^ " }"
 ;;
 
-let _filter_gen (x : Symbol.sym) (ty : Ctype.ctype) (cs : constraints) : gen =
+let filter_gen (x : Symbol.sym) (ty : Ctype.ctype) (cs : constraints) : gen =
   match cs with
   | c :: cs' ->
     Filter
@@ -581,6 +581,150 @@ let _filter_gen (x : Symbol.sym) (ty : Ctype.ctype) (cs : constraints) : gen =
           cs'
       , Arbitrary ty )
   | [] -> Arbitrary ty
+;;
+
+let compile_gen (x : Symbol.sym) (ty : Ctype.ctype) (e : IT.t) (cs : constraints) : gen =
+  match e with
+  | IT (Sym x', _, _) when weak_sym_equal x x' -> filter_gen x ty cs
+  | _ -> Return (ty, e)
+;;
+
+let rec compile_singles'
+  (gtx : gen_context)
+  (locs : locations)
+  (cs : constraints)
+  (iter : variables)
+  : gen_context * variables
+  =
+  let get_loc x =
+    List.find_map
+      (fun (e, y) ->
+        if weak_sym_equal x y
+        then (
+          match e with
+          | IT.IT (Sym z, _, _) -> Some z
+          | _ -> None)
+        else None)
+      locs
+  in
+  match iter with
+  | (x, (ty, e)) :: iter' ->
+    let var_in_gtx y =
+      List.find_opt (fun (z, _) -> weak_sym_equal y z) gtx |> Option.is_some
+    in
+    let relevant_cs =
+      List.filter
+        (fun c ->
+          List.exists
+            (weak_sym_equal x)
+            (c |> IT.free_vars |> IT.SymSet.to_seq |> List.of_seq))
+        cs
+    in
+    let no_free_vars =
+      List.for_all
+        (fun c ->
+          List.for_all
+            (fun y -> weak_sym_equal x y || var_in_gtx y)
+            (c |> IT.free_vars |> IT.SymSet.to_seq |> List.of_seq))
+        relevant_cs
+    in
+    if no_free_vars
+    then (
+      let gen = compile_gen x ty e relevant_cs in
+      let gen_loc = Alloc (Ctype.Ctype ([], Pointer (Ctype.no_qualifiers, ty)), x) in
+      match get_loc x with
+      | Some x_loc -> compile_singles' ((x_loc, gen_loc) :: (x, gen) :: gtx) locs cs iter'
+      | None -> compile_singles' ((x, gen) :: gtx) locs cs iter')
+    else (
+      let gtx, iter' = compile_singles' gtx locs cs iter' in
+      gtx, (x, (ty, e)) :: iter')
+  | [] -> gtx, iter
+;;
+
+let rec compile_singles
+  (gtx : gen_context)
+  (vars : variables)
+  (locs : locations)
+  (cs : constraints)
+  : gen_context
+  =
+  let gtx, vars = compile_singles' gtx locs cs vars in
+  if List.non_empty vars then compile_singles gtx vars locs cs else gtx
+;;
+
+let rec compile_structs'
+  (gtx : gen_context)
+  (vars : variables)
+  (ms : members)
+  (locs : locations)
+  : gen_context * members
+  =
+  let get_loc x =
+    List.find_map
+      (fun (e, y) ->
+        if weak_sym_equal x y
+        then (
+          match e with
+          | IT.IT (Sym z, _, _) -> Some z
+          | _ -> None)
+        else None)
+      locs
+  in
+  match ms with
+  | (x, syms) :: ms' ->
+    let gtx, ms' = compile_structs' gtx vars ms' locs in
+    let free_vars =
+      not
+        (List.for_all
+           (fun (_, (_, sym)) -> List.assoc_opt weak_sym_equal sym gtx |> Option.is_some)
+           syms)
+    in
+    if free_vars
+    then gtx, (x, syms) :: ms'
+    else (
+      let _, (ty, _) = List.find (fun (y, _) -> weak_sym_equal x y) vars in
+      let mems = List.map (fun (id, (_, sym)) -> id, sym) syms in
+      match get_loc x with
+      | Some loc ->
+        let gen = Struct (ty, mems) in
+        let gen_loc = Alloc (Ctype.Ctype ([], Pointer (Ctype.no_qualifiers, ty)), x) in
+        (loc, gen_loc) :: (x, gen) :: gtx, ms'
+      | None -> (x, Struct (ty, mems)) :: gtx, ms')
+  | [] -> gtx, []
+;;
+
+let rec compile_structs
+  (gtx : gen_context)
+  (vars : variables)
+  (ms : members)
+  (locs : locations)
+  : gen_context
+  =
+  let gtx, ms = compile_structs' gtx vars ms locs in
+  if List.non_empty ms then compile_structs gtx vars ms locs else gtx
+;;
+
+let _compile ((vars, ms, locs, cs) : goal) : gen_context =
+  (* Not owned *)
+  let vars' =
+    List.filter
+      (fun (x, _) ->
+        List.for_all
+          (fun (e, _) ->
+            match e with
+            | IT.IT (Sym y, _, _) -> not (weak_sym_equal x y)
+            | _ -> true)
+          locs)
+      vars
+  in
+  (* Not a struct *)
+  let vars' =
+    List.filter
+      (fun (x, _) -> List.for_all (fun (y, _) -> not (weak_sym_equal x y)) ms)
+      vars'
+  in
+  let gtx = compile_singles [] vars' locs cs in
+  compile_structs gtx vars ms locs |> List.rev
 ;;
 
 type test_framework = GTest

--- a/backend/cn/testGeneration.ml
+++ b/backend/cn/testGeneration.ml
@@ -278,6 +278,232 @@ let rec _collect_lat
   | I _ -> return (vars, ms, [], [])
 ;;
 
+let subst_goal (x : Symbol.sym) (v : IT.t) ((vars, ms, locs, cs) : goal) : goal =
+  let vars =
+    List.map (fun (x', (ty, e)) -> x', (ty, IT.subst (IT.make_subst [ x, v ]) e)) vars
+  in
+  let locs = List.map (fun (e, y) -> IT.subst (IT.make_subst [ x, v ]) e, y) locs in
+  let cs = List.map (fun e -> IT.subst (IT.make_subst [ x, v ]) e) cs in
+  vars, ms, locs, cs
+;;
+
+let rec inline_constants' (g : goal) (iter : constraints) : goal =
+  match iter with
+  | IT (Binop (EQ, IT (Const c, bt, loc), IT (Sym x, _, _)), _, _) :: iter'
+  | IT (Binop (EQ, IT (Sym x, _, _), IT (Const c, bt, loc)), _, _) :: iter' ->
+    let g = subst_goal x (IT (Const c, bt, loc)) g in
+    inline_constants' g iter'
+  | _ :: iter' -> inline_constants' g iter'
+  | [] -> g
+;;
+
+let inline_constants (g : goal) : goal =
+  let _, _, _, cs = g in
+  inline_constants' g cs
+;;
+
+let eval_term (it : IT.t) : IT.const option =
+  let g = Global.empty in
+  let m = Solver.empty_model in
+  match Solver.eval g m it with
+  | Some (IT (Const c, _, _)) -> Some c
+  | _ -> None
+;;
+
+let rec remove_tautologies ((vars, ms, locs, cs) : goal) : goal =
+  match cs with
+  | IT (Binop (EQ, IT (Sym x, _, _), IT (Sym y, _, _)), _, _) :: cs
+    when weak_sym_equal x y -> remove_tautologies (vars, ms, locs, cs)
+  | c :: cs ->
+    (match eval_term c with
+     | Some (Bool b) ->
+       if b
+       then remove_tautologies (vars, ms, locs, cs)
+       else failwith "Inconsistent constraints"
+     | Some _ -> failwith "unreachable"
+     | None ->
+       let vars, ms, locs, cs = remove_tautologies (vars, ms, locs, cs) in
+       vars, ms, locs, c :: cs)
+  | [] -> vars, ms, locs, cs
+;;
+
+let rec cnf_ (e : BT.t IT.term_) : BT.t IT.term_ =
+  match e with
+  (* Double negation elimination *)
+  | Unop (Not, IT (Unop (Not, IT (e, _, _)), _, _)) -> e
+  (* Flip inequalities *)
+  | Unop (Not, IT (Binop (LT, e1, e2), _, _)) -> Binop (LE, e2, e1)
+  | Unop (Not, IT (Binop (LE, e1, e2), _, _)) -> Binop (LT, e2, e1)
+  (* De Morgan's Law *)
+  | Unop (Not, IT (Binop (And, e1, e2), info, loc)) ->
+    Binop (Or, IT (Unop (Not, cnf e1), info, loc), IT (Unop (Not, cnf e2), info, loc))
+  | Unop (Not, IT (Binop (Or, e1, e2), info, loc)) ->
+    Binop (And, IT (Unop (Not, cnf e1), info, loc), IT (Unop (Not, cnf e2), info, loc))
+  (* Distribute disjunction *)
+  | Binop (Or, e1, IT (Binop (And, e2, e3), info, loc))
+  | Binop (Or, IT (Binop (And, e2, e3), info, loc), e1) ->
+    Binop (And, IT (Binop (Or, e1, e2), info, loc), IT (Binop (Or, e1, e3), info, loc))
+  | _ -> e
+
+and cnf (e : IT.t) : IT.t =
+  let (IT (e, info, loc)) = e in
+  IT (cnf_ e, info, loc)
+;;
+
+let rec inline_aliasing' (g : goal) (iter : constraints) : goal =
+  match iter with
+  | IT (Binop (EQ, IT (Sym x, info_x, loc_x), IT (Sym y, _, _)), info_y, loc_y) :: iter'
+    ->
+    let vars, _, _, _ = g in
+    let g =
+      match List.assoc weak_sym_equal x vars with
+      | _, IT (Sym x', _, _) when weak_sym_equal x x' ->
+        subst_goal x (IT (Sym y, info_y, loc_y)) g
+      | _ -> subst_goal y (IT (Sym x, info_x, loc_x)) g
+    in
+    inline_aliasing' g iter'
+  | _ :: iter' -> inline_aliasing' g iter'
+  | [] -> g
+;;
+
+let inline_aliasing (g : goal) : goal =
+  let _, _, _, cs = g in
+  inline_aliasing' g cs
+;;
+
+let rec remove_nonnull_for_locs ((vars, ms, locs, cs) : goal) : goal =
+  match cs with
+  | IT (Unop (Not, IT (Binop (EQ, e, IT (Const Null, _, _)), _, _)), _, _) :: cs
+    when List.assoc_opt Stdlib.( = ) e locs |> Option.is_some ->
+    remove_nonnull_for_locs (vars, ms, locs, cs)
+  | IT (Unop (Not, IT (Binop (EQ, IT (Const Null, _, _), e), _, _)), _, _) :: cs
+    when List.assoc_opt Stdlib.( = ) e locs |> Option.is_some ->
+    remove_nonnull_for_locs (vars, ms, locs, cs)
+  | c :: cs ->
+    let vars, ms, locs, cs = remove_nonnull_for_locs (vars, ms, locs, cs) in
+    vars, ms, locs, c :: cs
+  | [] -> vars, ms, locs, []
+;;
+
+let rec indirect_members_expr_ (ms : members) (e : BT.t IT.term_) : BT.t IT.term_ =
+  match e with
+  | StructMember (IT (Sym x, _, _), Symbol.Identifier (_, y)) ->
+    let new_sym = List.assoc weak_sym_equal x ms |> List.assoc String.equal y |> snd in
+    Sym new_sym
+  | Unop (op, e') -> Unop (op, indirect_members_expr ms e')
+  | Binop (op, e1, e2) ->
+    Binop (op, indirect_members_expr ms e1, indirect_members_expr ms e2)
+  | ITE (e_if, e_then, e_else) ->
+    ITE
+      ( indirect_members_expr ms e_if
+      , indirect_members_expr ms e_then
+      , indirect_members_expr ms e_else )
+  | EachI ((min, (x', bt), max), e') ->
+    EachI ((min, (x', bt), max), indirect_members_expr ms e')
+  | Tuple es -> Tuple (List.map (indirect_members_expr ms) es)
+  | NthTuple (i, e') -> NthTuple (i, indirect_members_expr ms e')
+  | Struct (x', xes) ->
+    Struct (x', List.map (fun (x', e') -> x', indirect_members_expr ms e') xes)
+  | StructMember (e', x') -> StructMember (indirect_members_expr ms e', x')
+  | StructUpdate ((e', x'), e'') ->
+    StructUpdate ((indirect_members_expr ms e', x'), indirect_members_expr ms e'')
+  | Record xes -> Record (List.map (fun (x', e') -> x', indirect_members_expr ms e') xes)
+  | RecordMember (e', x') -> RecordMember (indirect_members_expr ms e', x')
+  | RecordUpdate ((e', x'), e'') ->
+    RecordUpdate ((indirect_members_expr ms e', x'), indirect_members_expr ms e'')
+  | Constructor (x', xes) ->
+    Constructor (x', List.map (fun (x', e') -> x', indirect_members_expr ms e') xes)
+  | MemberShift (e', x', x'') -> MemberShift (indirect_members_expr ms e', x', x'')
+  | ArrayShift { base; ct; index } ->
+    ArrayShift
+      { base = indirect_members_expr ms base; ct; index = indirect_members_expr ms index }
+  | CopyAllocId { addr; loc } ->
+    CopyAllocId
+      { addr = indirect_members_expr ms addr; loc = indirect_members_expr ms loc }
+  | Cons (e1, e2) -> Cons (indirect_members_expr ms e1, indirect_members_expr ms e2)
+  | Head e' -> Head (indirect_members_expr ms e')
+  | Tail e' -> Tail (indirect_members_expr ms e')
+  | NthList (e1, e2, e3) ->
+    NthList
+      ( indirect_members_expr ms e1
+      , indirect_members_expr ms e2
+      , indirect_members_expr ms e3 )
+  | ArrayToList (e1, e2, e3) ->
+    ArrayToList
+      ( indirect_members_expr ms e1
+      , indirect_members_expr ms e2
+      , indirect_members_expr ms e3 )
+  | Representable (ty, e') -> Representable (ty, indirect_members_expr ms e')
+  | Good (ty, e') -> Good (ty, indirect_members_expr ms e')
+  | Aligned { t; align } ->
+    Aligned { t = indirect_members_expr ms t; align = indirect_members_expr ms align }
+  | WrapI (ty, e') -> WrapI (ty, indirect_members_expr ms e')
+  | MapConst (bt, e') -> MapConst (bt, indirect_members_expr ms e')
+  | MapSet (e1, e2, e3) ->
+    MapSet
+      ( indirect_members_expr ms e1
+      , indirect_members_expr ms e2
+      , indirect_members_expr ms e3 )
+  | MapGet (e1, e2) -> MapGet (indirect_members_expr ms e1, indirect_members_expr ms e2)
+  | MapDef (xbt, e') -> MapDef (xbt, indirect_members_expr ms e')
+  | Apply (x', es) -> Apply (x', List.map (indirect_members_expr ms) es)
+  | Let ((x', e1), e2) ->
+    Let ((x', indirect_members_expr ms e1), indirect_members_expr ms e2)
+  | Match (e', pes) ->
+    Match
+      ( indirect_members_expr ms e'
+      , List.map (fun (p, e') -> p, indirect_members_expr ms e') pes )
+  | Cast (bt, e') -> Cast (bt, indirect_members_expr ms e')
+  | Sym _ | Const _ | SizeOf _ | OffsetOf _ | Nil _ -> e
+
+and indirect_members_expr (ms : members) (e : IT.t) : IT.t =
+  let (IT (e, info, loc)) = e in
+  IT (indirect_members_expr_ ms e, info, loc)
+;;
+
+let indirect_members ((vars, ms, locs, cs) : goal) : goal =
+  ( List.map (fun (x, (ty, e)) -> x, (ty, indirect_members_expr ms e)) vars
+  , ms
+  , List.map (fun (e, x) -> indirect_members_expr ms e, x) locs
+  , List.map (fun e -> indirect_members_expr ms e) cs )
+;;
+
+let listify_constraints (cs : constraints) : constraints =
+  let rec loop (c : IT.t) : constraints =
+    match c with
+    | IT (Binop (And, e1, e2), _, _) -> loop e1 @ loop e2
+    | _ -> [ c ]
+  in
+  List.map loop cs |> List.flatten
+;;
+
+let remove_good (cs : constraints) : constraints =
+  List.filter
+    (fun (c : IT.t) ->
+      match c with
+      | IT (Good _, _, _) -> false
+      | _ -> true)
+    cs
+;;
+
+let _simplify (g : goal) : goal =
+  let g = indirect_members g in
+  let vars, ms, locs, cs = g in
+  let g = vars, ms, locs, List.map cnf cs in
+  let g = remove_nonnull_for_locs g in
+  let rec loop (g : goal) : goal =
+    let og = g in
+    let g = inline_constants g in
+    let g = inline_aliasing g in
+    let vars, ms, locs, cs = remove_tautologies g in
+    let cs = listify_constraints cs in
+    let cs = remove_good cs in
+    let g = vars, ms, locs, cs in
+    if Stdlib.( <> ) og g then loop g else g
+  in
+  loop g
+;;
+
 type test_framework = GTest
 
 let main

--- a/backend/cn/testGeneration.mli
+++ b/backend/cn/testGeneration.mli
@@ -1,0 +1,12 @@
+module CF = Cerb_frontend
+
+type test_framework = GTest
+
+val main
+  :  string
+  -> string
+  -> int
+  -> _ CF.AilSyntax.sigma
+  -> unit Mucore.mu_file
+  -> test_framework
+  -> unit

--- a/backend/cn/testGeneration.mli
+++ b/backend/cn/testGeneration.mli
@@ -6,7 +6,7 @@ val main
   :  string
   -> string
   -> int
-  -> _ CF.AilSyntax.sigma
+  -> CF.GenTypes.genTypeCategory CF.AilSyntax.sigma
   -> unit Mucore.mu_file
   -> test_framework
   -> unit

--- a/backend/cn/testGeneration.mli
+++ b/backend/cn/testGeneration.mli
@@ -2,10 +2,15 @@ module CF = Cerb_frontend
 
 type test_framework = GTest
 
+(** The entrypoint into test generation.
+    @param output_dir Directory to place generated test files
+    @param filename File with specifications to generate tests for
+    @param max_unfolds The maximum number of times that predicates will be unfolded
+**)
 val main
-  :  string
-  -> string
-  -> int
+  :  output_dir:string
+  -> filename:string
+  -> max_unfolds:int
   -> CF.GenTypes.genTypeCategory CF.AilSyntax.sigma
   -> unit Mucore.mu_file
   -> test_framework


### PR DESCRIPTION
Add an implementation of test generation.

This version generates Google Test harnesses with RapidCheck generators, one per path through the precondition.
It unfolds recursive predicates up to the specified max depth.

I still have to add some tests for CI.