### PR TITLE
[CN] Report multiple verification errors, when possible

### DIFF
--- a/backend/cn/bin/main.ml
+++ b/backend/cn/bin/main.ml
@@ -306,7 +306,13 @@ let verify
     ~handle_error:(handle_type_error ~json ~state_file ~output_dir)
     ~f:(fun ~prog5 ~ail_prog ~statement_locs ~paused ->
       match output_decorated with
-      | None -> Typing.run_from_pause (fun paused -> Check.check paused lemmata) paused
+      | None ->
+        let check (functions, lemmas) =
+          let open Typing in
+          let@ _errors = Check.time_check_c_functions functions in
+          Check.generate_lemmas lemmas lemmata
+        in
+        Typing.run_from_pause check paused
       | Some output_filename ->
         Cerb_colour.without_colour
           (fun () ->

--- a/backend/cn/bin/main.ml
+++ b/backend/cn/bin/main.ml
@@ -261,7 +261,7 @@ let verify
   use_vip
   no_use_ity
   use_peval
-  batch
+  fail_fast
   no_inherit_loc
   magic_comment_char_dollar
   =
@@ -288,7 +288,7 @@ let verify
   Solver.solver_flags := solver_flags;
   Check.skip_and_only := (opt_comma_split skip, opt_comma_split only);
   IndexTerms.use_vip := use_vip;
-  Check.batch := batch;
+  Check.fail_fast := fail_fast;
   Diagnostics.diag_string := diag;
   WellTyped.use_ity := not no_use_ity;
   Sym.executable_spec_enabled := Option.is_some output_decorated;
@@ -515,12 +515,11 @@ module Verify_flags = struct
       & info [ "locs" ] ~docv:"HEX" ~doc)
 
 
-  let batch =
-    let doc =
-      "Type check functions in batch/do not stop on first type error (unless `only` is \
-       used)"
-    in
-    Arg.(value & flag & info [ "batch" ] ~doc)
+  let fail_fast =
+    let doc = "Abort immediately after encountering a verification error" in
+    Arg.(value & flag & info [ "fail-fast" ] ~doc)
+
+
 
 
   let slow_smt_threshold =
@@ -716,7 +715,7 @@ let verify_t : unit Term.t =
   $ Verify_flags.use_vip
   $ Common_flags.no_use_ity
   $ Common_flags.use_peval
-  $ Verify_flags.batch
+  $ Verify_flags.fail_fast
   $ Common_flags.no_inherit_loc
   $ Common_flags.magic_comment_char_dollar
 

--- a/backend/cn/bin/main.ml
+++ b/backend/cn/bin/main.ml
@@ -332,7 +332,8 @@ let verify
       | None ->
         let check (functions, lemmas) =
           let open Typing in
-          let@ _errors = Check.time_check_c_functions functions in
+          let@ errors = Check.time_check_c_functions functions in
+          List.iter (report_type_error ~json ?state_file ?output_dir) errors;
           Check.generate_lemmas lemmas lemmata
         in
         Typing.run_from_pause check paused

--- a/backend/cn/bin/main.ml
+++ b/backend/cn/bin/main.ml
@@ -285,6 +285,7 @@ let verify
   no_use_ity
   use_peval
   fail_fast
+  quiet
   no_inherit_loc
   magic_comment_char_dollar
   =
@@ -333,7 +334,8 @@ let verify
         let check (functions, lemmas) =
           let open Typing in
           let@ errors = Check.time_check_c_functions functions in
-          List.iter (report_type_error ~json ?state_file ?output_dir) errors;
+          if not quiet then
+            List.iter (report_type_error ~json ?state_file ?output_dir) errors;
           Check.generate_lemmas lemmas lemmata
         in
         Typing.run_from_pause check paused
@@ -550,6 +552,11 @@ module Verify_flags = struct
     Arg.(value & flag & info [ "fail-fast" ] ~doc)
 
 
+  let quiet =
+    let doc = "Only report success and failure, rather than rich errors" in
+    Arg.(value & flag & info [ "quiet" ] ~doc)
+
+
   let slow_smt_threshold =
     let doc = "Set the time threshold (in seconds) for logging slow smt queries." in
     Arg.(value & opt (some float) None & info [ "slow-smt" ] ~docv:"TIMEOUT" ~doc)
@@ -744,6 +751,7 @@ let verify_t : unit Term.t =
   $ Common_flags.no_use_ity
   $ Common_flags.use_peval
   $ Verify_flags.fail_fast
+  $ Verify_flags.quiet
   $ Common_flags.no_inherit_loc
   $ Common_flags.magic_comment_char_dollar
 

--- a/backend/cn/bin/main.ml
+++ b/backend/cn/bin/main.ml
@@ -192,7 +192,7 @@ let handle_type_error ~json ~state_file ~output_dir e =
   if json then
     TypeErrors.report_json ?state_file ?output_dir e
   else
-    TypeErrors.report ?state_file ?output_dir e;
+    TypeErrors.report_pretty ?state_file ?output_dir e;
   match e.msg with TypeErrors.Unsupported _ -> exit 2 | _ -> exit 1
 
 

--- a/backend/cn/lib/check.ml
+++ b/backend/cn/lib/check.ml
@@ -2077,27 +2077,32 @@ let check_c_functions_fast (funs : c_function list) : unit m =
   return ()
 
 
+(** Check the provided C functions, each in an isolated context, capturing and
+    counting failures. The result represents [(num_passed, num_failed)]. *)
+let check_c_functions_all (funs : c_function list) : (int * int) m =
+  let total = List.length funs in
+  let check_and_count (num_checked, pass, fail) c_fn =
+    let fn_name = c_function_name c_fn in
+    let@ outcome = sandbox (check_c_function c_fn) in
+    let checked = num_checked + 1 in
+    match outcome with
+    | Ok () ->
+      progress_simple (of_total checked total) (fn_name ^ " -- pass");
+      return (checked, pass + 1, fail)
+    | Error _ ->
+      progress_simple (of_total checked total) (fn_name ^ " -- fail");
+      return (checked, pass, fail + 1)
+  in
+  let@ _, pass, fail = ListM.fold_leftM check_and_count (0, 0, 0) funs in
+  return (pass, fail)
+
+
 let check_c_functions funs =
   let selected_funs = select_functions funs in
-  let number_entries = List.length selected_funs in
   match !batch with
   | false -> check_c_functions_fast selected_funs
   | true ->
-    let@ _, pass, fail =
-      ListM.fold_leftM
-        (fun (counter, pass, fail) c_fn ->
-          let fn_name = c_function_name c_fn in
-          let@ outcome = sandbox (check_c_function c_fn) in
-          match outcome with
-          | Ok () ->
-            progress_simple (of_total (counter + 1) number_entries) (fn_name ^ " -- pass");
-            return (counter + 1, pass + 1, fail)
-          | Error _err ->
-            progress_simple (of_total (counter + 1) number_entries) (fn_name ^ " -- fail");
-            return (counter + 1, pass, fail + 1))
-        (0, 0, 0)
-        selected_funs
-    in
+    let@ pass, fail = check_c_functions_all selected_funs in
     print
       stdout
       (item "summary" (int pass ^^^ !^"pass" ^^ comma ^^^ int fail ^^^ !^"fail"));

--- a/backend/cn/lib/check.ml
+++ b/backend/cn/lib/check.ml
@@ -2101,7 +2101,9 @@ let check_c_functions_all (funs : c_function list) : TypeErrors.t list m =
   return (List.rev errors)
 
 
-let check_c_functions funs =
+(** Downselect from the provided functions with [select_functions] and check the
+    results. When [batch] is set, report summary statistics of all errors. *)
+let check_c_functions (funs : c_function list) : unit m =
   let selected_funs = select_functions funs in
   match !batch with
   | false -> check_c_functions_fast selected_funs

--- a/backend/cn/lib/check.ml
+++ b/backend/cn/lib/check.ml
@@ -2070,29 +2070,26 @@ let check_c_functions funs =
   | false ->
     let@ _ =
       ListM.mapiM
-        (fun counter (fsym, (loc, args_and_body)) ->
+        (fun counter c_fn ->
           let () =
-            progress_simple (of_total (counter + 1) number_entries) (Sym.pp_string fsym)
+            progress_simple (of_total (counter + 1) number_entries) (c_function_name c_fn)
           in
-          check_procedure loc fsym args_and_body)
+          check_c_function c_fn)
         selected_funs
     in
     return ()
   | true ->
     let@ _, pass, fail =
       ListM.fold_leftM
-        (fun (counter, pass, fail) (fsym, (loc, args_and_body)) ->
-          let@ outcome = sandbox (check_procedure loc fsym args_and_body) in
+        (fun (counter, pass, fail) c_fn ->
+          let fn_name = c_function_name c_fn in
+          let@ outcome = sandbox (check_c_function c_fn) in
           match outcome with
-          | Ok _ ->
-            progress_simple
-              (of_total (counter + 1) number_entries)
-              (Sym.pp_string fsym ^ " -- pass");
+          | Ok () ->
+            progress_simple (of_total (counter + 1) number_entries) (fn_name ^ " -- pass");
             return (counter + 1, pass + 1, fail)
-          | Error _ ->
-            progress_simple
-              (of_total (counter + 1) number_entries)
-              (Sym.pp_string fsym ^ " -- fail");
+          | Error _err ->
+            progress_simple (of_total (counter + 1) number_entries) (fn_name ^ " -- fail");
             return (counter + 1, pass, fail + 1))
         (0, 0, 0)
         selected_funs

--- a/backend/cn/lib/check.ml
+++ b/backend/cn/lib/check.ml
@@ -2030,7 +2030,11 @@ let wf_check_and_record_functions mu_funs mu_call_sigs =
     ([], [])
 
 
-let check_c_functions funs =
+type c_function = symbol * (loc * basetype mu_proc_args_and_body)
+
+(** Filter functions according to [skip_and_only]: first according to "only",
+    then according to "skip" *)
+let select_functions (funs : c_function list) : c_function list =
   let matches_str s fsym = String.equal s (Sym.pp_string fsym) in
   let str_fsyms s =
     match List.filter (matches_str s) (List.map fst funs) with
@@ -2047,9 +2051,11 @@ let check_c_functions funs =
     | [] -> funs
     | _ss -> List.filter (fun (fsym, _) -> SymSet.mem fsym only) funs
   in
-  let selected_funs =
-    List.filter (fun (fsym, _) -> not (SymSet.mem fsym skip)) only_funs
-  in
+  List.filter (fun (fsym, _) -> not (SymSet.mem fsym skip)) only_funs
+
+
+let check_c_functions funs =
+  let selected_funs = select_functions funs in
   let number_entries = List.length selected_funs in
   match !batch with
   | false ->

--- a/backend/cn/lib/check.ml
+++ b/backend/cn/lib/check.ml
@@ -2063,21 +2063,25 @@ let check_c_function ((fsym, (loc, args_and_body)) : c_function) : unit m =
   check_procedure loc fsym args_and_body
 
 
+(** Check the provided C functions. Failure of any check will short-circuit the
+    remainder of the checks. *)
+let check_c_functions_fast (funs : c_function list) : unit m =
+  let total = List.length funs in
+  let@ _ =
+    ListM.mapiM
+      (fun counter c_fn ->
+        let () = progress_simple (of_total (counter + 1) total) (c_function_name c_fn) in
+        check_c_function c_fn)
+      funs
+  in
+  return ()
+
+
 let check_c_functions funs =
   let selected_funs = select_functions funs in
   let number_entries = List.length selected_funs in
   match !batch with
-  | false ->
-    let@ _ =
-      ListM.mapiM
-        (fun counter c_fn ->
-          let () =
-            progress_simple (of_total (counter + 1) number_entries) (c_function_name c_fn)
-          in
-          check_c_function c_fn)
-        selected_funs
-    in
-    return ()
+  | false -> check_c_functions_fast selected_funs
   | true ->
     let@ _, pass, fail =
       ListM.fold_leftM

--- a/backend/cn/lib/check.ml
+++ b/backend/cn/lib/check.ml
@@ -2063,18 +2063,28 @@ let check_c_function ((fsym, (loc, args_and_body)) : c_function) : unit m =
   check_procedure loc fsym args_and_body
 
 
-(** Check the provided C functions. Failure of any check will short-circuit the
-    remainder of the checks. *)
-let check_c_functions_fast (funs : c_function list) : unit m =
+(** Check the provided C functions. The first failed check will short-circuit
+    the remainder of the checks, and the associated error will be returned as
+    [Some]. *)
+let check_c_functions_fast (funs : c_function list) : TypeErrors.t option m =
   let total = List.length funs in
-  let@ _ =
-    ListM.mapiM
-      (fun counter c_fn ->
-        let () = progress_simple (of_total (counter + 1) total) (c_function_name c_fn) in
-        check_c_function c_fn)
-      funs
+  let check_and_record (num_checked, prev_error) c_fn =
+    match prev_error with
+    | Some _ -> return (num_checked, prev_error)
+    | None ->
+      let fn_name = c_function_name c_fn in
+      let@ outcome = sandbox (check_c_function c_fn) in
+      let checked = num_checked + 1 in
+      (match outcome with
+       | Ok () ->
+         progress_simple (of_total checked total) (fn_name ^ " -- pass");
+         return (checked, None)
+       | Error err ->
+         progress_simple (of_total checked total) (fn_name ^ " -- fail");
+         return (checked, Some err))
   in
-  return ()
+  let@ _num_checked, error = ListM.fold_leftM check_and_record (0, None) funs in
+  return error
 
 
 (** Check the provided C functions, each in an isolated context, capturing any
@@ -2106,7 +2116,9 @@ let check_c_functions_all (funs : c_function list) : TypeErrors.t list m =
 let check_c_functions (funs : c_function list) : unit m =
   let selected_funs = select_functions funs in
   match !batch with
-  | false -> check_c_functions_fast selected_funs
+  | false ->
+    let@ _ = check_c_functions_fast selected_funs in
+    return ()
   | true ->
     let@ errors = check_c_functions_all selected_funs in
     let fail = List.length errors in

--- a/backend/cn/lib/check.ml
+++ b/backend/cn/lib/check.ml
@@ -2077,24 +2077,28 @@ let check_c_functions_fast (funs : c_function list) : unit m =
   return ()
 
 
-(** Check the provided C functions, each in an isolated context, capturing and
-    counting failures. The result represents [(num_passed, num_failed)]. *)
-let check_c_functions_all (funs : c_function list) : (int * int) m =
+(** Check the provided C functions, each in an isolated context, capturing any
+    (monadic) check failures and returning them. All checks will be performed
+    regardless of intermediate failures. The result's order is determined by
+    the input's order: if function [f] appears before function [g], then
+    function [f]'s error (if any) will appear before function [g]'s error (if
+    any). *)
+let check_c_functions_all (funs : c_function list) : TypeErrors.t list m =
   let total = List.length funs in
-  let check_and_count (num_checked, pass, fail) c_fn =
+  let check_and_record (num_checked, errors) c_fn =
     let fn_name = c_function_name c_fn in
     let@ outcome = sandbox (check_c_function c_fn) in
     let checked = num_checked + 1 in
     match outcome with
     | Ok () ->
       progress_simple (of_total checked total) (fn_name ^ " -- pass");
-      return (checked, pass + 1, fail)
-    | Error _ ->
+      return (checked, errors)
+    | Error err ->
       progress_simple (of_total checked total) (fn_name ^ " -- fail");
-      return (checked, pass, fail + 1)
+      return (checked, err :: errors)
   in
-  let@ _, pass, fail = ListM.fold_leftM check_and_count (0, 0, 0) funs in
-  return (pass, fail)
+  let@ _num_checked, errors = ListM.fold_leftM check_and_record (0, []) funs in
+  return (List.rev errors)
 
 
 let check_c_functions funs =
@@ -2102,7 +2106,9 @@ let check_c_functions funs =
   match !batch with
   | false -> check_c_functions_fast selected_funs
   | true ->
-    let@ pass, fail = check_c_functions_all selected_funs in
+    let@ errors = check_c_functions_all selected_funs in
+    let fail = List.length errors in
+    let pass = List.length selected_funs - fail in
     print
       stdout
       (item "summary" (int pass ^^^ !^"pass" ^^ comma ^^^ int fail ^^^ !^"fail"));

--- a/backend/cn/lib/check.ml
+++ b/backend/cn/lib/check.ml
@@ -2261,15 +2261,20 @@ let check_decls_lemmata_fun_specs (mu_file : unit mu_file) =
   return (List.rev checked, lemmata)
 
 
-let check (checked, lemmata) o_lemma_mode =
+(** With CSV timing enabled, check the provided functions with
+    [check_c_functions]. See that function for more information on the
+    semantics of checking. *)
+let time_check_c_functions (checked : c_function list) : TypeErrors.t list m =
   Cerb_debug.begin_csv_timing () (*type checking functions*);
-  let@ _ = check_c_functions checked in
+  let@ errors = check_c_functions checked in
   Cerb_debug.end_csv_timing "type checking functions";
+  return errors
+
+
+let generate_lemmas lemmata o_lemma_mode =
   let@ global = get_global () in
   match o_lemma_mode with
-  | Some mode ->
-    let@ _ = embed_resultat (Lemmata.generate global mode lemmata) in
-    return ()
+  | Some mode -> embed_resultat (Lemmata.generate global mode lemmata)
   | None -> return ()
 
 (* TODO:

--- a/backend/cn/lib/check.ml
+++ b/backend/cn/lib/check.ml
@@ -2032,6 +2032,10 @@ let wf_check_and_record_functions mu_funs mu_call_sigs =
 
 type c_function = symbol * (loc * basetype mu_proc_args_and_body)
 
+let c_function_name ((fsym, (_loc, _args_and_body)) : c_function) : string =
+  Sym.pp_string fsym
+
+
 (** Filter functions according to [skip_and_only]: first according to "only",
     then according to "skip" *)
 let select_functions (funs : c_function list) : c_function list =
@@ -2052,6 +2056,11 @@ let select_functions (funs : c_function list) : c_function list =
     | _ss -> List.filter (fun (fsym, _) -> SymSet.mem fsym only) funs
   in
   List.filter (fun (fsym, _) -> not (SymSet.mem fsym skip)) only_funs
+
+
+(** Check a single C function. Failure of the check is encoded monadically. *)
+let check_c_function ((fsym, (loc, args_and_body)) : c_function) : unit m =
+  check_procedure loc fsym args_and_body
 
 
 let check_c_functions funs =

--- a/backend/cn/lib/check.ml
+++ b/backend/cn/lib/check.ml
@@ -2250,7 +2250,7 @@ let check_decls_lemmata_fun_specs (mu_file : unit mu_file) =
   in
   Pp.debug 3 (lazy (Pp.headline "type-checked C functions and specifications."));
   Cerb_debug.end_csv_timing "decl, lemmata, function specification checking";
-  return (checked, lemmata)
+  return (List.rev checked, lemmata)
 
 
 let check (checked, lemmata) o_lemma_mode =

--- a/backend/cn/lib/check.ml
+++ b/backend/cn/lib/check.ml
@@ -1863,7 +1863,9 @@ let check_procedure (loc : loc) (fsym : Sym.t) (args_and_body : _ mu_proc_args_a
 
 let skip_and_only = ref (([] : string list), ([] : string list))
 
-let batch = ref false
+(** When set, causes verification of multiple functions to abort as soon as a
+    single function fails to verify. *)
+let fail_fast = ref false
 
 let record_tagdefs tagDefs =
   PmapM.iterM
@@ -2112,21 +2114,15 @@ let check_c_functions_all (funs : c_function list) : TypeErrors.t list m =
 
 
 (** Downselect from the provided functions with [select_functions] and check the
-    results. When [batch] is set, report summary statistics of all errors. *)
-let check_c_functions (funs : c_function list) : unit m =
+    results. Errors in checking are captured, collected, and returned. When
+    [fail_fast] is set, the first error encountered will halt checking. *)
+let check_c_functions (funs : c_function list) : TypeErrors.t list m =
   let selected_funs = select_functions funs in
-  match !batch with
-  | false ->
-    let@ _ = check_c_functions_fast selected_funs in
-    return ()
+  match !fail_fast with
   | true ->
-    let@ errors = check_c_functions_all selected_funs in
-    let fail = List.length errors in
-    let pass = List.length selected_funs - fail in
-    print
-      stdout
-      (item "summary" (int pass ^^^ !^"pass" ^^ comma ^^^ int fail ^^^ !^"fail"));
-    return ()
+    let@ error_opt = check_c_functions_fast selected_funs in
+    return (Option.to_list error_opt)
+  | false -> check_c_functions_all selected_funs
 
 
 (* (Sym.t * (Locations.t * ArgumentTypes.lemmat)) list *)
@@ -2267,7 +2263,7 @@ let check_decls_lemmata_fun_specs (mu_file : unit mu_file) =
 
 let check (checked, lemmata) o_lemma_mode =
   Cerb_debug.begin_csv_timing () (*type checking functions*);
-  let@ () = check_c_functions checked in
+  let@ _ = check_c_functions checked in
   Cerb_debug.end_csv_timing "type checking functions";
   let@ global = get_global () in
   match o_lemma_mode with

--- a/backend/cn/lib/typeErrors.ml
+++ b/backend/cn/lib/typeErrors.ml
@@ -572,18 +572,13 @@ let mk_state_file_name ?(output_dir : string option) (loc : Cerb_location.t) : s
     error contains enough information to create an HTML state report, generate
     one in [output_dir] (or, failing that, the system temporary directory) and
     print a link to it. *)
-let report_pretty ?state_file:to_ ?output_dir:dir_ { loc; msg } =
+let report_pretty ?output_dir:dir_ { loc; msg } =
   (* stealing some logic from pp_errors *)
   let report = pp_message msg in
   let consider =
     match report.state with
     | Some state ->
-      (* Decide where to write the state *)
-      let state_error_file =
-        match to_ with
-        | Some file -> file
-        | None -> mk_state_file_name ?output_dir:dir_ loc
-      in
+      let state_error_file = mk_state_file_name ?output_dir:dir_ loc in
       let link = Report.make state_error_file (Cerb_location.get_filename loc) state in
       let msg = !^"State file:" ^^^ !^("file://" ^ link) in
       Some msg
@@ -593,17 +588,12 @@ let report_pretty ?state_file:to_ ?output_dir:dir_ { loc; msg } =
 
 
 (* stealing some logic from pp_errors *)
-let report_json ?state_file:to_ ?output_dir:dir_ { loc; msg } =
+let report_json ?output_dir:dir_ { loc; msg } =
   let report = pp_message msg in
   let state_error_file =
     match report.state with
     | Some state ->
-      (* Decide where to write the state *)
-      let file =
-        match to_ with
-        | Some file -> file
-        | None -> mk_state_file_name ?output_dir:dir_ loc
-      in
+      let file = mk_state_file_name ?output_dir:dir_ loc in
       let link = Report.make file (Cerb_location.get_filename loc) state in
       `String link
     | None -> `Null


### PR DESCRIPTION
Fixes #287, according to the discussion in that issue. In particular:
- CN now displays verification errors for multiple functions by default, if the functions under analysis pass their wellformedness checks.
- A new flag, `--fail-fast`, allows reversion to the preexisting single-error behavior.
- A new flag, `--quiet`, causes CN to only report pass/fail outcomes, like how `--batch` currently behaves.
- The `--batch` flag has been removed, supplanted by `--quiet`.
- The `--state-file` flag has been removed, with the hope that `--output-dir` provides users sufficient control over output.
- CN now checks functions in declaration order.

This ended up being a more substantial change than I'd hoped to make, in part because CN's assumption of only handling a single error was more baked-in than I'd anticipated, and in part because I took the liberty of doing some light refactoring and documentation in places where I needed to make changes anyway.