### PR TITLE
CN: Generalise cnnames

### DIFF
--- a/backend/cn/bin/main.ml
+++ b/backend/cn/bin/main.ml
@@ -73,12 +73,14 @@ let frontend
   let@ stdlib = load_core_stdlib () in
   let@ impl = load_core_impl stdlib impl_name in
   let conf = Setup.conf macros incl_dirs incl_files astprints in
+  let cn_init_scope : Cn_desugaring.init_scope =
+    { predicates = [ Alloc.Predicate.(str, sym, Some loc) ];
+      functions = List.map (fun (str, sym) -> (str, sym, None)) cn_builtin_fun_names;
+      idents = [ Alloc.History.(str, sym, Some loc) ]
+    }
+  in
   let@ _, ail_prog_opt, prog0 =
-    c_frontend_and_elaboration
-      ~cnnames:cn_builtin_fun_names
-      (conf, io)
-      (stdlib, impl)
-      ~filename
+    c_frontend_and_elaboration ~cn_init_scope (conf, io) (stdlib, impl) ~filename
   in
   let@ () =
     if conf.typecheck_core then

--- a/backend/cn/lib/alloc.ml
+++ b/backend/cn/lib/alloc.ml
@@ -1,0 +1,38 @@
+module History = struct
+  let str = "allocs"
+
+  let sym = Sym.fresh_named str
+
+  let loc = Locations.other __MODULE__
+
+  let value_bt =
+    BaseTypes.Record
+      [ (Id.id "base", Memory.uintptr_bt); (Id.id "size", Memory.uintptr_bt) ]
+
+
+  let bt = BaseTypes.Map (Alloc_id, value_bt)
+
+  let sbt = SurfaceBaseTypes.of_basetype bt
+end
+
+module Predicate = struct
+  let str = "Alloc"
+
+  let loc = Locations.other __MODULE__
+
+  let sym = Sym.fresh_named str
+
+  let pred_name = ResourceTypes.PName sym
+
+  let make pointer : ResourceTypes.predicate_type =
+    { name = pred_name; pointer; iargs = [] }
+
+
+  let def : ResourcePredicates.definition =
+    { loc = Locations.other (__FILE__ ^ ":" ^ string_of_int __LINE__);
+      pointer = Sym.fresh_named "ptr";
+      iargs = [];
+      oarg_bt = History.value_bt;
+      clauses = None
+    }
+end

--- a/backend/cn/lib/check.ml
+++ b/backend/cn/lib/check.ml
@@ -1451,7 +1451,12 @@ let rec check_expr labels (e : BT.t mu_expr) (k : IT.t -> unit m) : unit m =
                 ( P { name = Owned (act.ct, Uninit); pointer = ret; iargs = [] },
                   O (default_ (Memory.bt_of_sct act.ct) loc) )
             in
-            let@ () = add_r loc (P (Global.mk_alloc ret), O (IT.unit_ loc)) in
+            (* FIXME add a constraint to the history and point the output argument to that *)
+            let@ () =
+              add_r
+                loc
+                (P (Alloc.Predicate.make ret), O (IT.default_ Alloc.History.value_bt loc))
+            in
             let@ () = record_action (Create ret, loc) in
             k ret)
         | M_CreateReadOnly (_sym1, _ct, _sym2, _prefix) ->
@@ -1470,7 +1475,10 @@ let rec check_expr labels (e : BT.t mu_expr) (k : IT.t -> unit m) : unit m =
                 ({ name = Owned (ct, Uninit); pointer = arg; iargs = [] }, None)
             in
             let@ _ =
-              RI.Special.predicate_request loc (Access Kill) (Global.mk_alloc arg, None)
+              RI.Special.predicate_request
+                loc
+                (Access Kill)
+                (Alloc.Predicate.make arg, None)
             in
             let@ () = record_action (Kill arg, loc) in
             k (unit_ loc))

--- a/backend/cn/lib/compile.ml
+++ b/backend/cn/lib/compile.ml
@@ -47,9 +47,10 @@ type env =
   }
 
 let init_env tagDefs fetch_enum_expr fetch_typedef =
