### PR TITLE
[CN] Use `Filename.concat` instead of `^` where appropriate

### DIFF
--- a/backend/cn/executable_spec.ml
+++ b/backend/cn/executable_spec.ml
@@ -33,7 +33,7 @@ let rec open_auxilliary_files
        else (
          let fn_list = String.split_on_char '/' fn' in
          let output_fn = List.nth fn_list (List.length fn_list - 1) in
-         let output_fn_with_prefix = prefix ^ output_fn in
+         let output_fn_with_prefix = Filename.concat prefix output_fn in
          if Sys.file_exists output_fn_with_prefix then (
            Printf.printf
              "Error in opening file %s as it already exists\n"
@@ -204,9 +204,9 @@ let main
   statement_locs
   =
   let prefix = match output_decorated_dir with Some dir_name -> dir_name | None -> "" in
-  let oc = Stdlib.open_out (prefix ^ output_filename) in
-  let cn_oc = Stdlib.open_out (prefix ^ "cn.c") in
-  let cn_header_oc = Stdlib.open_out (prefix ^ "cn.h") in
+  let oc = Stdlib.open_out (Filename.concat prefix output_filename) in
+  let cn_oc = Stdlib.open_out (Filename.concat prefix "cn.c") in
+  let cn_header_oc = Stdlib.open_out (Filename.concat prefix "cn.h") in
   populate_record_map prog5;
   let instrumentation, symbol_table = Core_to_mucore.collect_instrumentation prog5 in
   let executable_spec =

--- a/backend/cn/main.ml
+++ b/backend/cn/main.ml
@@ -33,11 +33,9 @@ end = struct
       Cerb_colour.do_colour := false;
       let count = !print_count in
       let file_path =
-        Filename.get_temp_dir_name ()
-        ^ Filename.dir_sep
-        ^ string_of_int count
-        ^ "__"
-        ^ filename
+        Filename.concat
+          (Filename.get_temp_dir_name ())
+          (string_of_int count ^ "__" ^ filename)
       in
       print_file file_path file;
       print_count := 1 + !print_count;
@@ -343,12 +341,6 @@ let generate_tests
   =
   (* flags *)
   Cerb_debug.debug_level := debug_level;
-  let output_dir =
-    if String.ends_with ~suffix:Filename.dir_sep output_dir then
-      output_dir
-    else
-      output_dir ^ Filename.dir_sep
-  in
   let handle_error (e : TypeErrors.type_error) =
     let report = TypeErrors.pp_message e.msg in
     Pp.error e.loc report.short (Option.to_list report.descr);

--- a/backend/cn/testGeneration/testGeneration.ml
+++ b/backend/cn/testGeneration/testGeneration.ml
@@ -99,10 +99,9 @@ let run
   in
   let oc =
     Stdlib.open_out
-      (output_dir
-       ^ "test_"
-       ^ (filename |> Filename.basename |> Filename.chop_extension)
-       ^ ".cpp")
+      (Filename.concat
+         output_dir
+         ("test_" ^ (filename |> Filename.basename |> Filename.chop_extension) ^ ".cpp"))
   in
   Codify.codify_prelude tf sigma instrumentation_list oc;
   List.iter (generate_pbt max_unfolds sigma prog5 tf oc) instrumentation_list


### PR DESCRIPTION
Better #421, using `Filename.concat` instead of using `prefix ^` or manually concatenating `Filename.dir_sep`.