### PR TITLE
[CN] Fix formatting commit hash

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,2 @@
 # CN: Format code according to .ocamlformat file
-36882ab6e66ebb5e8c36e2bb7b80dbfa5be64322
+ce8b6186fde296e05532b05783de36e814cbf465


### PR DESCRIPTION
It looks like the existing commit hash referred to the hash of the formatting commit on its original branch, which was merged via #403. For some reason, though arguably for no good reason, GitHub will _not_ preserve hashes from a branch when merging a branch via rebase, even when the branch is entirely up to date, rebasing amounts to a fast-forward, and `git rebase` on its own _would_ preserve the hashes, all of which looks to have been true in #403. Instead, GitHub [creates new hashes](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/about-merge-methods-on-github#rebasing-and-merging-your-commits) from scratch for those commits.

This is the hash of the formatting commit as it exists on `master`. You can check locally that these commits contain the same content with `git diff`, i.e. `git diff 36882ab ce8b618`, which should show no differences.