### PR TITLE
CN: Fix and re-enable formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,7 @@ jobs:
       run: |
         opam switch ${{ matrix.version }}
         eval $(opam env --switch=${{ matrix.version }})
+        USE_OPAM='' cd backend/cn && dune build @fmt
 
     - name: Install Cerberus-CHERI
       if: ${{ matrix.version == '4.14.1' }}

--- a/backend/cn/lib/check.ml
+++ b/backend/cn/lib/check.ml
@@ -559,21 +559,21 @@ let rec check_pexpr (pe : BT.t mu_pexpr) (k : IT.t -> unit m) : unit m =
                 let@ model = model () in
                 let ub = CF.Undefined.UB045a_division_by_zero in
                 fail (fun ctxt -> { loc; msg = Undefined_behaviour { ub; ctxt; model } })))
-          | OpRem_t ->
-             let@ () = WellTyped.ensure_base_type loc ~expect (bt_of_pexpr pe1) in
-             let@ () = WellTyped.ensure_bits_type loc expect in
-             let@ () = WellTyped.ensure_bits_type loc (bt_of_pexpr pe2) in
-             check_pexpr pe1 (fun v1 ->
-              check_pexpr pe2 (fun v2 ->
-                let@ provable = provable loc in
-                let v2_bt = bt_of_pexpr pe2 in
-                let here = Locations.other __FUNCTION__ in
-                match provable (t_ (ne_ (v2, int_lit_ 0 v2_bt here) here)) with
-                | `True -> k (rem_ (v1, v2) loc)
-                | `False -> 
-                  let@ model = model () in
-                  let ub = CF.Undefined.UB045b_modulo_by_zero in
-                  fail (fun ctxt -> {loc; msg = Undefined_behaviour {ub; ctxt; model}})))
+        | OpRem_t ->
+          let@ () = WellTyped.ensure_base_type loc ~expect (bt_of_pexpr pe1) in
+          let@ () = WellTyped.ensure_bits_type loc expect in
+          let@ () = WellTyped.ensure_bits_type loc (bt_of_pexpr pe2) in
+          check_pexpr pe1 (fun v1 ->
+            check_pexpr pe2 (fun v2 ->
+              let@ provable = provable loc in
+              let v2_bt = bt_of_pexpr pe2 in
+              let here = Locations.other __FUNCTION__ in
+              match provable (t_ (ne_ (v2, int_lit_ 0 v2_bt here) here)) with
+              | `True -> k (rem_ (v1, v2) loc)
+              | `False ->
+                let@ model = model () in
+                let ub = CF.Undefined.UB045b_modulo_by_zero in
+                fail (fun ctxt -> { loc; msg = Undefined_behaviour { ub; ctxt; model } })))
         | OpEq ->
           let@ () = WellTyped.ensure_base_type loc ~expect Bool in
           let@ () =


### PR DESCRIPTION
https://github.com/rems-project/cerberus/commit/c77d64541983966a50cc00e349b6627756d18024 deleted the formatting CI check and https://github.com/rems-project/cerberus/commit/d7b47b7417ab78af0d9e0dbbc590453b83bc5870 committed badly formatted code.

This commit fixes both of the above.