### PR TITLE
Add optional arguments `rfrac` and `width` to `CF.Pp_utils. to_plain_pretty_string`

### DIFF
--- a/backend/cn/pp.mli
+++ b/backend/cn/pp.mli
@@ -242,7 +242,7 @@ val print : PPrint.ToChannel.channel -> document -> unit
 
 val print_file : string -> document -> unit
 
-val plain : PPrint.ToBuffer.document -> string
+val plain : ?rfrac:float -> ?width:int -> PPrint.ToBuffer.document -> string
 
 val ( ^^^ )
   :  Cerb_pp_prelude.P.document ->

--- a/backend/cn/testGeneration/dsl.ml
+++ b/backend/cn/testGeneration/dsl.ml
@@ -14,12 +14,7 @@ type gen =
 let rec string_of_gen (g : gen) : string =
   match g with
   | Arbitrary ty -> "arbitrary<" ^ string_of_ctype ty ^ ">()"
-  | Return (ty, e) ->
-    "return<"
-    ^ string_of_ctype ty
-    ^ ">("
-    ^ CF.Pp_utils.to_plain_pretty_string (IT.pp e)
-    ^ ")"
+  | Return (ty, e) -> "return<" ^ string_of_ctype ty ^ ">(" ^ Pp.plain (IT.pp e) ^ ")"
   | Filter (x, ty, e, g') ->
     "filter("
     ^ "|"
@@ -27,7 +22,7 @@ let rec string_of_gen (g : gen) : string =
     ^ ": "
     ^ string_of_ctype ty
     ^ "| "
-    ^ CF.Pp_utils.to_plain_pretty_string (IT.pp e)
+    ^ Pp.plain (IT.pp e)
     ^ ", "
     ^ string_of_gen g'
     ^ ")"
@@ -38,7 +33,7 @@ let rec string_of_gen (g : gen) : string =
     ^ ": "
     ^ string_of_ctype ty
     ^ "| "
-    ^ CF.Pp_utils.to_plain_pretty_string (IT.pp e)
+    ^ Pp.plain (IT.pp e)
     ^ ", "
     ^ string_of_gen g'
     ^ ")"

--- a/backend/cn/testGeneration/testGeneration.ml
+++ b/backend/cn/testGeneration/testGeneration.ml
@@ -58,30 +58,22 @@ let generate_pbt
       if debug then
         output_string
           oc
-          ("/* Collected:\n"
-           ^ CF.Pp_utils.to_plain_pretty_string (Constraints.pp_goal g)
-           ^ "\n*/\n\n");
+          ("/* Collected:\n" ^ Pp.plain ~width:90 (Constraints.pp_goal g) ^ "\n*/\n\n");
       let g = Constraints.simplify g in
       if debug then
         output_string
           oc
-          ("/* Simplified:\n"
-           ^ CF.Pp_utils.to_plain_pretty_string (Constraints.pp_goal g)
-           ^ "\n*/\n\n");
+          ("/* Simplified:\n" ^ Pp.plain ~width:90 (Constraints.pp_goal g) ^ "\n*/\n\n");
       let gtx = Dsl.compile g in
       if debug then
         output_string
           oc
-          ("/* Compiled:\n"
-           ^ CF.Pp_utils.to_plain_pretty_string (Dsl.pp_gen_context gtx)
-           ^ "\n*/\n\n");
+          ("/* Compiled:\n" ^ Pp.plain ~width:90 (Dsl.pp_gen_context gtx) ^ "\n*/\n\n");
       let gtx = Dsl.optimize gtx in
       if debug then
         output_string
           oc
-          ("/* Optimized:\n"
-           ^ CF.Pp_utils.to_plain_pretty_string (Dsl.pp_gen_context gtx)
-           ^ "\n*/\n\n");
+          ("/* Optimized:\n" ^ Pp.plain ~width:90 (Dsl.pp_gen_context gtx) ^ "\n*/\n\n");
       Codify.codify_pbt tf instrumentation args i oc gtx)
     (Constraints.collect ~max_unfolds sigma prog5 args lat)
 

--- a/ocaml_frontend/pprinters/pp_utils.ml
+++ b/ocaml_frontend/pprinters/pp_utils.ml
@@ -5,9 +5,9 @@ let to_plain_string d =
   Buffer.clear buf;
   str
 
-let to_plain_pretty_string d =
+let to_plain_pretty_string ?(rfrac=1.0) ?(width=150) d =
   let buf = Buffer.create 50 in
-  PPrint.ToBuffer.pretty 1.0 150 buf d;
+  PPrint.ToBuffer.pretty rfrac width buf d;
   let str = Buffer.contents buf in
   Buffer.clear buf;
   str


### PR DESCRIPTION
If there's an existing method for easily converting from `Pp.document` to a `string` with a set width, please let me know.