### PR TITLE
[CN-Exec] Minor changes to runtime library to accomodate testing

### DIFF
--- a/runtime/libcn/include/cn-executable/alloc.h
+++ b/runtime/libcn/include/cn-executable/alloc.h
@@ -1,6 +1,10 @@
 #ifndef CN_ALLOC
 #define CN_ALLOC
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // enum CNTYPE {
 //     NODE_CN,
 //     SEQ,
@@ -19,5 +23,9 @@ void *alloc_(long nbytes, const char *, int);
 
 
 // void *alloc_zeros(long nbytes);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // CN_ALLOC

--- a/runtime/libcn/include/cn-executable/alloc.h
+++ b/runtime/libcn/include/cn-executable/alloc.h
@@ -1,3 +1,6 @@
+#ifndef CN_ALLOC
+#define CN_ALLOC
+
 // enum CNTYPE {
 //     NODE_CN,
 //     SEQ,
@@ -16,3 +19,5 @@ void *alloc_(long nbytes, const char *, int);
 
 
 // void *alloc_zeros(long nbytes);
+
+#endif // CN_ALLOC

--- a/runtime/libcn/include/cn-executable/hash_table.h
+++ b/runtime/libcn/include/cn-executable/hash_table.h
@@ -1,3 +1,6 @@
+#ifndef CN_HASH_TABLE
+#define CN_HASH_TABLE
+
 /*
 
 MIT License
@@ -65,3 +68,5 @@ typedef struct {
 hash_table_iterator ht_iterator(hash_table* table);
 
 _Bool ht_next(hash_table_iterator* it);
+
+#endif // CN_HASH_TABLE

--- a/runtime/libcn/include/cn-executable/hash_table.h
+++ b/runtime/libcn/include/cn-executable/hash_table.h
@@ -30,6 +30,10 @@ SOFTWARE.
 #include <stdbool.h>
 #include <cn-executable/alloc.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // Hash table entry (slot may be filled or empty).
 typedef struct {
     signed long *key;  // key is NULL if this slot is empty
@@ -68,5 +72,9 @@ typedef struct {
 hash_table_iterator ht_iterator(hash_table* table);
 
 _Bool ht_next(hash_table_iterator* it);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // CN_HASH_TABLE

--- a/runtime/libcn/include/cn-executable/utils.h
+++ b/runtime/libcn/include/cn-executable/utils.h
@@ -559,4 +559,4 @@ static inline void cn_postfix(void *ptr, size_t size)
     (*__tmp) OP;                                              \
  })
 
-#endif
+#endif // CN_UTILS

--- a/runtime/libcn/include/cn-executable/utils.h
+++ b/runtime/libcn/include/cn-executable/utils.h
@@ -12,6 +12,9 @@
 #include <cn-executable/alloc.h>
 #include <cn-executable/hash_table.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 struct cn_error_message_info {
     const char *function_name;
@@ -558,5 +561,9 @@ static inline void cn_postfix(void *ptr, size_t size)
     cn_postfix(__tmp, sizeof(typeof(LV)));                    \
     (*__tmp) OP;                                              \
  })
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // CN_UTILS

--- a/runtime/libcn/include/cn-executable/utils.h
+++ b/runtime/libcn/include/cn-executable/utils.h
@@ -112,6 +112,9 @@ void cn_free_sized(void*, size_t len);
 void cn_print_nr_u64(int i, unsigned long u) ;
 void cn_print_u64(const char *str, unsigned long u) ;
 
+/* cn_exit callbacks */
+void set_cn_exit_cb(void (*callback)(void));
+void reset_cn_exit_cb(void);
 
 /* Conversion functions */
 

--- a/runtime/libcn/src/utils.c
+++ b/runtime/libcn/src/utils.c
@@ -14,7 +14,7 @@ void cn_exit_aux(void) {
     exit(SIGABRT);
 }
 
-void (*cn_exit)(void) = &cn_exit_aux;
+void static (*cn_exit)(void) = &cn_exit_aux;
 
 void set_cn_exit_cb(void (*callback)(void)) {
     cn_exit = callback;

--- a/runtime/libcn/src/utils.c
+++ b/runtime/libcn/src/utils.c
@@ -16,6 +16,14 @@ void cn_exit_aux(void) {
 
 void (*cn_exit)(void) = &cn_exit_aux;
 
+void set_cn_exit_cb(void (*callback)(void)) {
+    cn_exit = callback;
+}
+
+void reset_cn_exit_cb(void) {
+    cn_exit = &cn_exit_aux;
+}
+
 void print_error_msg_info(void) {
   printf("Function: %s, %s:%d\n", error_msg_info.function_name, error_msg_info.file_name, error_msg_info.line_number);
 }


### PR DESCRIPTION
- include guards on all headers
- allowing the header files to be imported directly into C++ files
- being able to set the callback used by `cn_exit`.
