### PR TITLE
CN: Sundry fixes to solver.ml

### DIFF
--- a/backend/cn/lib/builtins.ml
+++ b/backend/cn/lib/builtins.ml
@@ -76,15 +76,13 @@ let rem_uf_def = ("rem_uf", Sym.fresh_named "rem_uf", mk_arg2 rem_no_smt_)
 
 let mod_uf_def = ("mod_uf", Sym.fresh_named "mod_uf", mk_arg2 mod_no_smt_)
 
-let xor_uf_def = ("xor_uf", Sym.fresh_named "xor_uf", mk_arg2 (arith_binop XORNoSMT))
+let xor_uf_def = ("xor_uf", Sym.fresh_named "xor_uf", mk_arg2 (arith_binop BW_Xor))
 
 let bw_and_uf_def =
   ("bw_and_uf", Sym.fresh_named "bw_and_uf", mk_arg2 (arith_binop BW_And))
 
 
-let bw_or_uf_def =
-  ("bw_or_uf", Sym.fresh_named "bw_or_uf", mk_arg2 (arith_binop BWOrNoSMT))
-
+let bw_or_uf_def = ("bw_or_uf", Sym.fresh_named "bw_or_uf", mk_arg2 (arith_binop BW_Or))
 
 let bw_clz_uf_def =
   ("bw_clz_uf", Sym.fresh_named "bw_clz_uf", mk_arg1 (arith_unop BW_CLZ_NoSMT))

--- a/backend/cn/lib/cLogicalFuns.ml
+++ b/backend/cn/lib/cLogicalFuns.ml
@@ -335,8 +335,8 @@ let rec symb_exec_mu_pexpr ctxt var_map pexpr =
     let binop =
       match binop with
       | M_BW_AND -> IT.BW_And
-      | M_BW_OR -> IT.BWOrNoSMT
-      | M_BW_XOR -> IT.XORNoSMT
+      | M_BW_OR -> IT.BW_Or
+      | M_BW_XOR -> IT.BW_Xor
     in
     simp_const_pe (IT.arith_binop binop (x, y) loc)
   | M_PEbool_to_integer pe ->

--- a/backend/cn/lib/check.ml
+++ b/backend/cn/lib/check.ml
@@ -507,10 +507,7 @@ let rec check_pexpr (pe : BT.t mu_pexpr) (k : IT.t -> unit m) : unit m =
        let@ () = ensure_base_type loc ~expect (bt_of_pexpr pe1) in
        let@ () = ensure_base_type loc ~expect (bt_of_pexpr pe2) in
        let binop =
