### PR TITLE
Update cn-runtime-dir script

### DIFF
--- a/tests/cn-runtime/cn-runtime-dir.sh
+++ b/tests/cn-runtime/cn-runtime-dir.sh
@@ -41,7 +41,6 @@ SUCCESS=$(find tests/cn -name '*.c' \
 BUGGY=("")
 
 SHOULD_FAIL=$(find tests/cn -name '*.error.c')
-# SHOULD_FAIL=("src/examples/read.broken.c" "src/examples/slf14_basic_succ_using_incr_attempt.broken.c")
 
 FAILED=""
 


### PR DESCRIPTION
Updated `tests/cn-runtime/cn-runtime-dir.sh` to match [`runtime-test.sh`](https://github.com/rems-project/cn-tutorial/blob/cn-runtime-testing/runtime-test.sh) from the CN tutorial repo, which is also what is being used in the runtime testing CI right now, since this script is cleaner to work with and shows test success/failure more clearly in the terminal.