+  let alloc_sig = { pred_iargs = []; pred_output = Alloc.Predicate.def.oarg_bt } in
   { computationals = SymMap.empty;
-    logicals = SymMap.empty;
-    predicates = SymMap.empty;
+    logicals = SymMap.(empty |> add Alloc.History.sym Alloc.History.sbt);
+    predicates = SymMap.(empty |> add Alloc.Predicate.sym alloc_sig);
     functions = SymMap.empty;
     datatypes = SymMap.empty;
     datatype_constrs = SymMap.empty;
@@ -61,7 +62,8 @@ let init_env tagDefs fetch_enum_expr fetch_typedef =
 
 let pointer_eq_warned = ref false
 
-(* TODO: ugly hack to get started *)
+(* FIXME: this is an ugly hack used by Core_to_mucore.collect_instrumentation
+ * which in turn is used by Executable_spec.main and TestGeneration.run *)
 module SymTable = Hashtbl.Make (Sym)
 
 let symtable = SymTable.create 10000
@@ -1272,8 +1274,8 @@ let allocation_token loc addr_s =
     | SD_ObjectAddress obj_name -> Sym.fresh_make_uniq ("A_" ^ obj_name)
     | _ -> assert false
   in
-  let alloc_ret = Global.mk_alloc (IT.sym_ (addr_s, BT.Loc, loc)) in
-  ((name, (ResourceTypes.P alloc_ret, BT.Unit)), (loc, None))
+  let alloc_ret = Alloc.Predicate.make (IT.sym_ (addr_s, BT.Loc, loc)) in
+  ((name, (ResourceTypes.P alloc_ret, Alloc.History.value_bt)), (loc, None))
 
 
 module LocalState = struct

--- a/backend/cn/lib/context.ml
+++ b/backend/cn/lib/context.ml
@@ -46,13 +46,11 @@ type t =
   }
 
 let empty =
-  let alloc_id = Sym.fresh_named "__cn_alloc_history" in
-  let loc_str = __FILE__ ^ ":" ^ string_of_int __LINE__ in
-  let l_info = (Locations.other loc_str, lazy (Pp.string loc_str)) in
-  let bt =
-    BT.Map (Alloc_id, Record [ (Id.id "base", Integer); (Id.id "len", Integer) ])
+  let logical =
+    let loc_str = __FILE__ ^ ":" ^ string_of_int __LINE__ in
+    let l_info = (Locations.other loc_str, lazy (Pp.string loc_str)) in
+    SymMap.(empty |> add Alloc.History.sym (BaseType Alloc.History.bt, l_info))
   in
-  let logical = SymMap.(empty |> add alloc_id (BaseType bt, l_info)) in
   { computational = SymMap.empty;
     logical;
     resources = ([], 0);

--- a/backend/cn/lib/core_to_mucore.ml
+++ b/backend/cn/lib/core_to_mucore.ml
@@ -1427,7 +1427,8 @@ let normalise_globs ~inherit_loc env _sym g =
         ~inherit_loc
         loc
         ( (env, C.LocalState.init_st.old_states),
-          (Pmap.empty Int.compare, CF.Cn_desugaring.initial_cn_desugaring_state []) )
+          ( Pmap.empty Int.compare,
+            CF.Cn_desugaring.(initial_cn_desugaring_state empty_init) ) )
         ([], Pmap.empty Int.compare)
         e
     in

--- a/backend/cn/lib/explain.ml
+++ b/backend/cn/lib/explain.ml
@@ -244,7 +244,7 @@ let state ctxt model_with_q extras =
       List.partition
         (fun (ret, _o) ->
           match ret with
-          | P ret when equal_predicate_name ret.name ResourceTypes.alloc_name -> false
+          | P ret when equal_predicate_name ret.name Alloc.Predicate.pred_name -> false
           | _ -> true)
         diff_res
     in

--- a/backend/cn/lib/global.ml
+++ b/backend/cn/lib/global.ml
@@ -16,29 +16,13 @@ type t =
     lemmata : (Locations.t * AT.lemmat) SymMap.t
   }
 
