### PR TITLE
CN: Run docker build nightly (#489)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,17 +1,19 @@
 name: docker
 
 on:
-  push:
-    branches:
-      - master
+  schedule:
+    - cron '30 18 * * *'
 
 env:
   CERBERUS_IMAGE_ID: ghcr.io/rems-project/cerberus/cn:release
 
-# cancel in-progress job when a new push is performed
+# Cancelling an in-progress job when a new push is performed causes the CI to
+# show up as failed: https://github.com/orgs/community/discussions/8336
+# This is noisy. If we want to enable that, we should consider:
+# https://github.com/MercuryTechnologies/delete-cancelled-runs
 concurrency:
   group: docker-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   deploy-docker:


### PR DESCRIPTION
The docker build is slow, especially on Arm since it has to run on QEMU (OCaml doesn't support cross compilation well yet) and because of this, and the `cancel-in-progress: true`, the CI becomes less helpful (pushing new commits cancels the previous job, which is fine, but then that shows up as failed on the CI history, which is unhelpful).

This commit changes it to run the build daily at 18:30 UTC and disables cancel-in-progress.