### PR TITLE
CN: Slightly improve inconsistent precond err msg

### DIFF
--- a/backend/cn/lib/typeErrors.ml
+++ b/backend/cn/lib/typeErrors.ml
@@ -218,6 +218,7 @@ type message =
   | Redundant_pattern of Pp.document
   | Duplicate_pattern
   | Empty_provenance
+  | Inconsistent_assumptions of string * (Context.t * log)
 
 type type_error =
   { loc : Locations.t;
@@ -536,6 +537,10 @@ let pp_message te =
          ^^ dot)
     in
     { short; descr; state = None }
+  | Inconsistent_assumptions (kind, ctxt_log) ->
+    let short = !^kind ^^ !^" makes inconsistent assumptions" in
+    let state = Some (trace ctxt_log (Solver.empty_model, []) Explain.no_ex) in
+    { short; descr = None; state }
 
 
 type t = type_error

--- a/backend/cn/lib/wellTyped.ml
+++ b/backend/cn/lib/wellTyped.ml
@@ -1188,10 +1188,8 @@ module WLAT = struct
         let@ () =
           match provable (LC.t_ (IT.bool_ false here)) with
           | `True ->
-            fail (fun _ ->
-              { loc;
-                msg = Generic !^("this " ^ kind ^ " makes inconsistent assumptions")
-              })
+            fail (fun ctxt_log ->
+              { loc; msg = Inconsistent_assumptions (kind, ctxt_log) })
           | `False -> return ()
         in
         let@ i = i_welltyped loc i in
@@ -1266,10 +1264,8 @@ module WLArgs = struct
         let@ () =
           match provable (LC.t_ (IT.bool_ false here)) with
           | `True ->
-            fail (fun _ ->
-              { loc;
-                msg = Generic !^("this " ^ kind ^ " makes inconsistent assumptions")
-              })
+            fail (fun ctxt_log ->
+              { loc; msg = Inconsistent_assumptions (kind, ctxt_log) })
           | `False -> return ()
         in
         let@ i = i_welltyped loc i in

--- a/tests/cn/inconsistent.error.c
+++ b/tests/cn/inconsistent.error.c
@@ -1,0 +1,9 @@
+void f()
+/*@
+requires
+    1i32 == 0i32;
+ensures
+    true;
+@*/
+{
+}


### PR DESCRIPTION
By outputting a state file, as suggested in
https://github.com/rems-project/cerberus/issues/398