### PR TITLE
Allow ' in numeric constants

### DIFF
--- a/parsers/c/c_lexer.mll
+++ b/parsers/c/c_lexer.mll
@@ -444,6 +444,10 @@ and initial flags = parse
       { CN_CONSTANT (str, `U, int_of_string n) }
   | (integer_constant as str) 'i' (cn_integer_width as n)
       { CN_CONSTANT (str, `I, int_of_string n) }
+  | (integer_constant as str) "'" 'u' (cn_integer_width as n)
+      { CN_CONSTANT (str, `U, int_of_string n) }
+  | (integer_constant as str) "'" 'i' (cn_integer_width as n)
+      { CN_CONSTANT (str, `I, int_of_string n) }
     (* /For CN. *)
   | (integer_constant as str)
       { CONSTANT (Cabs.CabsInteger_const (str, None)) }

--- a/tests/cn/apostrophy1.c
+++ b/tests/cn/apostrophy1.c
@@ -1,0 +1,45 @@
+//NOTE:
+/* You can use an apostrophe to separate numeric value and its sign and size.
+
+   For example: You can now do 3'i32 for 3i32. 
+
+   It makes it much more readable. */
+
+int add_or_subtract (int x, int y)
+/*@ requires let sum = (i64) x + (i64) y;
+             let diff = (i64) x - (i64) y;
+            -2147483648'i64 <= sum; sum <= 2147483647'i64;
+            -2147483648'i64 <= diff; diff <= 2147483647'i64;
+            let five = 5'u64;
+    ensures return == ((x > y) ? (i32) diff : (i32) sum); 
+@*/
+{
+    if (x > y)
+    {
+        return x - y;
+    }
+
+    return x + y;
+
+}
+
+// NOTE: 
+/* You can still do the regular 3i32 like nothing ever happened. */
+
+int add_or_subtract_ (int x, int y)
+/*@ requires let sum = (i64) x + (i64) y;
+             let diff = (i64) x - (i64) y;
+            -2147483648i64 <= sum; sum <= 2147483647i64;
+            -2147483648i64 <= diff; diff <= 2147483647i64;
+            let five = 5u64;
+    ensures return == ((x > y) ? (i32) diff : (i32) sum);
+@*/
+{
+    if (x > y)
+    {
+        return x - y;
+    }
+
+    return x + y;
+
+}

--- a/tests/cn/apostrophy2.c
+++ b/tests/cn/apostrophy2.c
@@ -1,0 +1,22 @@
+// NOTE:
+/*@ You can use the apostrophe and non-apostrophe way
+    of writing numeric constants interchangeably. @*/
+
+int add_or_subtract (int x, int y)
+/*@ requires let sum = (i64) x + (i64) y;
+             let diff = (i64) x - (i64) y;
+            -2147483648'i64 <= sum; sum <= 2147483647i64;
+            -2147483648i64 <= diff; diff <= 2147483647'i64;
+            let five = 5'u64;
+    ensures return == ((x > y) ? (i32) diff : (i32) sum);
+@*/
+{
+    if (x > y)
+    {
+        return x - y;
+    }
+
+    return x + y;
+
+}
+


### PR DESCRIPTION
Allowing `'` in numeric constants, so you can write things like `34'i32`.

This adds this as an option, however `34i32` still works.