### PR TITLE
[CN] Use subcommands (`cn verify` and `cn generate-tests`)

### DIFF
--- a/tests/cn-runtime/cn-runtime-dir.sh
+++ b/tests/cn-runtime/cn-runtime-dir.sh
@@ -37,7 +37,7 @@ do
   fi
   EXEC_C_FILE=$EXEC_C_DIRECTORY/$TEST_BASENAME-exec.c
   echo Generating $EXEC_C_FILE ...
-  if ! cn $TEST_NAME --output_decorated=$TEST_BASENAME-exec.c --output_decorated_dir=$EXEC_C_DIRECTORY/ --with_ownership_checking
+  if ! cn verify $TEST_NAME --output-decorated=$TEST_BASENAME-exec.c --output-decorated-dir=$EXEC_C_DIRECTORY/ --with-ownership-checking
   then
     echo Generation failed.
     NUM_GENERATION_FAILED=$(( $NUM_GENERATION_FAILED + 1 ))

--- a/tests/cn-runtime/cn-runtime-single-file.sh
+++ b/tests/cn-runtime/cn-runtime-single-file.sh
@@ -9,7 +9,7 @@ while getopts "o:" flag; do
  case $flag in
    o) 
    echo "Ownership checking enabled"
-   OWNERSHIP_CLI_FLAG="--with_ownership_checking"
+   OWNERSHIP_CLI_FLAG="--with-ownership-checking"
    OWNERSHIP_C_FILE="ownership.c"
    OWNERSHIP_OBJECT_FILE="ownership.o"
    ;;
@@ -57,7 +57,7 @@ fi
 
 
 echo -n "Generating C files from CN-annotated source... "
-if ! cn $INPUT_FN --output_decorated=$INPUT_BASENAME-exec.c --output_decorated_dir=$EXEC_DIR/ --with_ownership_checking
+if ! cn verify $INPUT_FN --output-decorated=$INPUT_BASENAME-exec.c --output-decorated-dir=$EXEC_DIR/ --with-ownership-checking
 then
   echo generation failed.
 else 

--- a/tests/cn/mutual_rec/build.sh
+++ b/tests/cn/mutual_rec/build.sh
@@ -1,6 +1,6 @@
 
 set -ex
-cn mutual_rec.c
-cn --lemmata coq_lemmas/theories/Gen_Spec.v mutual_rec.c 
+cn verify mutual_rec.c
+cn verify --lemmata coq_lemmas/theories/Gen_Spec.v mutual_rec.c 
 make -C coq_lemmas
 

--- a/tests/run-cn-tutorial-ci.sh
+++ b/tests/run-cn-tutorial-ci.sh
@@ -21,10 +21,10 @@ cd "$TUTORIAL_PATH"
 
 FAILURE=0
 
-make check CN_PATH="$CN --solver-type=cvc5"
+make check CN_PATH="$CN verify --solver-type=cvc5"
 ((FAILURE+=$?))
 
-make check CN_PATH="$CN --solver-type=z3"
+make check CN_PATH="$CN verify --solver-type=z3"
 ((FAILURE+=$?))
 
 cd $HERE

--- a/tests/run-cn-vip.sh
+++ b/tests/run-cn-vip.sh
@@ -15,10 +15,10 @@ SUCC=$(
         \! -name '*.error.c' \
         \! -name '*.unprovable.c' \
 )
-FAIL=$(find $DIRNAME/cn -name '*.error.c')
-ANNOT=$(find $DIRNAME/cn -name '*.annot.c')
+FAIL=$(find $DIRNAME/cn verify -name '*.error.c')
+ANNOT=$(find $DIRNAME/cn verify -name '*.annot.c')
 UNPROV=$(
-    find $DIRNAME/cn -name '*.unprovable.c' \
+    find $DIRNAME/cn verify -name '*.unprovable.c' \
         \! -name 'pointer_copy_user_ctrlflow_bytewise.unprovable.c'
 )
 
@@ -28,7 +28,7 @@ FAILED=''
 
 for TEST in $SUCC $ANNOT
 do
-  $CN -DVIP -DANNOT $TEST
+  $CN verify -DVIP -DANNOT $TEST
   RET=$?
   if [[ "$RET" = 0 ]]
   then
@@ -48,7 +48,7 @@ done
 
 for TEST in $FAIL $ANNOT $UNPROV
 do
-  $CN $TEST
+  $CN verify $TEST
   RET=$?
   if [[ "$RET" = 1 || "$RET" = 2 ]]
   then

--- a/tests/run-cn.sh
+++ b/tests/run-cn.sh
@@ -8,9 +8,9 @@ CN=$OPAM_SWITCH_PREFIX/bin/cn
 
 DIRNAME=$(dirname $0)
 
-SUCC=$(find $DIRNAME/cn -name '*.c' | grep -v '\.error\.c' | grep -v '\.unknown\.c')
-FAIL=$(find $DIRNAME/cn -name '*.error.c')
-UNKNOWN=$(find $DIRNAME/cn -name '*.unknown.c')
+SUCC=$(find $DIRNAME/verify -name '*.c' | grep -v '\.error\.c' | grep -v '\.unknown\.c')
+FAIL=$(find $DIRNAME/cn verify -name '*.error.c')
+UNKNOWN=$(find $DIRNAME/cn verify -name '*.unknown.c')
 
 NUM_FAILED=0
 FAILED=''
@@ -18,7 +18,7 @@ FAILED=''
 
 for TEST in $SUCC
 do
-  $CN $TEST
+  $CN verify $TEST
   RET=$?
   if [[ "$RET" = 0 ]]
   then
@@ -33,7 +33,7 @@ done
 
 for TEST in $FAIL
 do
-  $CN $TEST
+  $CN verify $TEST
   RET=$?
   if [[ "$RET" = 1 || "$RET" = 2 ]]
   then
@@ -52,7 +52,7 @@ done
 
 echo $UNKNOWN | xargs -n 1 cn
 
-COQ_LEMMAS=$(find $DIRNAME/cn -name 'coq_lemmas' -type d)
+COQ_LEMMAS=$(find $DIRNAME/cn verify -name 'coq_lemmas' -type d)
 
 for TEST in $COQ_LEMMAS
 do


### PR DESCRIPTION
Meant to address #343.

Currently:
- Moves the current functionality under `cn verify` and deprecates the current use `cn [FILE]`.
- Splits off test generation under `cn generate-tests`.
- Changes a few flags to use `-` as a separator instead of `_`, for consistency.

~~Easy to add:~~
- ~~Move the executable spec into a subcommand (I just couldn't come up with a great name)~~

Other thoughts:
- Are there any flags used by the frontend that are assigned outside the `frontend` function?
- Ideally, we'd also move lemma export into a subcommand, but it seems very tied to CN checking currently.