-         match binop with
-         | M_BW_AND -> BW_And
-         | M_BW_OR -> BWOrNoSMT
-         | M_BW_XOR -> XORNoSMT
+         match binop with M_BW_AND -> BW_And | M_BW_OR -> BW_Or | M_BW_XOR -> BW_Xor
        in
        check_pexpr pe1 (fun vt1 ->
          check_pexpr pe2 (fun vt2 ->

--- a/backend/cn/lib/cn_internal_to_ail.ml
+++ b/backend/cn/lib/cn_internal_to_ail.ml
@@ -342,9 +342,9 @@ let cn_to_ail_binop_internal bt1 bt2 =
   | Exp | ExpNoSMT -> (A.And, Some (get_cn_int_type_str bt1 bt2 ^ "_pow"))
   | Rem | RemNoSMT -> failwith "TODO cn_to_ail_binop: rem"
   | Mod | ModNoSMT -> (A.(Arithmetic Mod), Some (get_cn_int_type_str bt1 bt2 ^ "_mod"))
-  | XORNoSMT -> (A.(Arithmetic Bxor), Some (get_cn_int_type_str bt1 bt2 ^ "_xor"))
+  | BW_Xor -> (A.(Arithmetic Bxor), Some (get_cn_int_type_str bt1 bt2 ^ "_xor"))
   | BW_And -> (A.(Arithmetic Band), Some (get_cn_int_type_str bt1 bt2 ^ "_bwand"))
-  | BWOrNoSMT -> (A.(Arithmetic Bor), Some (get_cn_int_type_str bt1 bt2 ^ "_bwor"))
+  | BW_Or -> (A.(Arithmetic Bor), Some (get_cn_int_type_str bt1 bt2 ^ "_bwor"))
   | ShiftLeft -> (A.(Arithmetic Shl), Some (get_cn_int_type_str bt1 bt2 ^ "_shift_left"))
   | ShiftRight -> (A.(Arithmetic Shr), Some (get_cn_int_type_str bt1 bt2 ^ "_shift_right"))
   | LT -> (A.Lt, Some (get_cn_int_type_str bt1 bt2 ^ "_lt"))

--- a/backend/cn/lib/lemmata.ml
+++ b/backend/cn/lib/lemmata.ml
@@ -986,9 +986,9 @@ let it_to_coq loc global list_mono it =
          | LE -> abinop (if enc_prop then "<=" else "<=?") x y
          | Exp -> abinop "^" x y
          | ExpNoSMT -> abinop "^" x y
-         | XORNoSMT -> f_appM "Z.lxor" [ aux x; aux y ]
+         | BW_Xor -> f_appM "Z.lxor" [ aux x; aux y ]
          | BW_And -> f_appM "Z.land" [ aux x; aux y ]
-         | BWOrNoSMT -> f_appM "Z.lor" [ aux x; aux y ]
+         | BW_Or -> f_appM "Z.lor" [ aux x; aux y ]
          | EQ ->
            let comp = Some (t, "argument of equality") in
            parensM (build [ f comp x; rets (if enc_prop then "=" else "=?"); f comp y ])

--- a/backend/cn/lib/terms.ml
+++ b/backend/cn/lib/terms.ml
@@ -47,9 +47,9 @@ type binop =
   | RemNoSMT
   | Mod
   | ModNoSMT
-  | XORNoSMT
+  | BW_Xor
   | BW_And
-  | BWOrNoSMT
+  | BW_Or
   | ShiftLeft
   | ShiftRight
   | LT
@@ -263,9 +263,9 @@ let pp
        | LEPointer -> infix 10 (langle () ^^ equals) 10 10
        | Min -> prefix "min"
        | Max -> prefix "max"
-       | XORNoSMT -> infix 7 !^"^" 7 7
+       | BW_Xor -> infix 7 !^"^" 7 7
        | BW_And -> infix 8 ampersand 8 8
-       | BWOrNoSMT -> infix 6 bar 6 6
+       | BW_Or -> infix 6 bar 6 6
        | ShiftLeft ->
          infix 0 (langle () ^^ langle ()) 1 1 (* easier to read with parens *)
        | ShiftRight ->

--- a/backend/cn/lib/testGeneration/codify.ml
+++ b/backend/cn/lib/testGeneration/codify.ml
@@ -53,9 +53,9 @@ let rec codify_it_ (e : BT.t IT.term_) : string option =
          "(" ^ codify_it e1 ^ " * " ^ codify_it e2 ^ ")"
        | Binop (Div, e1, e2) | Binop (DivNoSMT, e1, e2) ->
          "(" ^ codify_it e1 ^ " / " ^ codify_it e2 ^ ")"
-       | Binop (XORNoSMT, e1, e2) -> "(" ^ codify_it e1 ^ " ^ " ^ codify_it e2 ^ ")"
+       | Binop (BW_Xor, e1, e2) -> "(" ^ codify_it e1 ^ " ^ " ^ codify_it e2 ^ ")"
        | Binop (BW_And, e1, e2) -> "(" ^ codify_it e1 ^ " & " ^ codify_it e2 ^ ")"
-       | Binop (BWOrNoSMT, e1, e2) -> "(" ^ codify_it e1 ^ " | " ^ codify_it e2 ^ ")"
+       | Binop (BW_Or, e1, e2) -> "(" ^ codify_it e1 ^ " | " ^ codify_it e2 ^ ")"
        | Binop (ShiftLeft, e1, e2) -> "(" ^ codify_it e1 ^ " << " ^ codify_it e2 ^ ")"
        | Binop (ShiftRight, e1, e2) -> "(" ^ codify_it e1 ^ " >> " ^ codify_it e2 ^ ")"
        | Binop (LT, e1, e2) | Binop (LTPointer, e1, e2) ->

--- a/backend/cn/lib/wellTyped.ml
+++ b/backend/cn/lib/wellTyped.ml
@@ -501,7 +501,7 @@ module WIT = struct
            in
            warn loc msg;
            return (IT (Binop (ExpNoSMT, t, t'), IT.bt t, loc))
-         | ExpNoSMT | RemNoSMT | ModNoSMT | XORNoSMT | BW_And | BWOrNoSMT | ShiftLeft
+         | ExpNoSMT | RemNoSMT | ModNoSMT | BW_Xor | BW_And | BW_Or | ShiftLeft
          | ShiftRight | Rem | Mod ->
            let@ t = infer t in
            let@ () = ensure_bits_type loc (IT.bt t) in


### PR DESCRIPTION
Struct and data fields are now suffixed with an underscore, making them more readable (and more consistent).

"XXX" is replaced with TODO, FIXME, or "ISD" as approriately.

"intptr_cast" was renamed to the more accurate "uintptr_cast" (no change in semantics, just a variable renaming).

A typo "done_strcuts" was changed to "done_structs"

A variable "here" which did not point to the OCaml function was renamed to "loc" (no change in semantics, merely renaming).

Two constructors "BWOrNoSMT" and "XORNoSMT" were given simpler, more readable and consistent names "BW_Or" and "BW_Xor".