### PR TITLE
Pp imrovements

### DIFF
--- a/backend/cn/lib/indexTerms.ml
+++ b/backend/cn/lib/indexTerms.ml
@@ -28,7 +28,7 @@ let term_of_sterm : sterm -> typed = Terms.map_term SurfaceBaseTypes.to_basetype
 
 let sterm_of_term : typed -> sterm = Terms.map_term SurfaceBaseTypes.of_basetype
 
-let pp ?(atomic = false) = Terms.pp ~atomic
+let pp ?(prec = 0) = Terms.pp ~prec
 
 let pp_with_typf f it = Pp.typ (pp it) (f (bt it))
 

--- a/backend/cn/lib/report.ml
+++ b/backend/cn/lib/report.ml
@@ -234,6 +234,7 @@ th, td {
   padding-right: 5px;
   padding-top: 3px;
   padding-bottom: 3px;
+  white-space: pre;
 }
 
 th {
@@ -342,6 +343,10 @@ th {
 
   tr {
     background-color: #181818;
+  }
+
+  tr:nth-child(even) {
+    background-color: #222222;
   }
 
   th {

--- a/backend/cn/lib/resourceTypes.ml
+++ b/backend/cn/lib/resourceTypes.ml
@@ -71,6 +71,13 @@ let pp_predicate_type_aux (p : predicate_type) oargs =
 
 
 let pp_qpredicate_type_aux (p : qpredicate_type) oargs =
+  (* XXX: this is `p + i * step` but that's "wrong" in a couple of ways:
+     - we are not using the correct precedences for `p` and `step`
+     - in C pointer arithmetic takes account of the types, but here
+       we seem to be doing it at the byte level.  Would `step` ever
+       differ from the size of elements that `p` points to?
+     - perhaps print as `&p[i]` or `&p[j + i]`
+  *)
   let pointer = IT.pp p.pointer ^^^ plus ^^^ Sym.pp (fst p.q) ^^^ star ^^^ IT.pp p.step in
   let args = pointer :: List.map IT.pp p.iargs in
   !^"each"

--- a/backend/cn/lib/simplify.ml
+++ b/backend/cn/lib/simplify.ml
@@ -379,6 +379,8 @@ module IndexTerms = struct
         let a = aux a in
         (match (op, IT.term a) with
          | Not, Const (Bool b) -> bool_ (not b) the_loc
+         | Not, Unop (Not, x) -> x
+         | Negate, Unop (Negate,x)  -> x
          | Negate, Const (Z z) -> z_ (Z.neg z) the_loc
          | Negate, Const (Bits ((sign, width), z)) ->
            num_lit_ (Z.neg z) (BT.Bits (sign, width)) the_loc

--- a/backend/cn/lib/simplify.ml
+++ b/backend/cn/lib/simplify.ml
@@ -380,7 +380,7 @@ module IndexTerms = struct
         (match (op, IT.term a) with
          | Not, Const (Bool b) -> bool_ (not b) the_loc
          | Not, Unop (Not, x) -> x
-         | Negate, Unop (Negate,x)  -> x
+         | Negate, Unop (Negate, x) -> x
          | Negate, Const (Z z) -> z_ (Z.neg z) the_loc
          | Negate, Const (Bits ((sign, width), z)) ->
            num_lit_ (Z.neg z) (BT.Bits (sign, width)) the_loc

--- a/backend/cn/lib/terms.ml
+++ b/backend/cn/lib/terms.ml
@@ -150,7 +150,7 @@ let rec pp_pattern (Pat (pat_, _bt, _)) =
 
 (* Precedences:
    Reference: https://en.cppreference.com/w/c/language/operator_precedence
-   The number we use are `16 - p` where `p` is the reference in the table.
+   The number we use are `16 - p` where `p` is the precedence in the table.
    We do this so bigger numbers are higher precedence.
 
    Highest
@@ -296,12 +296,7 @@ let pp
       ^^^ rbrace
     | StructMember (t, member) -> wrap_after 15 (aux 15 t ^^ dot ^^ Id.pp member)
     | StructUpdate ((t, member), v) ->
-      braces
-        (!^"..."
-         ^^ aux 0 t
-         ^^ comma
-         ^^^ (Pp.group @@ dot ^^ Id.pp member ^^^ equals)
-         ^^^ align (aux 0 v))
+      braces (dot ^^ Id.pp member ^^ colon ^^^ aux 0 v ^^ comma ^^^ !^".." ^^ aux 0 t)
     | Record members ->
       align
       @@ lbrace
@@ -315,12 +310,7 @@ let pp
       ^^^ rbrace
     | RecordMember (t, member) -> wrap_after 15 (aux 15 t ^^ dot ^^ Id.pp member)
     | RecordUpdate ((t, member), v) ->
-      braces
-        (!^"..."
-         ^^ aux 0 t
-         ^^ comma
-         ^^^ (Pp.group @@ dot ^^ Id.pp member ^^^ equals)
-         ^^^ align (aux 0 v))
+      braces (dot ^^ Id.pp member ^^ colon ^^^ aux 0 v ^^ comma ^^^ !^".." ^^ aux 0 t)
     | Cast (cbt, t) -> wrap_after 14 (align @@ parens (BaseTypes.pp cbt) ^^ aux 14 t)
     | MemberShift (t, _tag, member) ->
       wrap_after 14 (ampersand ^^ aux 15 t ^^ (!^"-" ^^ rangle ()) ^^ Id.pp member)


### PR DESCRIPTION
Changes in this PR:

* Add 2 additional rewrites to remove double negations
* A couple of small tweaks the CSS style for reports
* A bunch of improvements to the pretty printer for terms, namely:
  
  * Changes the `atomic` boolean parameter to a `prec` integer                 
    parameter specifying the precedence of the surrounding context.                 
                                                                                  
  * We also change how some things are printed:                                     
    - a lot fewer parens, based on precedence                                       
    - suffix of numeric literals is separated by `'` (see also #337)                
    - pointers are printed in base 16                                               
    - use `NULL` instead of `null` to match CN's input notation                     
    - custom printing for negated comparisons `x != y` instead of `!(x == y)`       
    - use `%` instead of `rem`                                                      
    - use `^` instead of `xor_uf`                                                   
    - use `&` instead of `bw_and_uf`                                                
    - use `|` instead of `bw_or_uf`                                                 
    - use `<<` instead of `shift_left`                                              
    - use `>>` instead of `shift_right`                                             
    - use `{ ...s, x = e }` for updating things.  This is borrowed                  
      from JavaScript but it makes the precedence story simpler.                    
    - use `&p->x` instead of `member_shift<T>(p,x)`                                 
    - use `&p[x]` instead of `array_shift<T>(p,x)`                                  
    - use `cons(x,xs)` instead of `x :: xs`                                         
~                                              