### PR TITLE
CN VIP: Add allocation history constraints to Create

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
       run: |
         opam switch ${{ matrix.version }}
         eval $(opam env --switch=${{ matrix.version }})
-        cd tests; USE_OPAM='' ./run-cn.sh
+        cd tests; USE_OPAM='' ./run-cn.sh -v
 
     - name: Run CN Tutorial CI tests
       run: |

--- a/backend/cn/lib/alloc.ml
+++ b/backend/cn/lib/alloc.ml
@@ -5,12 +5,29 @@ module History = struct
 
   let loc = Locations.other __MODULE__
 
-  let value_bt =
-    BaseTypes.Record
-      [ (Id.id "base", Memory.uintptr_bt); (Id.id "size", Memory.uintptr_bt) ]
+  let base_id = Id.id "base"
+
+  let base_bt = Memory.uintptr_bt
+
+  let size_id = Id.id "size"
+
+  let size_bt = Memory.uintptr_bt
+
+  let value_bt = BaseTypes.Record [ (base_id, base_bt); (size_id, size_bt) ]
+
+  let make_value ~base ~size loc' =
+    IndexTerms.(
+      record_ [ (base_id, base); (size_id, num_lit_ (Z.of_int size) size_bt loc') ] loc')
 
 
   let bt = BaseTypes.Map (Alloc_id, value_bt)
+
+  let it = IndexTerms.sym_ (sym, bt, loc)
+
+  let lookup_ptr ptr loc' =
+    assert (BaseTypes.(equal (IndexTerms.bt ptr) Loc));
+    IndexTerms.(map_get_ it (allocId_ ptr loc') loc')
+
 
   let sbt = SurfaceBaseTypes.of_basetype bt
 end

--- a/backend/cn/lib/alloc.mli
+++ b/backend/cn/lib/alloc.mli
@@ -1,0 +1,41 @@
+module History : sig
+  val str : string
+
+  val sym : Sym.t
+
+  val loc : Locations.t
+
+  val base_id : Id.t
+
+  val base_bt : BaseTypes.t
+
+  val size_id : Id.t
+
+  val size_bt : BaseTypes.t
+
+  val value_bt : BaseTypes.t
+
+  val make_value : base:IndexTerms.t -> size:int -> Locations.t -> IndexTerms.t
+
+  val bt : BaseTypes.t
+
+  val it : IndexTerms.t
+
+  val lookup_ptr : IndexTerms.t -> Locations.t -> IndexTerms.t
+
+  val sbt : SurfaceBaseTypes.t
+end
+
+module Predicate : sig
+  val str : string
+
+  val loc : Locations.t
+
+  val sym : Sym.t
+
+  val pred_name : ResourceTypes.predicate_name
+
+  val make : IndexTerms.t -> ResourceTypes.predicate_type
+
+  val def : ResourcePredicates.definition
+end

--- a/runtime/libcn/libexec/cn-runtime-single-file.sh
+++ b/runtime/libcn/libexec/cn-runtime-single-file.sh
@@ -10,8 +10,9 @@ function echo_and_err() {
 
 QUIET=""
 CHECK_OWNERSHIP=""
+VIP=""
 
-while getopts "hoq" flag; do
+while getopts "hovq" flag; do
  case "$flag" in
    h)
    printf "${USAGE}"
@@ -19,6 +20,9 @@ while getopts "hoq" flag; do
    ;;
    o)
    CHECK_OWNERSHIP="--with-ownership-checking"
+   ;;
+   v)
+   VIP="--vip"
    ;;
    q)
    QUIET=1
@@ -54,7 +58,7 @@ EXEC_DIR=$(mktemp -d -t 'cn-exec.XXXX')
 # INPUT_FN="${EXEC_DIR}/${INPUT_BASENAME}.pp.c"
 
 # Instrument code with CN
-if cn verify "${INPUT_FN}" \
+if cn verify "${VIP}" "${INPUT_FN}" \
     --output-decorated="${INPUT_BASENAME}-exec.c" \
     --output-decorated-dir="${EXEC_DIR}" \
     ${CHECK_OWNERSHIP}; then