-let mk_alloc : IndexTerms.t -> ResourceTypes.predicate_type =
-  fun pointer -> { name = ResourceTypes.alloc_name; pointer; iargs = [] }
-
-
 let empty =
-  let[@ocaml.warning "-8"] { name = PName alloc; _ } : ResourceTypes.predicate_type =
-    mk_alloc (IndexTerms.null_ @@ Cerb_location.other __FUNCTION__)
-  in
-  let def : ResourcePredicates.definition =
-    { loc = Locations.other (__FILE__ ^ ":" ^ string_of_int __LINE__);
-      pointer = Sym.fresh_named "__cn_alloc_ptr";
-      iargs = [];
-      oarg_bt = Unit;
-      clauses = None
-    }
-  in
-  let resource_predicates = SymMap.(empty |> add alloc def) in
   { struct_decls = SymMap.empty;
     datatypes = SymMap.empty;
     datatype_constrs = SymMap.empty;
     datatype_order = None;
     fun_decls = SymMap.empty;
-    resource_predicates;
+    resource_predicates = SymMap.(empty |> add Alloc.Predicate.sym Alloc.Predicate.def);
     logical_functions = SymMap.empty;
     lemmata = SymMap.empty
   }

--- a/backend/cn/lib/resourceTypes.ml
+++ b/backend/cn/lib/resourceTypes.ml
@@ -25,8 +25,6 @@ let pp_predicate_name = function
   | PName pn -> Sym.pp pn
 
 
