### PR TITLE
[CN-Exec] Use `output-decorated-dir` as directory by using `Filename.concat`

### DIFF
--- a/backend/cn/executable_spec.ml
+++ b/backend/cn/executable_spec.ml
@@ -33,7 +33,7 @@ let rec open_auxilliary_files
        else (
          let fn_list = String.split_on_char '/' fn' in
          let output_fn = List.nth fn_list (List.length fn_list - 1) in
-         let output_fn_with_prefix = prefix ^ output_fn in
+         let output_fn_with_prefix = Filename.concat prefix output_fn in
          if Sys.file_exists output_fn_with_prefix then (
            Printf.printf
              "Error in opening file %s as it already exists\n"
@@ -204,9 +204,9 @@ let main
   statement_locs
   =
   let prefix = match output_decorated_dir with Some dir_name -> dir_name | None -> "" in
-  let oc = Stdlib.open_out (prefix ^ output_filename) in
-  let cn_oc = Stdlib.open_out (prefix ^ "cn.c") in
-  let cn_header_oc = Stdlib.open_out (prefix ^ "cn.h") in
+  let oc = Stdlib.open_out (Filename.concat prefix output_filename) in
+  let cn_oc = Stdlib.open_out (Filename.concat prefix "cn.c") in
+  let cn_header_oc = Stdlib.open_out (Filename.concat prefix "cn.h") in
   populate_record_map prog5;
   let instrumentation, symbol_table = Core_to_mucore.collect_instrumentation prog5 in
   let executable_spec =


### PR DESCRIPTION
I assume this is the intended behavior ("to the provided directory" from `--help`).

If not, I think the `doc` for the `output-decorated-dir` should be a bit clearer.