--- a/tests/cn/alloc_create.c
+++ b/tests/cn/alloc_create.c
@@ -1,0 +1,17 @@
+/*@
+lemma check_alloc(pointer p)
+requires
+    let log = allocs[(alloc_id)p];
+    log.base == (u64)p;
+    log.size == sizeof<int>;
+ensures
+    true;
+@*/
+
+int main()
+{
+    int x = 0;
+    /*@ apply check_alloc(&x); @*/
+    int y = 1;
+    /*@ apply check_alloc(&y); @*/
+}

--- a/tests/cn/simplify_array_shift.c
+++ b/tests/cn/simplify_array_shift.c
@@ -14,7 +14,12 @@ struct int_queueCell {
   int first;
   struct int_queueCell* next;
 };
+
 /*@
+function (boolean) eq_testable(pointer x, pointer y) {
+    ptr_eq(x,y) || !addr_eq(x,y)
+}
+
 predicate (void) Test(pointer f, pointer b) {
   if (ptr_eq(f,b)) {
     take F = Owned<struct int_queueCell>(b);
@@ -38,6 +43,7 @@ void IntQueue_pop (struct int_queue *q)
 requires
     take Q = Owned<struct int_queue>(q);
     !is_null(Q.front) && !is_null(Q.back);
+    eq_testable(Q.front, Q.back);
     take B = Test(Q.front, Q.back);
 ensures
     take Q2 = Block<struct int_queue>(q);

--- a/tests/run-cn-exec.sh
+++ b/tests/run-cn-exec.sh
@@ -17,7 +17,7 @@ CHECK_SCRIPT="${RUNTIME_PREFIX}/libexec/cn-runtime-single-file.sh"
 
 [ -f "${CHECK_SCRIPT}" ] || echo_and_err "Could not find single file helper script: ${CHECK_SCRIPT}"
 
-SCRIPT_OPT="-oq"
+SCRIPT_OPT="-ovq"
 
 function exits_with_code() {
   local file=$1

--- a/tests/run-cn.sh
+++ b/tests/run-cn.sh
@@ -14,8 +14,9 @@ function echo_and_err() {
 }
 
 LEMMATA=0
+VIP=""
 
-while getopts "hl" flag; do
+while getopts "hlv" flag; do
  case "$flag" in
    h)
    printf "%s\n" "${USAGE}"
@@ -23,6 +24,9 @@ while getopts "hl" flag; do
    ;;
    l)
    LEMMATA=1
+   ;;
+   v)
+   VIP="--vip"
    ;;
    \?)
    echo_and_err "${USAGE}"
@@ -58,13 +62,13 @@ FAIL=$(find "${DIRNAME}"/cn -name '*.error.c')
 FAILED=""
 
 for TEST in ${SUCC}; do
-  if ! exits_with_code "cn verify" "${TEST}" 0; then
+  if ! exits_with_code "cn verify ${VIP}" "${TEST}" 0; then
     FAILED+=" ${TEST}"
   fi
 done
 
 for TEST in ${FAIL}; do
-  if ! exits_with_code "cn verify" "${TEST}" "(1 2)"; then
+  if ! exits_with_code "cn verify ${VIP}" "${TEST}" "(1 2)"; then
     FAILED+=" ${TEST}"
   fi
 done


### PR DESCRIPTION
This commit enables (under the `--vip` flag) the Create memory action in CN adding a constraint to the `allocs` allocation history variable to map the newly allocated pointer's allocation ID to the appropriate base and length.

This change is underneath a flag because it is not backwards compatiable in the presence of more than one create (of a different adress or size) because in the solver, all allocation IDs are mapped to unit, meaning adding the second constraint makes the context inconsistent and terminates type checking early.

As a result, the test suite is now run with the `--vip` flag enabled (so that new features can be tested).  Note that the tutorial remains running without the `--vip` flags (and should not yet be using any of the new featuers), and so any backwards compatibility issues will be caught there.