### PR TITLE
Properly defining two calling conventions for Core

### DIFF
--- a/backend/bmc/bmc_utils.ml
+++ b/backend/bmc/bmc_utils.ml
@@ -408,6 +408,7 @@ let set_uid_globs (gname, glb) =
 let set_uid file1 =
  ({
   main=    (file1.main);
+  calling_convention= (file1.calling_convention);
   tagDefs= (file1.tagDefs);
   stdlib=  (file1.stdlib);
   impl=    (file1.impl);

--- a/backend/web/instance.ml
+++ b/backend/web/instance.ml
@@ -328,6 +328,7 @@ let set_uid file =
     )
   in
   { main=    file.main;
+    calling_convention= file.calling_convention;
     tagDefs= file.tagDefs;
     stdlib=  file.stdlib;
     impl=    file.impl;

--- a/frontend/model/core.lem
+++ b/frontend/model/core.lem
@@ -403,18 +403,27 @@ type core_tag_definitions =
 
 type visible_objects_env = map nat (list (Symbol.sym * Ctype.ctype))
 
+type calling_convention =
+  | Normal_callconv
+  | Inner_arg_callconv
+
+instance (Eq calling_convention)
+  let (=)  = unsafe_structural_equality
+  let (<>) = unsafe_structural_inequality
+end
 
 (* a Core file is just a set of named functions *)
 type generic_file 'bty 'a = <|
-  main    : maybe Symbol.sym;
-  tagDefs : core_tag_definitions;
-  stdlib  : generic_fun_map 'bty 'a;
-  impl    : generic_impl 'bty;
-  globs   : list (Symbol.sym * generic_globs 'a 'bty);
-  funs    : generic_fun_map 'bty 'a;
-  extern  : extern_map;
-  funinfo : map Symbol.sym (Loc.t * Annot.attributes * ctype * list (maybe Symbol.sym * ctype) * bool * bool);
-  loop_attributes : Annot.loop_attributes;
+  main: maybe Symbol.sym;
+  calling_convention: calling_convention;
+  tagDefs: core_tag_definitions;
+  stdlib: generic_fun_map 'bty 'a;
+  impl: generic_impl 'bty;
+  globs: list (Symbol.sym * generic_globs 'a 'bty);
+  funs: generic_fun_map 'bty 'a;
+  extern: extern_map;
+  funinfo: map Symbol.sym (Loc.t * Annot.attributes * ctype * list (maybe Symbol.sym * ctype) * bool * bool);
+  loop_attributes: Annot.loop_attributes;
   visible_objects_env: visible_objects_env;
 |>
 

--- a/frontend/model/core_linking.lem
+++ b/frontend/model/core_linking.lem
@@ -281,10 +281,14 @@ val link_aux: forall 'a 'b. generic_file 'a 'b ->
                            generic_file 'a 'b ->
                            exceptM (generic_file 'a 'b) (Loc.t * cause)
 let link_aux f1 f2 =
+  if f1.calling_convention <> f2.calling_convention then
+    link_fail Loc.unknown IncompatibleCallingConvention
+  else
   link_extern f2.extern f1.extern >>= fun (extern, reduntant_globs) ->
   link_main f1.main f2.main >>= fun main ->
   return
     <| main=    main;
+       calling_convention= f1.calling_convention;
        tagDefs= f1.tagDefs union f2.tagDefs;
        stdlib=  f1.stdlib;
        impl=    f1.impl;

--- a/frontend/model/core_run_aux.lem
+++ b/frontend/model/core_run_aux.lem
@@ -693,6 +693,7 @@ let convert_file file =
 
  <|
   main=    file.main;
+  calling_convention= file.calling_convention;
   tagDefs= file.tagDefs;
   stdlib=  Map.map convert_fun_map_decl file.stdlib;
   impl=    Map.map convert_impl_decl file.impl;

--- a/frontend/model/core_typing.lem
+++ b/frontend/model/core_typing.lem
@@ -1630,9 +1630,21 @@ let rec collect_labels env (Expr _ expr_) =
 
 
 (* val     typecheck_expr: Loc.t -> typing_env -> core_base_type -> Core.expr unit -> E.eff (typed_expr unit) *)
-and typecheck_expr tagDefs (env: typing_env) expected_bTy (Expr annot expr_) =
-  let typecheck_expr env expected_bTy expr = typecheck_expr tagDefs env expected_bTy expr in
+and typecheck_expr callconv tagDefs (env: typing_env) expected_bTy (Expr annot expr_) =
+  let typecheck_expr env expected_bTy expr = typecheck_expr callconv tagDefs env expected_bTy expr in
   let loc = Annot.get_loc_ annot in
+  let typecheck_ccall_argument =
+    match callconv with
+      | Normal_callconv ->
+          fun _ pe -> typecheck_export_pexpr tagDefs env (BTy_object OTy_pointer) pe
+      | Inner_arg_callconv ->
+          fun ty pe -> match Core_aux.core_object_type_of_ctype ty with
+            | Just oTy ->
+                typecheck_export_pexpr tagDefs env (BTy_loaded oTy) pe
+            | Nothing ->
+                E.fail loc (CoreTyping_TODO "the first operand of ccall() has a C function type with a non object parameter type")
+          end
+    end in
   Expr annot <$> match expr_ with
     | Epure pe ->
         Epure <$> typecheck_export_pexpr tagDefs env expected_bTy pe
@@ -1676,43 +1688,46 @@ and typecheck_expr tagDefs (env: typing_env) expected_bTy (Expr annot expr_) =
         Eif <$> typecheck_export_pexpr tagDefs env BTy_boolean pe1
             <*> typecheck_expr env expected_bTy e2
             <*> typecheck_expr env expected_bTy e3
-    | Eccall annot pe_ty pe pes ->
-        infer_pexpr tagDefs env pe_ty >>= export_pexpr >>= fun pe_ty' ->
+    | Eccall annot ty_pe pe pes ->
+        infer_pexpr tagDefs env ty_pe >>= export_pexpr >>= fun ty_pe' ->
         infer_pexpr tagDefs env pe    >>= export_pexpr >>= fun (Pexpr _ bTy _ as pe') ->
-        match (pe_ty, bTy) with
-          | (Pexpr _ _ (PEval (Vctype (Cty.Ctype _ (Cty.Pointer _ (Cty.Ctype _ (Cty.Function (qs, ty) params isVariadic))))))
-            , BTy_loaded OTy_pointer) ->
+        match (ty_pe, bTy) with
+          | ( Pexpr _ _ (PEval (Vctype (Cty.Ctype _ (Cty.Pointer _ (Cty.Ctype _ (Cty.Function (qs, ty) params isVariadic))))))
+            , BTy_loaded OTy_pointer ) ->
               begin
                 if isVariadic then
                   match List.dest_init pes with
                     | Nothing ->
                         E.fail loc (CoreTyping_TODO "ccall to a variadic C procedure must at least have a list of pointers as last argument")
-                    | Just (first_pes, last_pe) ->
-                        E.mapM (fun pe ->
-                          typecheck_export_pexpr tagDefs env (BTy_object OTy_pointer) pe
-                        ) first_pes >>= fun first_pes' ->
+                    | Just (xs, last_pe) ->
+                        E.mapM (fun ((_, ty, _), pe) ->
+                          typecheck_ccall_argument ty pe
+                        ) (List.zip params pes) >>= fun pes' ->
                         typecheck_export_pexpr tagDefs env
                           (BTy_list (BTy_tuple [BTy_ctype; BTy_object OTy_pointer])) last_pe >>= fun last_pe' ->
-                        E.return (first_pes' ++ [last_pe'])
+                        E.return (pes' ++ [last_pe'])
                   end
                 else
-                  if Global.has_switch Global.SW_inner_arg_temps then
-                    E.mapM (fun ((_, ty, _), pe) ->
-                      match Core_aux.core_object_type_of_ctype ty with
-                        | Just oTy ->
-                            typecheck_export_pexpr tagDefs env (BTy_loaded oTy) pe
-                        | Nothing ->
-                            E.fail loc (CoreTyping_TODO "the first operand of ccall() has a C function type with a non object parameter type")
-                      end
-                    ) (List.zip params pes)
-                  else
-                    E.mapM (fun pe ->
-                      typecheck_export_pexpr tagDefs env (BTy_object OTy_pointer) pe
-                    ) pes
+                  E.mapM (fun ((_, ty, _), pe) -> typecheck_ccall_argument ty pe) (List.zip params pes)
+                (* else match callconv with
+                  | Normal_callconv ->
+                      E.mapM (fun pe ->
+                        typecheck_export_pexpr tagDefs env (BTy_object OTy_pointer) pe
+                      ) pes
+                  | Inner_arg_callconv ->
+                      E.mapM (fun ((_, ty, _), pe) ->
+                        match Core_aux.core_object_type_of_ctype ty with
+                          | Just oTy ->
+                              typecheck_export_pexpr tagDefs env (BTy_loaded oTy) pe
+                          | Nothing ->
+                              E.fail loc (CoreTyping_TODO "the first operand of ccall() has a C function type with a non object parameter type")
+                        end
+                      ) (List.zip params pes)
+                end *)
               end >>= fun pes' ->
               let ret_oTy_opt = Core_aux.core_object_type_of_ctype ty in
               guard_match loc "ccall" expected_bTy (maybe BTy_unit BTy_loaded ret_oTy_opt) >>
-              E.return (Eccall annot pe_ty' pe' pes')
+              E.return (Eccall annot ty_pe' pe' pes')
           | (_, _) ->
               E.fail loc (CoreTyping_TODO "the first operand of ccall() should have a C function type")
         end
@@ -1819,6 +1834,8 @@ and typecheck_expr tagDefs (env: typing_env) expected_bTy (Expr annot expr_) =
 (* TODO: add a check for the existence of main *)
 val typecheck_program: forall 'bty 'a. Core.generic_file 'bty 'a -> Exception.exceptM (Core.typed_file 'a) Errors.error
 let typecheck_program file =
+  let typecheck_expr env expected_bTy expr =
+    typecheck_expr file.calling_convention file.tagDefs env expected_bTy expr in
   let aux =
     (* The startup function/procedure must be defined *)
     match file.main with
@@ -1866,7 +1883,7 @@ let typecheck_program file =
         | Proc loc mrk bTy sym_bTys e ->
             let env' = List.foldr (fun (sym, bTy) acc -> insert_tdecl (Sym sym) (TDsym bTy) acc) env sym_bTys in
             collect_labels env' e >>= fun env' ->
-            Proc loc mrk bTy sym_bTys <$> typecheck_expr file.tagDefs env' bTy e
+            Proc loc mrk bTy sym_bTys <$> typecheck_expr env' bTy e
       end) file.stdlib >>= fun stdlib' ->
     
     (* Typechecking of the impl constants *)
@@ -1884,7 +1901,7 @@ let typecheck_program file =
       match decl with
         | GlobalDef (bTy, ct) e ->
             collect_labels env_acc e >>= fun env_acc' ->
-            typecheck_expr file.tagDefs env_acc' bTy e >>= fun te ->
+            typecheck_expr env_acc' bTy e >>= fun te ->
             E.return (insert_tdecl (Sym sym) (TDsym bTy) env_acc', (sym, GlobalDef (bTy, ct) te) :: acc)
         | GlobalDecl (bTy, ct) ->
             E.return (insert_tdecl (Sym sym) (TDsym bTy) env_acc, (sym, GlobalDecl (bTy, ct)) :: acc)
@@ -1919,11 +1936,12 @@ let typecheck_program file =
         | Proc loc mrk bTy sym_bTys e ->
             let env' = List.foldr (fun (sym, bTy) acc -> insert_tdecl (Sym sym) (TDsym bTy) acc) env sym_bTys in
             collect_labels env' e >>= fun env' ->
-            Proc loc mrk bTy sym_bTys <$> typecheck_expr file.tagDefs env' bTy e
+            Proc loc mrk bTy sym_bTys <$> typecheck_expr env' bTy e
       end) file.funs >>= fun funs' ->
     
     E.return <|
       main= file.main;
+      calling_convention = file.calling_convention;
       tagDefs= file.tagDefs;
       stdlib= stdlib';
       impl= impl';

--- a/frontend/model/core_typing.lem
+++ b/frontend/model/core_typing.lem
@@ -1631,6 +1631,7 @@ let rec collect_labels env (Expr _ expr_) =
 
 (* val     typecheck_expr: Loc.t -> typing_env -> core_base_type -> Core.expr unit -> E.eff (typed_expr unit) *)
 and typecheck_expr tagDefs (env: typing_env) expected_bTy (Expr annot expr_) =
+  let typecheck_expr env expected_bTy expr = typecheck_expr tagDefs env expected_bTy expr in
   let loc = Annot.get_loc_ annot in
   Expr annot <$> match expr_ with
     | Epure pe ->
@@ -1653,9 +1654,9 @@ and typecheck_expr tagDefs (env: typing_env) expected_bTy (Expr annot expr_) =
           | Just case_bTy ->
               export_pexpr pe' >>= fun pe' ->
               E.mapM (fun (pat, e) ->
-                typecheck_pattern case_bTy pat                             >>= fun (env', pat') ->
-                export_pattern loc pat'                                    >>= fun pat'         ->
-                typecheck_expr tagDefs (env_union env env') expected_bTy e >>= fun e'           ->
+                typecheck_pattern case_bTy pat                     >>= fun (env', pat') ->
+                export_pattern loc pat'                            >>= fun pat'         ->
+                typecheck_expr (env_union env env') expected_bTy e >>= fun e'           ->
                 E.return (pat', e')
               ) cases >>= fun cases' ->
               E.return (Ecase pe' cases')
@@ -1666,15 +1667,15 @@ and typecheck_expr tagDefs (env: typing_env) expected_bTy (Expr annot expr_) =
           | Nothing ->
               E.fail (locOf pat) TooGeneral
           | Just pat_bTy ->
-              typecheck_pexpr tagDefs env pat_bTy pe1 >>= export_pexpr       >>= fun pe1' ->
-              export_pattern loc _pat'                                       >>= fun pat' ->
-              typecheck_expr tagDefs (env_union env pat_env) expected_bTy e2 >>= fun e2'  ->
+              typecheck_pexpr tagDefs env pat_bTy pe1 >>= export_pexpr >>= fun pe1' ->
+              export_pattern loc _pat'                                 >>= fun pat' ->
+              typecheck_expr (env_union env pat_env) expected_bTy e2   >>= fun e2'  ->
               E.return (Elet pat' pe1' e2')
         end
     | Eif pe1 e2 e3 ->
         Eif <$> typecheck_export_pexpr tagDefs env BTy_boolean pe1
-            <*> typecheck_expr tagDefs env expected_bTy e2
-            <*> typecheck_expr tagDefs env expected_bTy e3
+            <*> typecheck_expr env expected_bTy e2
+            <*> typecheck_expr env expected_bTy e3
     | Eccall annot pe_ty pe pes ->
         infer_pexpr tagDefs env pe_ty >>= export_pexpr >>= fun pe_ty' ->
         infer_pexpr tagDefs env pe    >>= export_pexpr >>= fun (Pexpr _ bTy _ as pe') ->
@@ -1739,7 +1740,7 @@ and typecheck_expr tagDefs (env: typing_env) expected_bTy (Expr annot expr_) =
         (* TODO: forbid jumps, par(), ... *)
         match expected_bTy with
           | BTy_tuple bTys ->
-              Eunseq <$> E.mapM (fun (bTy, e) -> typecheck_expr tagDefs env bTy e)
+              Eunseq <$> E.mapM (fun (bTy, e) -> typecheck_expr env bTy e)
                           (List.zip bTys es)
           | _ -> E.fail loc (CoreTyping_TODO "UNSEQ illtyped")
         end
@@ -1750,8 +1751,8 @@ and typecheck_expr tagDefs (env: typing_env) expected_bTy (Expr annot expr_) =
               E.fail loc TooGeneral
           | Just pat_bTy ->
               Ewseq <$> export_pattern loc _pat'
-                    <*> typecheck_expr tagDefs env pat_bTy e1
-                    <*> typecheck_expr tagDefs (env_union env env') expected_bTy e2
+                    <*> typecheck_expr env pat_bTy e1
+                    <*> typecheck_expr (env_union env env') expected_bTy e2
         end
     | Esseq pat e1 e2 ->
         infer_pattern pat >>= fun (env', infer, _pat') ->
@@ -1760,17 +1761,17 @@ and typecheck_expr tagDefs (env: typing_env) expected_bTy (Expr annot expr_) =
               E.fail loc TooGeneral
           | Just pat_bTy ->
               Esseq <$> export_pattern loc _pat'
-                    <*> typecheck_expr tagDefs env pat_bTy e1
-                    <*> typecheck_expr tagDefs (env_union env env') expected_bTy e2
+                    <*> typecheck_expr env pat_bTy e1
+                    <*> typecheck_expr (env_union env env') expected_bTy e2
         end
     | Ebound e ->
         (* TODO *)
-        Ebound <$> typecheck_expr tagDefs env expected_bTy e
+        Ebound <$> typecheck_expr env expected_bTy e
     | End es ->
         if List.length es < 2 then
           E.fail loc (CoreTyping_TODO "nd() should have at least 2 operand")
         else
-          E.mapM (typecheck_expr tagDefs env expected_bTy) es >>= fun es' ->
+          E.mapM (typecheck_expr env expected_bTy) es >>= fun es' ->
           E.return (End es')
     | Esave sym_bTy sym_bTy_pes e ->
         (* TODO: check *)
@@ -1780,7 +1781,7 @@ and typecheck_expr tagDefs (env: typing_env) expected_bTy (Expr annot expr_) =
            E.return (sym, (((bTy,ct), pe')))
         ) sym_bTy_pes >>= fun sym_bTy_pes' ->
         let env' = <| decls= Map.fromList (List.map (fun (sym, ((bTy,_), _)) -> (Sym sym, TDsym bTy)) sym_bTy_pes'); labs= Map.empty |> in
-        Esave sym_bTy sym_bTy_pes' <$> typecheck_expr tagDefs (env_union env env') expected_bTy e
+        Esave sym_bTy sym_bTy_pes' <$> typecheck_expr (env_union env env') expected_bTy e
     | Erun annot sym pes ->
         match Map.lookup sym env.labs with
           | Just (bTy, bTys) ->
@@ -1800,7 +1801,7 @@ and typecheck_expr tagDefs (env: typing_env) expected_bTy (Expr annot expr_) =
           E.fail loc (CoreTyping_TODO "Epar must have at least 2 operands")
         else match expected_bTy with
           | BTy_tuple bTys ->
-              Epar <$> E.mapM (uncurry $ typecheck_expr tagDefs env) (List.zip bTys es)
+              Epar <$> E.mapM (uncurry $ typecheck_expr env) (List.zip bTys es)
           | _ ->
               E.fail loc (CoreTyping_TODO "Epar has as tuple type")
         end

--- a/frontend/model/ctype.lem
+++ b/frontend/model/ctype.lem
@@ -381,6 +381,10 @@ val ptrdiff_t: ctype
 let ptrdiff_t =
   Ctype [] (Basic (Integer Ptrdiff_t))
 
+val pointer_to_char: ctype
+let pointer_to_char =
+  Ctype [] (Pointer no_qualifiers char)
+
 import Global
 val ptraddr_t: unit -> ctype
 let ptraddr_t _ =

--- a/frontend/model/driver.lem
+++ b/frontend/model/driver.lem
@@ -910,8 +910,8 @@ let can_advance = function
       not is_unseq_with_ccall (* false *)
   | Core_reduction.Step_blocked2 ->
       false
-  | Core_reduction.Step_error2 _ ->
-      error "can_advance: Step_error2"
+  | Core_reduction.Step_error2 str ->
+      error ("can_advance: Step_error2 ==> " ^ str)
   | Core_reduction.Step_thread_done2 _ _ ->
       true
   | Core_reduction.Step_done2 _ ->
@@ -1624,6 +1624,81 @@ declare ocaml target_rep function pp_exeState = `Pp_cmm.pp_execState`
 
 
 
+let prepare_main_args loc callconv tid0 main_sym arg_strs argc_sym argv_sym =
+  (* memory_values to be stored in memory objects pointed to by the element of main.argv *)
+  let args_mem_val_tys =
+    List.map (fun arg_str ->
+      let mem_vals =
+        List.map (fun c ->
+          (* TODO: fixing impl choice here (ASCII) *)
+          Mem.integer_mval Ctype.Char (Decode.decode_character_constant (String.toString [c]))
+        ) (String.toCharList arg_str) in
+      (* NOTE: adding a null termination to the char array *)
+      ( Mem.array_mval (mem_vals ++ [Mem.integer_mval Ctype.Char 0])
+      , Ctype.Ctype [] (Ctype.Array Ctype.char (Just ((integerFromNat (List.length mem_vals)) + 1))) )
+    ) arg_strs in
+
+  let number_of_args = integerFromNat (List.length args_mem_val_tys) in
+
+  (* allocating and initialising the objects pointed to by the elements of argv *)
+  ND.foldlM (fun ptr_vals (arg_mem_val, arg_ty) ->
+    liftMem (
+      Mem.bind (Mem.allocate_object tid0 (Symbol.PrefOther "argv refs") (Mem.alignof_ival arg_ty) arg_ty Nothing Nothing) (fun ptr_val ->
+        Mem.bind (Mem.store (Loc.other "argv refs init") arg_ty false ptr_val arg_mem_val) (fun _ ->
+          Mem.return (ptr_val :: ptr_vals)
+        )
+      )
+    )
+  ) [] args_mem_val_tys >>= fun ptr_vals_rev ->
+
+  (* allocating and initialising an object for main.argv *)
+  (* NOTE: the element argv[argc] is required to be a null pointer
+      by the STD, hence argv has one more element than the number
+      of supplied arguments *)
+ liftMem begin
+    let pref = Symbol.PrefSource loc [main_sym; argv_sym(*TODO: change the sym?*)] in
+    let argv_array_ty = Ctype.Ctype [] (Ctype.Array Ctype.pointer_to_char (Just (1 + (integerFromNat (List.length ptr_vals_rev))))) in
+    let argv_array_mem_val = Mem.array_mval (
+      List.map (Mem.pointer_mval Ctype.char) (List.reverse (Mem.null_ptrval Ctype.char :: ptr_vals_rev))
+    ) in
+    Mem.bind
+      (Mem.allocate_object tid0 pref (Mem.alignof_ival argv_array_ty) argv_array_ty Nothing Nothing) (fun ptr_val ->
+    Mem.bind
+      (Mem.store (Loc.other "argv array init") argv_array_ty false ptr_val argv_array_mem_val) (fun _ ->
+      ND.return ptr_val
+    ))
+  end >>= fun argv_array_ptr_val ->
+    
+  match callconv with
+    | Core.Normal_callconv ->
+        let argc_mem_val = Mem.integer_mval (Ctype.Signed Ctype.Int_) number_of_args in
+        liftMem begin
+          let pref = Symbol.PrefSource loc [main_sym; argc_sym] in
+          Mem.bind (Mem.allocate_object tid0 pref (Mem.alignof_ival Ctype.signed_int) Ctype.signed_int Nothing Nothing) (fun argc_ptr_val ->
+          Mem.bind (Mem.store (Loc.other "argc init") Ctype.signed_int false argc_ptr_val argc_mem_val) (fun _ ->
+
+          (* NOTE: because of argument promotions, the char *argv[] is turned into a char **argv
+              so two objects are allocated: an array and a pointer to that array (which is what argv designate) *)
+          let pref = Symbol.PrefSource loc [main_sym; argv_sym] in
+          let argv_ty = Ctype.mk_ctype_pointer Ctype.no_qualifiers Ctype.pointer_to_char in
+          Mem.bind
+            (Mem.allocate_object tid0 pref (Mem.alignof_ival argv_ty) argv_ty Nothing Nothing) (fun argv_ptr_val ->
+          Mem.bind
+            (Mem.store (Loc.other "argv init") argv_ty false argv_ptr_val (Mem.pointer_mval Ctype.pointer_to_char argv_array_ptr_val)) ( fun _ ->
+
+            Mem.return
+              ( Core.Vobject (Core.OVpointer argc_ptr_val)
+              , Core.Vobject (Core.OVpointer argv_ptr_val) )
+          ))))
+        end
+    | Core.Inner_arg_callconv ->
+        let argc_cval = Core.Vloaded (Core.LVspecified (Core.OVinteger (Mem.integer_ival number_of_args))) in
+        let argv_cval = Core.Vloaded (Core.LVspecified (Core.OVpointer argv_array_ptr_val)) in
+        ND.return (argc_cval, argv_cval)
+  end
+
+
+
 
 val drive: bool -> Core.file Core_run.core_run_annotation -> list string -> driverM driver_result
 let drive (with_concurrency: bool) file (arg_strs: list string) =
@@ -1660,6 +1735,8 @@ let drive (with_concurrency: bool) file (arg_strs: list string) =
         
         match params with
           | [(argc_sym, _); (argv_sym, _)] ->
+
+(*
               (* memory_values to be stored in memory objects pointed to by
                  the element of main.argv  *)
               let args_mem_val_tys =
@@ -1672,7 +1749,7 @@ let drive (with_concurrency: bool) file (arg_strs: list string) =
                   (* NOTE: adding a null termination to the char array *)
                   (
                     Mem.array_mval $ mem_vals ++ [Mem.integer_mval Ctype.Char 0],
-                    Ctype.Ctype [] (Ctype.Array Ctype.char (Just $ (integerFromNat $ List.length mem_vals) + 1))
+                    Ctype.Ctype [] (Ctype.Array Ctype.char (Just ((integerFromNat (List.length mem_vals)) + 1)))
                   )
                 ) arg_strs in
               
@@ -1731,6 +1808,9 @@ let drive (with_concurrency: bool) file (arg_strs: list string) =
                 Mem.return (Core.Vobject (Core.OVpointer argv_ptr_val))
                 ))))
               ) >>= fun argv_cval ->
+*)
+              prepare_main_args loc file.Core.calling_convention tid0 main_sym arg_strs argc_sym argv_sym >>= fun (argc_cval, argv_cval) ->
+
               (* Adding the values of argc and argv to the Core symbol environment *)
               get_thread_states >>= function
                 | [(_, (_, th_st))] ->

--- a/frontend/model/errors.lem
+++ b/frontend/model/errors.lem
@@ -43,6 +43,7 @@ type core_typing_cause =
 type core_linking_cause =
   | DuplicateExternalName of Symbol.identifier
   | DuplicateMain
+  | IncompatibleCallingConvention
 
 type core_run_cause =
   | Illformed_program of string (* typing or name-scope error *)

--- a/frontend/model/mini_pipeline.lem
+++ b/frontend/model/mini_pipeline.lem
@@ -104,14 +104,18 @@ let evalConstantExpressionAux loc (*TODO*)(ailnames, stdlib_fun_map, impl) sigm 
     | Right a_expr ->
         (* applies the provided typing guard *)
         typing_guard (GenTypes.genTypeCategoryOf a_expr) >>= fun () ->
+
+        let callconv =
+          if Global.has_switch Global.SW_inner_arg_temps then Core.Inner_arg_callconv else Core.Normal_callconv in
         
         (* elaborate the typed expression into Core *)
-        let (core_expr, translate_final_st) = TranslateEff.runStateM (toCore a_expr) (TranslateEff.elab_init ()) in
+        let (core_expr, translate_final_st) = TranslateEff.runStateM (toCore a_expr) (TranslateEff.elab_init callconv) in
         
         let dr_st =
           (* this just builds the shell of the driver state *)
           let dummy_core_file = Core_run_aux.convert_file
             <| C.main= Nothing
+             ; C.calling_convention= callconv
              ; C.stdlib= stdlib_fun_map
              ; C.impl= impl
              ; C.globs= []

--- a/frontend/model/translation.lem
+++ b/frontend/model/translation.lem
@@ -824,6 +824,9 @@ val translate_function_call:
   list (A.expression GenTypes.genTypeCategory) ->
   E.elabM (C.expr unit)
 let translate_function_call loc is_used translate_expr stdlib e es =
+  (* TODO: is_used_pe is commented out because it requires some changes to CN to support it.
+      But as a result currently a non-void function missing a return statement is deemed UB even when
+      the value of the function call is NOT used by the caller. (which is explicitly excluded from the UB by the STD) *)
   (* let is_used_pe = Caux.mk_boolean_pe is_used in *)
   let (expect_ret_ty, expect_params, expect_is_variadic) =
     match ctype_of e with
@@ -839,6 +842,7 @@ let translate_function_call loc is_used translate_expr stdlib e es =
       | Nothing ->
           false
     end in
+  E.get_calling_convention >>= fun callconv ->
   (* TODO: This is ignoring has_proto, §6.5.2.2#6 is not being considered! *)
   (* STD §6.5.2.2 *)
   E.wrapped_fresh_symbol (C.BTy_loaded C.OTy_pointer) >>= fun fun_wrp         ->
@@ -924,8 +928,9 @@ let translate_function_call loc is_used translate_expr stdlib e es =
           end
         )) :: rev_core_creates )
   ) (0,[]) (List.zip expect_params args_info) >>= fun (_, rev_core_creates) ->
-  (* standard arguments (CN elaboration switch) *)
-  begin if Global.has_switch Global.SW_inner_arg_temps then
+  match callconv with
+  | C.Inner_arg_callconv ->
+    (* standard arguments (CN elaboration switch) *)
     E.foldlM (fun (n, cn_core_args) ((_, expect_param_ty, _), (arg_ty, arg_is_null, arg_sym_pe)) ->
       E.wrapped_fresh_symbol C.BTy_ctype                  >>= fun param_ty_wrp ->
       E.wrapped_fresh_symbol (C.BTy_object C.OTy_pointer) >>= fun arg_ptr_wrp ->
@@ -956,7 +961,7 @@ let translate_function_call loc is_used translate_expr stdlib e es =
             end
           )) :: cn_core_args )
     ) (0,[]) (List.zip expect_params args_info)
