### PR TITLE
CN-exec: Implement datatype default and map get

### DIFF
--- a/backend/cn/lib/cn_internal_to_ail.ml
+++ b/backend/cn/lib/cn_internal_to_ail.ml
@@ -1536,6 +1536,79 @@ let cn_to_ail_pred_records map_bindings =
   List.map generate_struct_definition flipped_bindings
 
 
+(* Generic map get for structs and datatypes *)
+(* Used in generate_struct_map_get and generate_datatype_map_get *)
+let generate_map_get sym =
+  let ctype_str = "struct_" ^ Sym.pp_string sym in
+  let fn_str = "cn_map_get_" ^ ctype_str in
+  let void_ptr_type = C.(mk_ctype_pointer empty_qualifiers (mk_ctype Void)) in
+  let param1_sym = Sym.fresh_pretty "m" in
+  let param2_sym = Sym.fresh_pretty "key" in
+  let param_syms = [ param1_sym; param2_sym ] in
+  let param_types =
+    List.map bt_to_ail_ctype [ BT.Map (Integer, Struct sym); BT.Integer ]
+  in
+  let param_types =
+    List.map (fun ctype -> (empty_qualifiers, ctype, false)) param_types
+  in
+  let fn_sym = Sym.fresh_pretty fn_str in
+  let ret_sym = Sym.fresh_pretty "ret" in
+  let ret_binding = create_binding ret_sym void_ptr_type in
+  let key_val_mem =
+    mk_expr A.(AilEmemberofptr (mk_expr (AilEident param2_sym), Id.id "val"))
+  in
+  let ht_get_fcall =
+    mk_expr
+      A.(
+        AilEcall
+          ( mk_expr (AilEident (Sym.fresh_pretty "ht_get")),
+            [ mk_expr (AilEident param1_sym); key_val_mem ] ))
+  in
+  let ret_decl = A.(AilSdeclaration [ (ret_sym, Some ht_get_fcall) ]) in
+  let ret_ident = A.(AilEident ret_sym) in
+  (* Function body *)
+  let if_cond =
+    mk_expr
+      A.(
+        AilEbinary
+          ( mk_expr A.(AilEconst (ConstantInteger (IConstant (Z.of_int 0, Decimal, None)))),
+            Eq,
+            mk_expr ret_ident ))
+  in
+  let default_fcall =
+    A.(AilEcall (mk_expr (AilEident (Sym.fresh_pretty ("default_" ^ ctype_str))), []))
+  in
+  let cast_expr = A.(AilEcast (empty_qualifiers, void_ptr_type, mk_expr default_fcall)) in
+  let if_stmt =
+    A.(
+      AilSif
+        ( if_cond,
+          mk_stmt (AilSreturn (mk_expr cast_expr)),
+          mk_stmt (AilSreturn (mk_expr ret_ident)) ))
+  in
+  let ret_type = void_ptr_type in
+  (* Generating function declaration *)
+  let decl =
+    ( fn_sym,
+      ( Cerb_location.unknown,
+        empty_attributes,
+        A.(
+          Decl_function
+            (false, (empty_qualifiers, ret_type), param_types, false, false, false)) ) )
+  in
+  (* Generating function definition *)
+  let def =
+    ( fn_sym,
+      ( Cerb_location.unknown,
+        0,
+        empty_attributes,
+        param_syms,
+        mk_stmt A.(AilSblock ([ ret_binding ], List.map mk_stmt [ ret_decl; if_stmt ])) )
+    )
+  in
+  [ (decl, def) ]
+
+
 let cn_to_ail_datatype ?(first = false) (cn_datatype : cn_datatype) =
   let enum_sym = generate_sym_with_suffix cn_datatype.cn_dt_name in
   let constructor_syms = List.map fst cn_datatype.cn_dt_cases in
@@ -1743,6 +1816,11 @@ let generate_datatype_equality_function (cn_datatype : cn_datatype) =
   [ (decl, def) ]
 
 
+let generate_datatype_map_get (cn_datatype : cn_datatype) =
+  let cn_sym = cn_datatype.cn_dt_name in
+  generate_map_get cn_sym
+
+
 let generate_datatype_default_function (cn_datatype : cn_datatype) =
   let cn_sym = cn_datatype.cn_dt_name in
   let fn_str = "default_struct_" ^ Sym.pp_string cn_sym in
@@ -1761,12 +1839,12 @@ let generate_datatype_default_function (cn_datatype : cn_datatype) =
   let res_ident = mk_expr A.(AilEident res_sym) in
   let res_binding = create_binding res_sym cn_struct_ptr_ctype in
   let res_decl = A.(AilSdeclaration [ (res_sym, Some alloc_fcall) ]) in
