### PR TITLE
[CN] Add CI for CN runtime testing capability 

### DIFF
--- a/.github/workflows/ci-runtime.yml
+++ b/.github/workflows/ci-runtime.yml
@@ -31,7 +31,7 @@ jobs:
       uses: actions/checkout@v4
       with: 
         repository: dc-mak/cerberus # FIXME: remove once the branch is merged 
-        ref: cn-runtime-testing # FIXME: remove once the branch is merged 
+        ref: upgrade-runtime-single-file-script # FIXME: remove once the branch is merged 
 
     - name: System dependencies (ubuntu)
       run: |

--- a/.github/workflows/ci-runtime.yml
+++ b/.github/workflows/ci-runtime.yml
@@ -1,0 +1,91 @@
+name: CI (CN runtime checks)
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - cheri-tests
+
+env:
+  CERBERUS_IMAGE_ID: ghcr.io/rems-project/cerberus/cn:release
+
+# cancel in-progress job when a new push is performed
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        # version: [4.12.0, 4.14.1]
+        version: [4.14.1]
+
+
+    runs-on: ubuntu-22.04
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: System dependencies (ubuntu)
+      run: |
+        sudo apt install build-essential libgmp-dev z3 opam cmake
+
+    - name: Restore cached opam
+      id: cache-opam-restore
+      uses: actions/cache/restore@v4
+      with:
+        path: ~/.opam
+        key: ${{ matrix.version }}
+
+    - name: Setup opam
+      if: steps.cache-opam-restore.outputs.cache-hit != 'true'
+      run: |
+        opam init --yes --no-setup --shell=sh --compiler=${{ matrix.version }}
+        opam install --deps-only --yes ./cerberus-lib.opam
+        opam switch create with_coq ${{ matrix.version }}
+        eval $(opam env --switch=with_coq)
+        opam repo add --yes --this-switch coq-released https://coq.inria.fr/opam/released
+        opam pin --yes -n coq-struct-tact https://github.com/uwplse/StructTact.git
+        opam repo add --yes --this-switch iris-dev https://gitlab.mpi-sws.org/iris/opam.git
+        opam pin --yes -n coq-sail-stdpp https://github.com/rems-project/coq-sail.git#f319aad
+        opam pin --yes -n coq-cheri-capabilities https://github.com/rems-project/coq-cheri-capabilities.git
+        opam install --deps-only --yes ./cerberus-lib.opam ./cerberus-cheri.opam
+
+    - name: Save cached opam
+      if: steps.cache-opam-restore.outputs.cache-hit != 'true'
+      id: cache-opam-save
+      uses: actions/cache/save@v4
+      with:
+        path: ~/.opam
+        key: ${{ steps.cache-opam-restore.outputs.cache-primary-key }}
+
+    - name: Install Cerberus
+      run: |
+        opam switch ${{ matrix.version }}
+        eval $(opam env --switch=${{ matrix.version }})
+        opam pin --yes --no-action add cerberus-lib .
+        opam pin --yes --no-action add cerberus .
+        opam install --yes cerberus
+
+    - name: Install CN
+      run: |
+        opam switch ${{ matrix.version }}
+        eval $(opam env --switch=${{ matrix.version }})
+        opam pin --yes --no-action add cn .
+        opam install --yes cn ocamlformat.0.26.2
+
+    - name: Checkout cn-tutorial
+      uses: actions/checkout@v4
+      with:
+        repository: rems-project/cn-tutorial
+        path: cn-tutorial
+        ref: cn-runtime-testing
+
+    - name: Run CN-runtime CI tests 
+      run: |
+        opam switch ${{ matrix.version }}
+        eval $(opam env --switch=${{ matrix.version }})
+        cd cn-tutorial; ./runtime-test.sh 
+        cd ..

--- a/.github/workflows/ci-runtime.yml
+++ b/.github/workflows/ci-runtime.yml
@@ -28,6 +28,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with: 
+        repository: dc-mak/cerberus # FIXME: remove once the branch is merged 
         ref: cn-runtime-testing # FIXME: remove once the branch is merged 
 
     - name: System dependencies (ubuntu)

--- a/.github/workflows/ci-runtime.yml
+++ b/.github/workflows/ci-runtime.yml
@@ -29,9 +29,6 @@ jobs:
 
     - name: Checkout cerberus 
       uses: actions/checkout@v4
-      with: 
-        repository: dc-mak/cerberus # FIXME: remove once the branch is merged 
-        ref: upgrade-runtime-single-file-script # FIXME: remove once the branch is merged 
 
     - name: System dependencies (ubuntu)
       run: |

--- a/.github/workflows/ci-runtime.yml
+++ b/.github/workflows/ci-runtime.yml
@@ -26,7 +26,9 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v3
+
+    - name: Checkout cerberus 
+      uses: actions/checkout@v4
       with: 
         repository: dc-mak/cerberus # FIXME: remove once the branch is merged 
         ref: cn-runtime-testing # FIXME: remove once the branch is merged 

--- a/.github/workflows/ci-runtime.yml
+++ b/.github/workflows/ci-runtime.yml
@@ -27,6 +27,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with: 
+        ref: cn-runtime-testing # FIXME: remove once the branch is merged 
 
     - name: System dependencies (ubuntu)
       run: |
@@ -81,7 +83,7 @@ jobs:
       with:
         repository: rems-project/cn-tutorial
         path: cn-tutorial
-        ref: cn-runtime-testing
+        ref: cn-runtime-testing # FIXME: remove once the branch is merged 
 
     - name: Run CN-runtime CI tests 
       run: |


### PR DESCRIPTION
Runs the CN runtime testing capability over specially-modified examples from the CN tutorial. 

Note: 
* The CI script checks out branch #439, which includes necessary test script modifications. Before merging this branch, we need to merge #439 and then the checkout target should be changed to `cerberus:master`
* The CI script applies the runtime testing to `cn-tutorial:cn-runtime-testing`. This branch adds `main()` functions to the tutorial examples, and so it cannot be merged into `cn-tutorial:main`. It's okay to merge without resolving this, but we should fix it sooner rather than later. 