-let alloc_name : predicate_name = PName (Sym.fresh_named "__CN_Alloc")
-
 type predicate_type =
   { name : predicate_name;
     pointer : IT.t; (* I *)

--- a/backend/cn/lib/typeErrors.ml
+++ b/backend/cn/lib/typeErrors.ml
@@ -376,7 +376,7 @@ let pp_message te =
     in
     { short; descr = Some descr; state = None }
   | Mismatch { has; expect } ->
-    let short = !^"Type error" in
+    let short = !^"Mismatched types." in
     let descr =
       !^"Expected value of type"
       ^^^ squotes expect
@@ -400,7 +400,7 @@ let pp_message te =
     { short; descr = Some descr; state = None }
   | NIA { it; hint } ->
     let it = IT.pp it in
-    let short = !^"Type error" in
+    let short = !^"Non-linear integer arithmetic." in
     let descr =
       !^"Illtyped expression"
       ^^^ squotes it
@@ -413,7 +413,7 @@ let pp_message te =
     { short; descr = Some descr; state = None }
   | TooBigExponent { it } ->
     let it = IT.pp it in
-    let short = !^"Type error" in
+    let short = !^"Exponent too big" in
     let descr =
       !^"Illtyped expression"
       ^^^ squotes it
@@ -426,7 +426,7 @@ let pp_message te =
     { short; descr = Some descr; state = None }
   | NegativeExponent { it } ->
     let it = IT.pp it in
-    let short = !^"Type error" in
+    let short = !^"Negative exponent" in
     let descr =
       !^"Illtyped expression"
       ^^ squotes it

--- a/backend/cn/lib/wellTyped.ml
+++ b/backend/cn/lib/wellTyped.ml
@@ -1075,6 +1075,7 @@ let oarg_bt loc = function
 
 module WRS = struct
   let welltyped loc (resource, bt) =
+    Pp.(debug 6 (lazy !^__FUNCTION__));
     let@ resource = WRET.welltyped loc resource in
     let@ bt = WBT.is_bt loc bt in
     let@ oarg_bt = oarg_bt loc resource in
@@ -1141,6 +1142,7 @@ module WRT = struct
   let pp = ReturnTypes.pp
 
   let welltyped loc rt =
+    Pp.(debug 6 (lazy !^__FUNCTION__));
     pure
       (match rt with
        | RT.Computational ((name, bt), info, lrt) ->
@@ -1241,6 +1243,7 @@ module WLArgs = struct
     =
     let rec aux =
       let here = Locations.other __FUNCTION__ in
+      Pp.(debug 6 (lazy !^__FUNCTION__));
       function
       | Mu.M_Define ((s, it), ((loc, _) as info), at) ->
         (* no need to alpha-rename, because context.ml ensures there's no name clashes *)
@@ -1288,6 +1291,7 @@ module WArgs = struct
     (Loc.t -> 'i -> 'j m) -> string -> Loc.t -> 'i Mu.mu_arguments -> 'j Mu.mu_arguments m
     =
     fun (i_welltyped : Loc.t -> 'i -> 'j m) kind loc (at : 'i Mu.mu_arguments) ->
+    Pp.(debug 6 (lazy !^__FUNCTION__));
     let rec aux = function
       | Mu.M_Computational ((name, bt), info, at) ->
         (* no need to alpha-rename, because context.ml ensures there's no name clashes *)
@@ -2096,91 +2100,6 @@ module BaseTyping = struct
        | _ -> ());
       let@ () = ensure_base_type (loc_of_expr expr) ~expect (bt_of_expr expr) in
       return expr
-
-  (* let infer_glob = function *)
-  (*   | M_GlobalDef (ct, expr) -> *)
-  (*     let@ expr = check_expr ((Memory.bt_of_sct ct)) expr in *)
-  (*     return (M_GlobalDef (ct, expr)) *)
-  (*   | M_GlobalDecl ct -> *)
-  (*     return (M_GlobalDecl ct) *)
-
-  (* let infer_globs gs = ListM.mapM (fun (nm, glob) -> *)
-  (*     let@ glob = infer_glob glob in *)
-  (*     return (nm, glob) *)
-  (*   ) gs *)
-
-  (* let rec infer_mu_args_l (f : 'i -> 'j m) (x : 'i mu_arguments_l) = *)
-  (*   match x with *)
-  (*   | M_Define ((nm, rhs), info, args) -> *)
-  (*     pure begin *)
-  (*     let@ () = add_l nm (IT.bt rhs) (fst info, lazy (Pp.string "defined-var")) in *)
-  (*     let@ args = infer_mu_args_l f args in *)
-  (*     return (M_Define ((nm, rhs), info, args)) *)
-  (*     end *)
-  (*   | M_Resource ((nm, (ret, bt)), info, args) -> *)
-  (*     pure begin *)
-  (*     let@ () = add_l nm bt (fst info, lazy (Pp.string "resource-var")) in *)
-  (*     let@ args = infer_mu_args_l f args in *)
-  (*     return (M_Resource ((nm, (ret, bt)), info, args)) *)
-  (*     end *)
-  (*   | M_Constraint (lc, info, args) -> *)
-  (*     let@ args = infer_mu_args_l f args in *)
-  (*     return (M_Constraint (lc, info, args)) *)
-  (*   | M_I y -> *)
-  (*     let@ y = f y in *)
-  (*     return (M_I y) *)
-
-  (* let rec infer_mu_args (f : 'i -> 'j m) (x : 'i mu_arguments) = *)
-  (*   match x with *)
-  (*   | M_Computational ((nm, bt), info, args) -> *)
-  (*     pure begin *)
-  (*     let@ () = add_l nm bt (fst info, lazy (Pp.string "argument")) in *)
-  (*     let@ args = infer_mu_args f args in *)
-  (*     return (M_Computational ((nm, bt), info, args)) *)
-  (*     end *)
-  (*   | M_L args_l -> *)
-  (*     let@ args_l = infer_mu_args_l f args_l in *)
-  (*     return (M_L args_l) *)
-
-  (* let infer_label_def = function *)
-  (*   | M_Return loc -> return (M_Return loc) *)
-  (*   | M_Label (loc, args, annots, spec) -> *)
-  (*     let@ args = infer_mu_args infer_expr args in *)
-  (*     return (M_Label (loc, args, annots, spec)) *)
-
-  (* let infer_fun_map_decl = function *)
-  (*   | M_Proc (loc, args_and_body, trusted, spec) -> *)
-  (*     let f (expr, label_defs, rt) = *)
-  (*       let@ expr = infer_expr expr in *)
-  (*       let@ label_defs = PmapM.mapM (fun sym label_def -> infer_label_def label_def) *)
-  (*           label_defs Sym.compare in *)
-  (*       return (expr, label_defs, rt) *)
-  (*     in *)
-  (*     let@ args_and_body = infer_mu_args f args_and_body in *)
-  (*     return (M_Proc (loc, args_and_body, trusted, spec)) *)
-  (*   | M_ProcDecl (loc, spec_opt) -> *)
-  (*     return (M_ProcDecl (loc, spec_opt)) *)
-
-  (* let infer_funs funs = PmapM.mapM (fun sym decl -> infer_fun_map_decl decl) funs
-     Sym.compare *)
-
-  (* let infer_types_file : 'bt. 'bt mu_file -> BT.t mu_file m = *)
-  (*   fun file -> *)
-  (*   let@ globs = infer_globs file.mu_globs in *)
-  (*   let@ funs = infer_funs file.mu_funs in *)
-  (*   return { *)
-  (*     mu_main = file.mu_main; *)
-  (*     mu_tagDefs = file.mu_tagDefs; *)
-  (*     mu_globs = globs; *)
-  (*     mu_funs = funs; *)
-  (*     mu_extern = file.mu_extern; *)
-  (*     mu_stdlib_syms = file.mu_stdlib_syms; *)
-  (*     mu_resource_predicates = file.mu_resource_predicates; *)
-  (*     mu_logical_predicates = file.mu_logical_predicates; *)
-  (*     mu_datatypes = file.mu_datatypes; *)
-  (*     mu_lemmata = file.mu_lemmata; *)
-  (*     mu_call_funinfo = file.mu_call_funinfo; *)
-  (*   } *)
 end
 
 module WLabel = struct
@@ -2221,6 +2140,7 @@ module WProc = struct
     _ (*BT.t*) Mu.mu_proc_args_and_body m
     =
     fun (loc : Loc.t) (at : 'TY1 Mu.mu_proc_args_and_body) ->
+    Pp.(debug 6 (lazy !^__FUNCTION__));
     WArgs.welltyped
       (fun loc (body, labels, rt) ->
         let@ rt = pure (WRT.welltyped loc rt) in

--- a/backend/common/pipeline.ml
+++ b/backend/common/pipeline.ml
@@ -166,7 +166,7 @@ let cpp (conf, io) ~filename =
         return @@ String.concat "\n" out
   end ()
 
-let c_frontend ?(cnnames=[]) (conf, io) (core_stdlib, core_impl) ~filename =
+let c_frontend ?(cn_init_scope=Cn_desugaring.empty_init) (conf, io) (core_stdlib, core_impl) ~filename =
   Cerb_fresh.set_digest filename;
   let parse filename file_content =
     C_parser_driver.parse_from_string ~filename file_content >>= fun cabs_tunit ->
@@ -188,7 +188,7 @@ let c_frontend ?(cnnames=[]) (conf, io) (core_stdlib, core_impl) ~filename =
     ret in
   let desugar cabs_tunit =
     let (ailnames, core_stdlib_fun_map) = core_stdlib in
-    Cabs_to_ail.desugar (ailnames, core_stdlib_fun_map, core_impl) cnnames
+    Cabs_to_ail.desugar (ailnames, core_stdlib_fun_map, core_impl) cn_init_scope
       "main" cabs_tunit >>= fun (markers_env, ail_prog) ->
           io.set_progress "DESUG"
       >|> io.pass_message "Cabs -> Ail completed!"
@@ -234,8 +234,8 @@ let c_frontend ?(cnnames=[]) (conf, io) (core_stdlib, core_impl) ~filename =
   ail_typechecking ail_prog   >>= fun ailtau_prog             ->
   return (cabs_tunit, (markers_env, ailtau_prog))
 
-let c_frontend_and_elaboration ?(cnnames=[]) (conf, io) (core_stdlib, core_impl) ~filename =
-  c_frontend ~cnnames (conf, io) (core_stdlib, core_impl) ~filename >>= fun (cabs_tunit, (markers_env, ailtau_prog)) ->
+let c_frontend_and_elaboration ?(cn_init_scope=Cn_desugaring.empty_init) (conf, io) (core_stdlib, core_impl) ~filename =
+  c_frontend ~cn_init_scope (conf, io) (core_stdlib, core_impl) ~filename >>= fun (cabs_tunit, (markers_env, ailtau_prog)) ->
   (* NOTE: the elaboration sets the struct/union tag definitions, so to allow the frontend to be
      used more than once, we need to do reset here *)
   (* TODO(someday): find a better way *)

--- a/backend/common/pipeline.mli
+++ b/backend/common/pipeline.mli
@@ -45,7 +45,7 @@ val load_core_impl:
 val cpp: (configuration * io_helpers) -> filename:string -> (string, Cerb_location.t * Errors.cause) Exception.exceptM
 
 val c_frontend:
-  ?cnnames: (string * Symbol.sym) list ->
+  ?cn_init_scope: Cn_desugaring.init_scope ->
   (configuration * io_helpers) ->
   (((string, Symbol.sym) Pmap.map * (unit, unit) Core.generic_fun_map) * unit Core.generic_impl) ->
   filename:string ->
@@ -54,7 +54,7 @@ val c_frontend:
   , Cerb_location.t * Errors.cause) Exception.exceptM
 
 val c_frontend_and_elaboration:
-  ?cnnames: (string * Symbol.sym) list ->
+  ?cn_init_scope: Cn_desugaring.init_scope ->
   (configuration * io_helpers) ->
   (((string, Symbol.sym) Pmap.map * (unit, unit) Core.generic_fun_map) * unit Core.generic_impl) ->
   filename:string ->

--- a/frontend/model/cabs_to_ail.lem
+++ b/frontend/model/cabs_to_ail.lem
@@ -4896,7 +4896,7 @@ let register_additional_cn_var id = E.register_cn_ident CN_vars id
 
 
 import Core
-val desugar: (map string Symbol.sym) * Core.fun_map unit * Core.impl -> list (string * Symbol.sym) -> string -> translation_unit ->
+val desugar: (map string Symbol.sym) * Core.fun_map unit * Core.impl -> Cn_desugaring.init_scope -> string -> translation_unit ->
   Exception.exceptM (E.fin_markers_env * ail_program unit) Errors.error
 let desugar core_eval_stuff cn_eval_stuff startup_str (TUnit edecls) =
 (*

--- a/frontend/model/cabs_to_ail_effect.lem
+++ b/frontend/model/cabs_to_ail_effect.lem
@@ -543,7 +543,7 @@ let empty_switch_info =
 
 
 (* ========================================================================== *)
-val initial_state: (map string Symbol.sym) * Core.fun_map unit * Core.impl -> list (string * Symbol.sym) -> state_with_markers
+val initial_state: (map string Symbol.sym) * Core.fun_map unit * Core.impl -> Cn_desugaring.init_scope -> state_with_markers
 let initial_state core_eval_stuff cn_eval_stuff = <|
   inner= <|
     aux_supply=      0;
@@ -610,7 +610,7 @@ let fin_markers_env () =
   State_exception.return (id, st.markers_env)
 
 
-val eval: forall 'a. (map string Symbol.sym) * Core.fun_map unit * Core.impl -> list (string * Symbol.sym) -> desugM 'a -> Exception.exceptM (fin_markers_env * 'a) Errors.error
+val eval: forall 'a. (map string Symbol.sym) * Core.fun_map unit * Core.impl -> Cn_desugaring.init_scope -> desugM 'a -> Exception.exceptM (fin_markers_env * 'a) Errors.error
 let cabs_to_ail_effect_eval core_eval_stuff cn_eval_stuff m =
   State_exception.eval begin
     m >>= fun res ->

--- a/frontend/model/cn_desugaring.lem
+++ b/frontend/model/cn_desugaring.lem
@@ -1,6 +1,6 @@
 (* Cabs to Ail desugaring auxiliary functions (included in Cabs_to_ail_effect) *)
 open import Pervasives
-import Symbol Loc Ctype State_exception Errors Map_extra String_extra
+import Symbol Loc Ctype State_exception Errors Map_extra Maybe String_extra
 
 open import Cn
 
@@ -17,14 +17,33 @@ type cn_desugaring_state = <|
   cn_type_synonyms: map Symbol.identifier (cn_base_type Symbol.sym);
 |>
 
-let initial_cn_desugaring_state cn_initial_function_identifiers = 
-  let cn_idents = 
-    List.foldl (fun acc (str, sym) ->
-        let entry = (CN_function, Symbol.Identifier Loc.unknown str) in
-        if Map.member entry acc 
+type init_scope = <|
+  functions: list (string * Symbol.sym * maybe Loc.t);
+  predicates: list (string * Symbol.sym * maybe Loc.t);
+  idents: list (string * Symbol.sym * maybe Loc.t);
+|>
+
+let empty_init = <|
+  functions = [];
+  predicates = [];
+  idents = [];
+|>
+
+let initial_cn_desugaring_state cn_desugaring_init =
+  let add (type_, names) acc =
+    List.foldl (fun acc (str, sym, loc) ->
+        let loc = match loc with | Just loc -> loc | Nothing -> Loc.unknown end in
+        let entry = (type_, Symbol.Identifier loc str) in
+        if Map.member entry acc
         then Assert_extra.failwith (str ^ " already registered as CN function name")
         else Map.insert entry sym acc
-      ) Map.empty cn_initial_function_identifiers
+      ) acc names
+  in
+  let cn_idents =
+    add (CN_function, cn_desugaring_init.functions)
+      (add (CN_predicate, cn_desugaring_init.predicates)
+        (add (CN_vars, cn_desugaring_init.idents)
+          Map.empty))
   in
 <|
   cn_idents= cn_idents;

--- a/tests/cn/alloc_token.c
+++ b/tests/cn/alloc_token.c
@@ -1,0 +1,43 @@
+#ifndef CN_UTILS
+void *cn_malloc(unsigned long long);
+void cn_free_sized(void*, unsigned long long);
+#endif
+
+void free_int(int *p)
+/*@
+trusted;
+requires
+    take log = Alloc(p);
+    allocs[(alloc_id)p] == log;
+    let base = array_shift<char>(p, -2i64);
+    log.base == (u64) base;
+    log.size == sizeof<int>;
+    take i = Block<int>(base);
+ensures
+    true;
+@*/
+{
+    cn_free_sized(p, sizeof(int));
+}
+
+int *malloc_int()
+/*@
+trusted;
+ensures
+    take log = Alloc(return);
+    allocs[(alloc_id)return] == log;
+    log.base == (u64) return;
+    log.size == sizeof<int>;
+    take i = Block<int>(return);
+@*/
+{
+    return cn_malloc(sizeof(int));
+}
+
+int main()
+/*@ trusted; @*/
+{
+    int *p = malloc_int();
+    *p = 4;
+    free_int(p);
+}

--- a/tests/run-cn-exec.sh
+++ b/tests/run-cn-exec.sh
@@ -90,6 +90,7 @@ SUCCESS=$(find cn -name '*.c' \
     ! -name "ptr_diff2.c" \
     ! -name "has_alloc_id_ptr_neq.c" \
     ! -name "spec_null_shift.c" \
+    ! -name "alloc_token.c" \
 )
 
 # Include files which cause error for proof but not testing
@@ -144,6 +145,7 @@ BUGGY="cn/division_casting.c \
        cn/ptr_diff2.c \
        cn/has_alloc_id_ptr_neq.c \
        cn/spec_null_shift.c \
+       cn/alloc_token.c \
        "
 
 # Exclude files which cause error for proof but not testing


### PR DESCRIPTION
This commit generalises CN names to work with variables and predicates, not just functions. It also exposes the `Alloc` allocation token/predicate and the `allocs` variable in the user-facing specs to (a) prepare for upcoming VIP related features and (b) test the implementation of first sentence.