### PR TITLE
CN: Fix free vars for lets in Z3 SMT

### DIFF
--- a/backend/cn/bin/main.ml
+++ b/backend/cn/bin/main.ml
@@ -306,8 +306,8 @@ let verify
   Solver.random_seed := random_seed;
   (match solver_logging with
    | Some d ->
-     Solver.log_to_temp := true;
-     Solver.log_dir := if String.equal d "" then None else Some d
+     Solver.Logger.to_file := true;
+     Solver.Logger.dir := if String.equal d "" then None else Some d
    | _ -> ());
   Solver.solver_path := solver_path;
   Solver.solver_type := solver_type;

--- a/backend/cn/lib/pp.ml
+++ b/backend/cn/lib/pp.ml
@@ -199,7 +199,7 @@ let debug l pp =
     let pp2 =
       if !print_timestamps then (
         let time = Sys.time () in
-        format [ Green ] ("[" ^ Float.to_string time ^ "] ") ^^ pp1)
+        format [ Green ] ("[" ^ Printf.sprintf "%.6f" time ^ "] ") ^^ pp1)
       else
         pp1
     in

--- a/backend/cn/lib/solver.mli
+++ b/backend/cn/lib/solver.mli
@@ -13,9 +13,11 @@ val empty_model : model
    maybe) *)
 val random_seed : int ref
 
-val log_to_temp : bool ref
+module Logger : sig
+  val to_file : bool ref
 
-val log_dir : string option ref
+  val dir : string option ref
+end
 
 val solver_path : string option ref
 


### PR DESCRIPTION
Commit https://github.com/rems-project/cerberus/commit/2b30e70b1d975937ee1e73e8643dce18b6036ae7 introduced a new solver backend for CN. This code included a work-around for Z3 (https://github.com/Z3Prover/z3/issues/7268), which involved calculating free variables for expressions. For `(let ((x term)) body)`, the code correctly looked in `body` but did not look in `term`.

This commit fixes that, whilst tidying up some debugging and logging code to make future debugging sessions easier.

It does not include a test because this bug was discovered during the development of a different feature (with file `tests/cn/ptr_diff2.c`) https://github.com/rems-project/cerberus/pull/494 which will be added in separately, later.