-  else
+  | C.Normal_callconv ->
     (* dummy empty list we are not using *)
     E.return (0, [])
   end >>= fun (_, rev_cn_core_args) ->
@@ -1017,6 +1022,43 @@ begin if expect_is_variadic then
           (Caux.mk_op_pe C.OpOr (Caux.mk_not_pe is_variadic_wrp.E.sym_pe)
                           (Caux.mk_not_pe (Caux.mk_are_compatible (Caux.mk_ail_ctype_pe expect_ret_ty) ret_wrp.E.sym_pe)))
           (Caux.mk_pure_e (Caux.mk_std_undef_pe loc "§6.5.2.2#9" Undefined.UB041_function_not_compatible))
+match callconv with
+| C.Inner_arg_callconv ->
+    let (_, varg_ptr_sym_pats) = List.splitAt (List.length expect_params) arg_ptr_sym_pats in
+          (Caux.mk_sseqs
+            (* create temporary object for the additional arguments *)
+            (List.zip varg_ptr_sym_pats (List.reverse rev_variadic_core_creates))
+            (Caux.mk_sseq_e call_ret_wrp.E.sym_pat
+              (* do the function call *)
+              (Caux.mk_ccall_e (Caux.mk_ail_ctype_pe (ctype_of e)) call_wrp.E.sym_pe
+                (let (_, varg_ptr_sym_pes) = List.splitAt (List.length expect_params) arg_ptr_sym_pes in
+                  let varargs_ty_pes =
+                    List.map (fun (ty_pe, pe) -> Caux.mk_tuple_pe [ty_pe; pe])
+                      (List.zip (List.reverse rev_arg_ty_pes) varg_ptr_sym_pes) in
+                  let varargs_ty_pes_type = 
+                    C.BTy_tuple [C.BTy_ctype; (C.BTy_object C.OTy_pointer)] in
+                  (*is_used_pe :: *) List.reverse rev_cn_core_args ++ [Caux.mk_list_pe varargs_ty_pes_type varargs_ty_pes]
+                )
+              )
+              (
+                let arg_ptr_syms_tys =
+                  List.zip (snd (List.splitAt (List.length expect_params) arg_ptr_syms))
+                    ((*List.map (fun (_, ty, _) -> ty) expect_params ++ *) List.reverse rev_arg_tys) in
+                let killall_pat =
+                  let len = List.length arg_ptr_syms_tys in
+                  if len < 2 then
+                    Caux.mk_empty_pat C.BTy_unit
+                  else
+                    Caux.mk_empty_pat (C.BTy_tuple (List.replicate len C.BTy_unit)) in
+                Caux.mk_sseq_e killall_pat
+                  (* kill temporary objects *)
+                  (Caux.mk_unseq (List.map (fun (sym,ct) -> Caux.pkill loc (C.Static ct) (Caux.mk_sym_pe sym)) arg_ptr_syms_tys))
+                  (* return function call result *)
+                  (Caux.mk_pure_e call_ret_wrp.E.sym_pe)
+              )
+            )
+          )
+| C.Normal_callconv ->
           (Caux.mk_sseqs
             (* create temporary object *)
             (List.zip arg_ptr_sym_pats (List.reverse rev_core_creates ++ List.reverse rev_variadic_core_creates))
@@ -1043,6 +1085,7 @@ begin if expect_is_variadic then
               )
             )
           )
