### PR TITLE
CN: make solver use uintptr_t in pointer mapping rather than intptr_t

### DIFF
--- a/backend/cn/lib/check.ml
+++ b/backend/cn/lib/check.ml
@@ -1265,7 +1265,7 @@ let rec check_expr labels (e : BT.t mu_expr) (k : IT.t -> unit m) : unit m =
               in
               let ptr_diff_bt = Memory.bt_of_sct (Integer Ptrdiff_t) in
               let value =
-                (* TODO: confirm that the cast from intptr_t to ptrdiff_t
+                (* TODO: confirm that the cast from uintptr_t to ptrdiff_t
                    yields the expected result. *)
                 div_
                   ( cast_

--- a/backend/cn/lib/indexTerms.ml
+++ b/backend/cn/lib/indexTerms.ml
@@ -667,9 +667,9 @@ let cast_ bt it loc = IT (Cast (bt, it), bt, loc)
 
 let integerToPointerCast_ it loc = cast_ Loc it loc
 
-let intptr_const_ n loc = num_lit_ n Memory.uintptr_bt loc
+let uintptr_const_ n loc = num_lit_ n Memory.uintptr_bt loc
 
-let intptr_int_ n loc = intptr_const_ (Z.of_int n) loc
+let uintptr_int_ n loc = uintptr_const_ (Z.of_int n) loc
 (* for integer-mode: z_ n *)
 
 let pointerToIntegerCast_ it loc = cast_ Memory.uintptr_bt it loc

--- a/backend/cn/lib/pack.ml
+++ b/backend/cn/lib/pack.ml
@@ -28,10 +28,10 @@ let unfolded_array loc init (ict, olength) pointer =
       pointer;
       q = (q_s, Memory.uintptr_bt);
       q_loc = loc;
-      step = intptr_int_ (Memory.size_of_ctype ict) loc;
+      step = uintptr_int_ (Memory.size_of_ctype ict) loc;
       iargs = [];
       permission =
-        and_ [ (intptr_int_ 0 loc %<= q) loc; (q %< intptr_int_ length loc) loc ] loc
+        and_ [ (uintptr_int_ 0 loc %<= q) loc; (q %< uintptr_int_ length loc) loc ] loc
     }
 
 
@@ -69,7 +69,7 @@ let packing_ft loc global provable ret =
                let request =
                  P
                    { name = Owned (padding_ct, Uninit);
-                     pointer = pointer_offset_ (ret.pointer, intptr_int_ offset loc) loc;
+                     pointer = pointer_offset_ (ret.pointer, uintptr_int_ offset loc) loc;
                      iargs = []
                    }
                in
@@ -117,7 +117,7 @@ let unpack_owned loc global (ct, init) pointer (O o) =
             let mresource =
               ( P
                   { name = Owned (padding_ct, Uninit);
-                    pointer = pointer_offset_ (pointer, intptr_int_ offset loc) loc;
+                    pointer = pointer_offset_ (pointer, uintptr_int_ offset loc) loc;
                     iargs = []
                   },
                 O (default_ (Memory.bt_of_sct padding_ct) loc) )


### PR DESCRIPTION
and tidy up names to make uintptr vs intptr distinction clear