-  let rec get_constrs_and_ms = function
+  let rec get_non_recursive_constr_and_ms = function
     | [] -> failwith "Datatype default generation failure: datatype has no constructors"
     | ((_, members) as x) :: xs ->
       let ids, basetypes = List.split members in
       if List.mem BT.equal (Datatype cn_sym) (List.map cn_base_type_to_bt basetypes) then
-        get_constrs_and_ms xs
+        get_non_recursive_constr_and_ms xs
       else
         x
   in
@@ -1786,7 +1864,7 @@ let generate_datatype_default_function (cn_datatype : cn_datatype) =
         return res;
       }
   *)
-  let constructor, members = get_constrs_and_ms cn_datatype.cn_dt_cases in
+  let constructor, members = get_non_recursive_constr_and_ms cn_datatype.cn_dt_cases in
   let enum_sym = generate_sym_with_suffix ~suffix:"" ~uppercase:true constructor in
   let enum_str = Sym.pp_string enum_sym in
   let attribute : CF.Annot.attribute =
@@ -2061,86 +2139,13 @@ let generate_struct_default_function
 
 
 let generate_struct_map_get
-  ?(is_record = false)
-  dts
   ((sym, (loc, attrs, tag_def)) :
     A.ail_identifier * (Cerb_location.t * CF.Annot.attributes * C.tag_definition))
   =
   match tag_def with
-  | C.StructDef (members, _) ->
-    let cn_sym = if is_record then sym else generate_sym_with_suffix ~suffix:"_cn" sym in
-    let ctype_str = "struct_" ^ Sym.pp_string cn_sym in
-    let fn_str = "cn_map_get_" ^ ctype_str in
-    let void_ptr_type = C.(mk_ctype_pointer empty_qualifiers (mk_ctype Void)) in
-    let param1_sym = Sym.fresh_pretty "m" in
-    let param2_sym = Sym.fresh_pretty "key" in
-    let param_syms = [ param1_sym; param2_sym ] in
-    let param_types =
-      List.map bt_to_ail_ctype [ BT.Map (Integer, Struct cn_sym); BT.Integer ]
-    in
-    let param_types =
-      List.map (fun ctype -> (empty_qualifiers, ctype, false)) param_types
-    in
-    let fn_sym = Sym.fresh_pretty fn_str in
-    let ret_sym = Sym.fresh_pretty "ret" in
-    let ret_binding = create_binding ret_sym void_ptr_type in
-    let key_val_mem =
-      mk_expr A.(AilEmemberofptr (mk_expr (AilEident param2_sym), Id.id "val"))
-    in
-    let ht_get_fcall =
-      mk_expr
-        A.(
-          AilEcall
-            ( mk_expr (AilEident (Sym.fresh_pretty "ht_get")),
-              [ mk_expr (AilEident param1_sym); key_val_mem ] ))
-    in
-    let ret_decl = A.(AilSdeclaration [ (ret_sym, Some ht_get_fcall) ]) in
-    let ret_ident = A.(AilEident ret_sym) in
-    (* Function body *)
-    let if_cond =
-      mk_expr
-        A.(
-          AilEbinary
-            ( mk_expr
-                A.(AilEconst (ConstantInteger (IConstant (Z.of_int 0, Decimal, None)))),
-              Eq,
-              mk_expr ret_ident ))
-    in
-    let default_fcall =
-      A.(AilEcall (mk_expr (AilEident (Sym.fresh_pretty ("default_" ^ ctype_str))), []))
-    in
-    let cast_expr =
-      A.(AilEcast (empty_qualifiers, void_ptr_type, mk_expr default_fcall))
-    in
-    let if_stmt =
-      A.(
-        AilSif
-          ( if_cond,
-            mk_stmt (AilSreturn (mk_expr cast_expr)),
-            mk_stmt (AilSreturn (mk_expr ret_ident)) ))
-    in
-    let ret_type = void_ptr_type in
-    (* Generating function declaration *)
-    let decl =
-      ( fn_sym,
-        ( Cerb_location.unknown,
-          empty_attributes,
-          A.(
-            Decl_function
-              (false, (empty_qualifiers, ret_type), param_types, false, false, false)) )
-      )
-    in
-    (* Generating function definition *)
-    let def =
-      ( fn_sym,
-        ( Cerb_location.unknown,
-          0,
-          empty_attributes,
-          param_syms,
-          mk_stmt A.(AilSblock ([ ret_binding ], List.map mk_stmt [ ret_decl; if_stmt ]))
-        ) )
-    in
-    [ (decl, def) ]
+  | C.StructDef _ ->
+    let cn_sym = generate_sym_with_suffix ~suffix:"_cn" sym in
+    generate_map_get cn_sym
   | C.UnionDef _ -> []
 
 