+end
         )
       )
 else
@@ -1056,14 +1099,30 @@ else
           (Caux.mk_op_pe C.OpOr is_variadic_wrp.E.sym_pe
                           (Caux.mk_not_pe (Caux.mk_are_compatible (Caux.mk_ail_ctype_pe expect_ret_ty) ret_wrp.E.sym_pe)))
           (Caux.mk_pure_e (Caux.mk_std_undef_pe loc "§6.5.2.2#9" Undefined.UB041_function_not_compatible))
-begin if Global.has_switch Global.SW_inner_arg_temps then
+match callconv with
+| C.Inner_arg_callconv ->
           (Caux.mk_ccall_e (Caux.mk_ail_ctype_pe (ctype_of e)) call_wrp.E.sym_pe ((*is_used_pe :: *)List.reverse rev_cn_core_args))
-else
+| C.Normal_callconv ->
             (* create temporary object *)
             (Caux.mk_sseqs (List.zip arg_ptr_sym_pats (List.reverse rev_core_creates))
             (Caux.mk_sseq_e call_ret_wrp.E.sym_pat
               (* do the function call *)
-              (Caux.mk_ccall_e (Caux.mk_ail_ctype_pe (ctype_of e)) call_wrp.E.sym_pe ((*is_used_pe :: *)arg_ptr_sym_pes))
+              (Caux.mk_ccall_e (Caux.mk_ail_ctype_pe (ctype_of e)) call_wrp.E.sym_pe
+              
+              
+            (
+              let (arg_pes, vararg_pes) = List.splitAt (List.length expect_params) arg_ptr_sym_pes in
+              let varargs_ty_pes =
+                List.map (fun (ty_pe, pe) -> Caux.mk_tuple_pe [ty_pe; pe])
+                  (List.zip (List.reverse rev_arg_ty_pes) vararg_pes) in
+              let varargs_ty_pes_type =
+                C.BTy_tuple [C.BTy_ctype; (C.BTy_object C.OTy_pointer)] in
+              if expect_is_variadic then
+                (*is_used_pe :: *) arg_pes ++ [Caux.mk_list_pe varargs_ty_pes_type varargs_ty_pes]
+              else
+                (*is_used_pe :: *) arg_pes
+            )
+              )
               (Caux.mk_sseq_e killall_pat
                 (* kill temporary objects *)
                 (let arg_ptr_syms_tys = List.map (fun (sym, (_, ty, _)) -> (sym, ty)) (List.zip arg_ptr_syms expect_params) in
@@ -4025,7 +4084,7 @@ let translate_program stdlib (startup_sym_opt, sigm) =
           let is_using_inner_arg_temps =
             (* NOTE: we exclude main because the driver allocates the objects for argc and argvs *)
             (* with this switch the argument temporary objects are allocated in the function *)
-            Global.has_switch Global.SW_inner_arg_temps && startup_sym_opt <> Just sym in
+            Global.has_switch Global.SW_inner_arg_temps in
           (* elaboration of a function *)
           let ret_bTy =
             if AilTypesAux.is_void return_ty then
@@ -4215,15 +4274,17 @@ let translate_extern_map (_, sigm) =
 (* This is the entry function (called from main.ml) *)
 val translate:
     (map string Symbol.sym) * C.fun_map unit ->
+    C.calling_convention ->
     C.impl -> 
     A.ail_program GenTypes.genTypeCategory ->
     C.file unit
-let translate (ailnames, stdlib_fun_map) impl prog =
+let translate (ailnames, stdlib_fun_map) callconv impl prog =
   let translation_stdlib = mk_translation_stdlib (ailnames, stdlib_fun_map) in
   let ((core_tagDefs, cglobs, (*cdecls, *) cfuns, funinfo), st) =
-    E.runStateM_errors (translate_program translation_stdlib prog) (E.elab_init ())
+    E.runStateM_errors (translate_program translation_stdlib prog) (E.elab_init callconv)
   in
   <| C.main= fst prog;
+     C.calling_convention= callconv;
      C.tagDefs= core_tagDefs;
      C.stdlib= stdlib_fun_map;
      C.impl= impl;

--- a/frontend/model/translation_effect.lem
+++ b/frontend/model/translation_effect.lem
@@ -30,14 +30,16 @@ type elab_state = <|
   temporary_objects: list (wrapped_symbol * Ctype.ctype);
   visible_objects_types_markers_env: map nat (list (Symbol.sym * Ctype.ctype));
 
-  errors: list string
+  errors: list string;
   
+  (* readonly *)
+  calling_convention: C.calling_convention;
 |>
 
 type elabM 'a = stateM 'a elab_state
 
-val elab_init: unit -> elab_state
-let elab_init () = <|
+val elab_init: C.calling_convention -> elab_state
+let elab_init callconv = <|
   visible_objects_types= Map.empty;
   visible_objects= [[]];
   string_literals= [];
@@ -45,7 +47,12 @@ let elab_init () = <|
   temporary_objects= [];
   visible_objects_types_markers_env = Map.empty;
   errors = [];
+  calling_convention= callconv;
 |>
+
+val get_calling_convention: elabM C.calling_convention
+let get_calling_convention =
+  fun st -> (st.calling_convention, st)
 
 
 (* TODO: this does not need to be in the monad, but it is useful to unsure

--- a/ocaml_frontend/pprinters/pp_errors.ml
+++ b/ocaml_frontend/pprinters/pp_errors.ml
@@ -462,9 +462,11 @@ let string_of_core_typing_cause = function
 
 let string_of_core_linking_cause = function
   | DuplicateExternalName (Symbol.Identifier (_, name)) ->
-    "duplicate external symbol: " ^ name
+      "duplicate external symbol: " ^ name
   | DuplicateMain ->
-    "duplicate main function"
+      "duplicate main function"
+  | IncompatibleCallingConvention ->
+      "incompatible calling conventions"
 
 
 let string_of_core_run_cause = function

--- a/ocaml_frontend/rewriters/core_peval.ml
+++ b/ocaml_frontend/rewriters/core_peval.ml
@@ -861,6 +861,7 @@ let rewrite_file file =
   in
 
   { main = file.main
+  ; calling_convention = file.calling_convention
   ; tagDefs = file.tagDefs
   ; stdlib = rewrite_fun_map file.stdlib
   ; impl = rewrite_impl file.impl

--- a/ocaml_frontend/rewriters/remove_unspecs.ml
+++ b/ocaml_frontend/rewriters/remove_unspecs.ml
@@ -102,6 +102,7 @@ let rewrite_file file =
         decl in
   
   { main = file.main
+  ; calling_convention = file.calling_convention
   ; tagDefs = file.tagDefs
   ; stdlib = Pmap.map rewrite_fun_map_decl file.stdlib
   ; impl = Pmap.map rewrite_impl_decl file.impl

--- a/ocaml_frontend/switches.ml
+++ b/ocaml_frontend/switches.ml
@@ -96,13 +96,43 @@ let set strs =
         Some (SW_magic_comment_char_dollar)
     | _ ->
         None in
+  let pred x = function
+    | SW_pointer_arith _ ->
+        begin match x with
+          | SW_pointer_arith _ -> true
+          | _ -> false
+        end
+    | SW_PNVI _ ->
+        begin match x with
+          | SW_PNVI _ -> true
+          | _ -> false
+        end
+    | SW_revocation _ ->
+        begin match x with
+          | SW_revocation _ -> true
+          | _ -> false
+        end
+    | SW_strict_reads
+    | SW_forbid_nullptr_free
+    | SW_zap_dead_pointers
+    | SW_strict_pointer_equality
+    | SW_strict_pointer_relationals
+    | SW_CHERI
+    | SW_inner_arg_temps
+    | SW_permissive_printf
+    | SW_zero_initialised
+    | SW_at_magic_comments
+    | SW_magic_comment_char_dollar as y ->
+        x = y in
   List.iter (fun str ->
     match read_switch str with
       | Some sw ->
-          if not (has_switch sw) then
+          if None = has_switch_pred (pred sw) then
             internal_ref := sw :: !internal_ref
+          else
+            prerr_endline ("switch '" ^ String.escaped str ^ "' would override a previous switch --> ignoring.")
       | None ->
-          prerr_endline ("failed to parse switch `" ^ String.escaped str ^ "' --> ignoring.")
+          prerr_endline ("failed to parse switch '" ^ String.escaped str ^ "' --> ignoring.")
   ) strs
 
 let set_iso_switches () =

--- a/runtime/libcore/std_inner_arg_temps.core
+++ b/runtime/libcore/std_inner_arg_temps.core
@@ -284,8 +284,7 @@ builtin vsnprintf (pointer, integer, [integer], integer) : eff loaded integer
 builtin rename    ([integer], [integer]) : eff loaded integer
 
 -- int printf(const char * restrict format, ...);
-proc [ailname = "printf"] printf_proxy(tmp_ptr: {-loaded-} pointer, args: [(ctype, pointer)]) : eff loaded integer :=
-  let strong frmt_ptr_: loaded pointer = load('char*', tmp_ptr) in
+proc [ailname = "printf"] printf_proxy(frmt_ptr_: loaded pointer, args: [(ctype, pointer)]) : eff loaded integer :=
   case frmt_ptr_ of
     | Specified(frmt_ptr: pointer) =>
         let strong xs: [integer] = pcall(listFromStr, frmt_ptr) in
@@ -296,10 +295,7 @@ proc [ailname = "printf"] printf_proxy(tmp_ptr: {-loaded-} pointer, args: [(ctyp
   end
 
 -- int vprintf (int fd, char * restrict format, va_list ap)
-proc [ailname = "__builtin_vprintf"] vprintf_proxy (fd_ptr: pointer, fmt_ptr: pointer, ap_ptr: pointer) : eff loaded integer :=
-  let strong fd_ptr_: loaded integer = load('signed int', fd_ptr) in
-  let strong fmt_ptr_: loaded pointer = load('char*', fmt_ptr) in
-  let strong ap_ptr_: loaded integer = load('signed int', ap_ptr) in
+proc [ailname = "__builtin_vprintf"] vprintf_proxy (fd_ptr_: loaded integer, fmt_ptr_: loaded pointer, ap_ptr_: loaded integer) : eff loaded integer :=
   case (fd_ptr_, fmt_ptr_, ap_ptr_) of
     | (Specified (fd: integer), Specified (fmt: pointer), Specified(ap: integer)) =>
         let strong xs: [integer] = pcall(listFromStr, fmt) in
@@ -309,11 +305,7 @@ proc [ailname = "__builtin_vprintf"] vprintf_proxy (fd_ptr: pointer, fmt_ptr: po
   end
 
 -- int vsnprintf(int fd, size_t n, const char * restrict fmt, va_list arg);
-proc [ailname = "__builtin_vsnprintf"] vsnprintf_proxy (s_ptr: pointer, size_ptr: pointer, fmt_ptr: pointer, ap_ptr: pointer) : eff loaded integer :=
-  let strong s_ptr_: loaded pointer = load('char*', s_ptr) in
-  let strong size_ptr_: loaded integer = load('size_t', size_ptr) in
-  let strong fmt_ptr_: loaded pointer = load('char*', fmt_ptr) in
-  let strong ap_ptr_: loaded integer = load('signed int', ap_ptr) in
+proc [ailname = "__builtin_vsnprintf"] vsnprintf_proxy (s_ptr_: loaded pointer, size_ptr_: loaded integer, fmt_ptr_: loaded pointer, ap_ptr_: loaded integer) : eff loaded integer :=
   case (s_ptr_, size_ptr_, fmt_ptr_, ap_ptr_) of
     | (Specified (s: pointer), Specified (size: integer), Specified (fmt: pointer), Specified(ap: integer)) =>
         let strong xs: [integer] = pcall(listFromStr, fmt) in
@@ -323,9 +315,7 @@ proc [ailname = "__builtin_vsnprintf"] vsnprintf_proxy (s_ptr: pointer, size_ptr
   end
 
 -- int rename(const char *oldpath, const char *newpath);
-proc [ailname = "rename"] rename_proxy (oldpath_ptr: pointer, newpath_ptr: pointer): eff loaded integer :=
-  let strong oldpath_loaded: loaded pointer = load('char*', oldpath_ptr) in
-  let strong newpath_loaded: loaded pointer = load('char*', newpath_ptr) in
+proc [ailname = "rename"] rename_proxy (oldpath_loaded: loaded pointer, newpath_loaded: loaded pointer): eff loaded integer :=
   case (oldpath_loaded, newpath_loaded) of
     | (Specified (oldpath: pointer), Specified (newpath: pointer)) =>
       let strong cs1: [integer] = pcall(listFromStr, oldpath) in
@@ -353,9 +343,7 @@ proc [ailname = "malloc"] malloc_proxy (size_: loaded integer) : eff loaded poin
         pure(error(<<<malloc_proxy>>>, False))
   end
 
-proc [ailname = "realloc"] realloc_proxy (old_ptrptr: pointer, size_ptr: pointer) : eff loaded pointer :=
-  let strong size_: loaded integer = load('size_t', size_ptr) in
-  let strong old_ptrptr_: loaded pointer = load('void *', old_ptrptr) in
+proc [ailname = "realloc"] realloc_proxy (old_ptrptr_: loaded pointer, size_: loaded integer) : eff loaded pointer :=
   case (size_, old_ptrptr_) of
     | (Specified(size: integer), Specified(old_ptr: pointer)) =>
         let strong ptr: pointer = memop(Realloc, IvMaxAlignment, old_ptr, size) in
@@ -372,9 +360,7 @@ proc [ailname = "free"] free_proxy (p_: loaded pointer) : eff unit :=
         pure(undef(<<DUMMY(kill_proxy_1)>>)) -- TODO check that
   end
 
-proc [ailname = "aligned_alloc"] aligned_alloc_proxy (align_ptr: pointer, size_ptr: pointer) : eff loaded pointer :=
-  let strong align_: loaded integer = load('size_t', align_ptr) in
-  let strong size_: loaded integer = load('size_t', size_ptr) in
+proc [ailname = "aligned_alloc"] aligned_alloc_proxy (align_: loaded integer, size_: loaded integer) : eff loaded pointer :=
   case (align_, size_) of
     | (Specified(align: integer), Specified(size: integer)) =>
         if size rem_t align = 0 then
@@ -568,9 +554,7 @@ proc [ailname = "closedir"] closedir_proxy (dirp_: loaded pointer): eff loaded i
 builtin open ([integer], integer): eff loaded pointer
 
 -- int open(const char *path, int oflag, ...);
-proc [ailname = "open"] open_proxy (path_ptr: pointer, oflag_ptr: pointer, args: [(ctype, pointer)]): eff loaded pointer :=
-  let strong path_loaded: loaded pointer = load('char*', path_ptr) in
-  let strong oflag_loaded: loaded integer = load('signed int', oflag_ptr) in
+proc [ailname = "open"] open_proxy (path_loaded: loaded pointer, oflag_loaded: loaded integer, args: [(ctype, pointer)]): eff loaded pointer :=
   -- TODO: i'm ignoring the args!!
   case (path_loaded, oflag_loaded) of
     | (Specified (path: pointer), Specified (oflag: integer)) =>


### PR DESCRIPTION
This PR updates Core and its runtime to fully support two calling conventions differing on whether temporary objects for parameters are allocated by the caller (default) or the callee (the `inner_arg_temps` switch used by CN).

This should address issue #391.