--- a/backend/cn/lib/executable_spec_internal.ml
+++ b/backend/cn/lib/executable_spec_internal.ml
@@ -227,30 +227,6 @@ let generate_record_strs
   (record_def_strs, record_decl_strs)
 
 
-(* let ail_record_equality_functions = List.map (fun r ->
-   Cn_internal_to_ail.generate_struct_equality_function ~is_record:true sigm.cn_datatypes
-   r) ail_records in let ail_record_equality_functions = List.concat
-   ail_record_equality_functions in let ail_record_default_functions = List.map (fun r ->
-   Cn_internal_to_ail.generate_struct_default_function ~is_record:true sigm.cn_datatypes
-   r) ail_records in let ail_record_default_functions = List.concat
-   ail_record_default_functions in let ail_record_mapget_functions = List.map (fun r ->
-   Cn_internal_to_ail.generate_struct_map_get ~is_record:true sigm.cn_datatypes r)
-   ail_records in let ail_record_mapget_functions = List.concat
-   ail_record_mapget_functions in *)
-(* let (eq_decls, eq_defs) = List.split ail_record_equality_functions in let
-   (default_decls, default_defs) = List.split ail_record_default_functions in let
-   (mapget_decls, mapget_defs) = List.split ail_record_mapget_functions in *)
-(* let modified_prog1 : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma = {sigm with
-   declarations = eq_decls @ default_decls @ mapget_decls; function_definitions = eq_defs
-   @ default_defs @ mapget_defs} in let equality_fun_strs = CF.Pp_ail.pp_program
-   ~executable_spec:true ~show_include:true (None, modified_prog1) in let decl_docs =
-   List.map (fun (sym, (_, _, decl)) -> CF.Pp_ail.pp_function_prototype
-   ~executable_spec:true sym decl) eq_decls in let equality_fun_prot_strs = List.map (fun
-   doc -> [CF.Pp_utils.to_plain_pretty_string doc]) decl_docs in let
-   equality_fun_prot_strs = String.concat "\n" (List.concat equality_fun_prot_strs) in *)
-(* (record_def_strs, record_decl_strs, CF.Pp_utils.to_plain_pretty_string
-   equality_fun_strs, equality_fun_prot_strs) *)
-
 let generate_all_record_strs sigm =
   generate_record_strs
     sigm
@@ -615,34 +591,45 @@ let generate_ownership_functions
 let generate_conversion_and_equality_functions
   (sigm : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma)
   =
-  let ail_funs =
+  let struct_conversion_funs =
     List.map Cn_internal_to_ail.generate_struct_conversion_function sigm.tag_definitions
   in
-  let ail_funs' =
+  let struct_equality_funs =
     List.map
       (Cn_internal_to_ail.generate_struct_equality_function sigm.cn_datatypes)
       sigm.tag_definitions
   in
-  let ail_funs'' =
+  let datatype_equality_funs =
     List.map Cn_internal_to_ail.generate_datatype_equality_function sigm.cn_datatypes
   in
-  let ail_funs''' =
-    List.map
-      (Cn_internal_to_ail.generate_struct_map_get sigm.cn_datatypes)
-      sigm.tag_definitions
+  let struct_map_get_funs =
+    List.map Cn_internal_to_ail.generate_struct_map_get sigm.tag_definitions
   in
-  let ail_funs'''' =
+  let struct_default_funs =
     List.map
       (Cn_internal_to_ail.generate_struct_default_function sigm.cn_datatypes)
       sigm.tag_definitions
   in
-  let ail_funs = List.concat ail_funs in
+  let datatype_map_get_funs =
+    List.map Cn_internal_to_ail.generate_datatype_map_get sigm.cn_datatypes
+  in
+  let datatype_default_funs =
+    List.map Cn_internal_to_ail.generate_datatype_default_function sigm.cn_datatypes
+  in
   let ail_funs =
-    ail_funs
-    @ List.concat ail_funs'
-    @ List.concat ail_funs''
-    @ List.concat ail_funs'''
-    @ List.concat ail_funs''''
+    List.fold_left
+      ( @ )
+      []
+      (List.map
+         List.concat
+         [ struct_conversion_funs;
+           struct_equality_funs;
+           datatype_equality_funs;
+           struct_map_get_funs;
+           struct_default_funs;
+           datatype_map_get_funs;
+           datatype_default_funs
+         ])
   in
   let decls, defs = List.split ail_funs in
   let modified_prog1 : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma =


### PR DESCRIPTION
Add plumbing for generating a default function in C for any user-defined CN datatypes and for generating map get functions for these datatypes too.