### PR TITLE
[CN-exec] Add `instrument` subcommand

### DIFF
--- a/backend/cn/bin/main.ml
+++ b/backend/cn/bin/main.ml
@@ -346,8 +346,7 @@ let verify
       Typing.run_from_pause check paused)
 
 
-let generate_executable_specs 
-  (* Common *)
+let generate_executable_specs
   filename
   macros
   incl_dirs
@@ -372,12 +371,12 @@ let generate_executable_specs
   no_inherit_loc
   magic_comment_char_dollar
   (* Executable spec *)
-  output_decorated
+    output_decorated
   output_decorated_dir
   with_ownership_checking
   with_test_gen
   copy_source_dir
-  = 
+  =
   if json then (
     if debug_level > 0 then
       CF.Pp_errors.fatal "debug level must be 0 for json output";
@@ -906,7 +905,8 @@ let runtime_testing_cmd =
     $ Executable_spec_flags.copy_source_dir
   in
   let doc =
-    "Instruments [FILE] with runtime C assertions that check the properties provided in CN specifications.\n"
+    "Instruments [FILE] with runtime C assertions that check the properties provided in \
+     CN specifications.\n"
   in
   let info = Cmd.info "runtime-test" ~doc in
   Cmd.v info runtime_testing_t

--- a/backend/cn/bin/main.ml
+++ b/backend/cn/bin/main.ml
@@ -868,9 +868,9 @@ let generate_tests_cmd =
   Cmd.v info generate_tests_t
 
 
-let runtime_test_cmd =
+let instrument_cmd =
   let open Term in
-  let runtime_test_t =
+  let instrument_t =
     const generate_executable_specs
     $ Common_flags.file
     $ Common_flags.macros
@@ -905,11 +905,11 @@ let runtime_test_cmd =
     "Instruments [FILE] with runtime C assertions that check the properties provided in \
      CN specifications.\n"
   in
-  let info = Cmd.info "runtime-test" ~doc in
-  Cmd.v info runtime_test_t
+  let info = Cmd.info "instrument" ~doc in
+  Cmd.v info instrument_t
 
 
-let subcommands = [ wf_cmd; verify_cmd; generate_tests_cmd; runtime_test_cmd ]
+let subcommands = [ wf_cmd; verify_cmd; generate_tests_cmd; instrument_cmd ]
 
 let () =
   let version_str = Cn_version.git_version ^ " [" ^ Cn_version.git_version_date ^ "]" in

--- a/backend/cn/bin/main.ml
+++ b/backend/cn/bin/main.ml
@@ -868,9 +868,9 @@ let generate_tests_cmd =
   Cmd.v info generate_tests_t
 
 
-let runtime_testing_cmd =
+let runtime_test_cmd =
   let open Term in
-  let runtime_testing_t =
+  let runtime_test_t =
     const generate_executable_specs
     $ Common_flags.file
     $ Common_flags.macros
@@ -906,10 +906,10 @@ let runtime_testing_cmd =
      CN specifications.\n"
   in
   let info = Cmd.info "runtime-test" ~doc in
-  Cmd.v info runtime_testing_t
+  Cmd.v info runtime_test_t
 
 
-let subcommands = [ wf_cmd; verify_cmd; generate_tests_cmd; runtime_testing_cmd ]
+let subcommands = [ wf_cmd; verify_cmd; generate_tests_cmd; runtime_test_cmd ]
 
 let () =
   let version_str = Cn_version.git_version ^ " [" ^ Cn_version.git_version_date ^ "]" in

--- a/backend/cn/bin/main.ml
+++ b/backend/cn/bin/main.ml
@@ -283,7 +283,6 @@ let verify
   solver_flags
   solver_path
   solver_type
-  output_decorated
   astprints
   use_vip
   no_use_ity
@@ -319,7 +318,6 @@ let verify
   Check.fail_fast := fail_fast;
   Diagnostics.diag_string := diag;
   WellTyped.use_ity := not no_use_ity;
-  Sym.executable_spec_enabled := Option.is_some output_decorated;
   with_well_formedness_check (* CLI arguments *)
     ~filename
     ~macros
@@ -393,7 +391,7 @@ let generate_executable_specs
   Check.fail_fast := fail_fast;
   Diagnostics.diag_string := diag;
   WellTyped.use_ity := not no_use_ity;
-  Sym.executable_spec_enabled := Option.is_some output_decorated;
+  Sym.executable_spec_enabled := true;
   with_well_formedness_check (* CLI arguments *)
     ~filename
     ~macros
@@ -801,7 +799,6 @@ let verify_t : unit Term.t =
   $ Verify_flags.solver_flags
   $ Verify_flags.solver_path
   $ Verify_flags.solver_type
-  $ Executable_spec_flags.output_decorated
   $ Common_flags.astprints
   $ Verify_flags.use_vip
   $ Common_flags.no_use_ity

--- a/backend/cn/bin/main.ml
+++ b/backend/cn/bin/main.ml
@@ -818,8 +818,58 @@ let generate_tests_cmd =
   let info = Cmd.info "generate-tests" ~doc in
   Cmd.v info generate_tests_t
 
+let generate_executable_specs 
+(* Common *)
+_filename
+_macros
+_incl_dirs
+_incl_files
+_debug_level
+_print_level
+_csv_times
+_log_times
+_astprints
+_use_peval
+_no_inherit_loc
+_magic_comment_char_dollar
+(* Executable spec *)
+_output_decorated
+_output_decorated_dir
+_with_ownership_checking
+_with_test_gen
+_copy_source_dir
+= ()
 
-let subcommands = [ wf_cmd; verify_cmd; generate_tests_cmd ]
+let runtime_testing_cmd =
+  let open Term in
+  let runtime_testing_t =
+    const generate_executable_specs
+    $ Common_flags.file
+    $ Common_flags.macros
+    $ Common_flags.incl_dirs
+    $ Common_flags.incl_files
+    $ Common_flags.debug_level
+    $ Common_flags.print_level
+    $ Common_flags.csv_times
+    $ Common_flags.log_times
+    $ Common_flags.astprints
+    $ Common_flags.use_peval
+    $ Common_flags.no_inherit_loc
+    $ Common_flags.magic_comment_char_dollar
+    $ Executable_spec_flags.output_decorated
+    $ Executable_spec_flags.output_decorated_dir
+    $ Executable_spec_flags.with_ownership_checking
+    $ Executable_spec_flags.with_test_gen
+    $ Executable_spec_flags.copy_source_dir
+  in
+  let doc =
+    "Instruments [FILE] with runtime C assertions that check the properties provided in CN specifications.\n"
+  in
+  let info = Cmd.info "runtime-test" ~doc in
+  Cmd.v info runtime_testing_t
+
+
+let subcommands = [ wf_cmd; verify_cmd; generate_tests_cmd; runtime_testing_cmd ]
 
 let () =
   let version_str = Cn_version.git_version ^ " [" ^ Cn_version.git_version_date ^ "]" in

--- a/backend/cn/lib/executable_spec.ml
+++ b/backend/cn/lib/executable_spec.ml
@@ -207,11 +207,7 @@ let main
   let output_filename =
     match output_decorated with
     | None ->
-      let strs = String.split_on_char '/' filename in
-      let last_str = List.nth strs (List.length strs - 1) in
-      let last_str_basename_list = String.split_on_char '.' last_str in
-      let last_str_basename = List.nth last_str_basename_list 0 in
-      last_str_basename ^ "-exec.c"
+      Filename.remove_extension (Filename.basename filename) ^ "-exec.c"
     | Some output_filename' -> output_filename'
   in
   let prefix = match output_decorated_dir with Some dir_name -> dir_name | None -> "" in

--- a/backend/cn/lib/executable_spec.ml
+++ b/backend/cn/lib/executable_spec.ml
@@ -206,8 +206,7 @@ let main
   =
   let output_filename =
     match output_decorated with
-    | None ->
-      Filename.remove_extension (Filename.basename filename) ^ "-exec.c"
+    | None -> Filename.remove_extension (Filename.basename filename) ^ "-exec.c"
     | Some output_filename' -> output_filename'
   in
   let prefix = match output_decorated_dir with Some dir_name -> dir_name | None -> "" in

--- a/backend/cn/lib/executable_spec.ml
+++ b/backend/cn/lib/executable_spec.ml
@@ -204,15 +204,16 @@ let main
   prog5
   statement_locs
   =
-  let output_filename = match output_decorated with
-    | None -> 
-      let strs = String.split_on_char '/' filename in 
-      let last_str = List.nth strs (List.length strs - 1) in 
-      let last_str_basename_list = String.split_on_char '.' last_str in 
-      let last_str_basename = List.nth last_str_basename_list 0 in 
+  let output_filename =
+    match output_decorated with
+    | None ->
+      let strs = String.split_on_char '/' filename in
+      let last_str = List.nth strs (List.length strs - 1) in
+      let last_str_basename_list = String.split_on_char '.' last_str in
+      let last_str_basename = List.nth last_str_basename_list 0 in
       last_str_basename ^ "-exec.c"
-    | Some output_filename' -> output_filename' 
-  in 
+    | Some output_filename' -> output_filename'
+  in
   let prefix = match output_decorated_dir with Some dir_name -> dir_name | None -> "" in
   let oc = Stdlib.open_out (Filename.concat prefix output_filename) in
   let cn_oc = Stdlib.open_out (Filename.concat prefix "cn.c") in

--- a/backend/cn/lib/executable_spec.ml
+++ b/backend/cn/lib/executable_spec.ml
@@ -199,11 +199,20 @@ let main
   ?(copy_source_dir = false)
   filename
   ((_, sigm) as ail_prog)
+  output_decorated
   output_decorated_dir
-  output_filename
   prog5
   statement_locs
   =
+  let output_filename = match output_decorated with
+    | None -> 
+      let strs = String.split_on_char '/' filename in 
+      let last_str = List.nth strs (List.length strs - 1) in 
+      let last_str_basename_list = String.split_on_char '.' last_str in 
+      let last_str_basename = List.nth last_str_basename_list 0 in 
+      last_str_basename ^ "-exec.c"
+    | Some output_filename' -> output_filename' 
+  in 
   let prefix = match output_decorated_dir with Some dir_name -> dir_name | None -> "" in
   let oc = Stdlib.open_out (Filename.concat prefix output_filename) in
   let cn_oc = Stdlib.open_out (Filename.concat prefix "cn.c") in

--- a/backend/cn/lib/executable_spec.ml
+++ b/backend/cn/lib/executable_spec.ml
@@ -206,7 +206,7 @@ let main
   =
   let output_filename =
     match output_decorated with
-    | None -> Filename.remove_extension (Filename.basename filename) ^ "-exec.c"
+    | None -> Filename.(remove_extension (basename filename)) ^ "-exec.c"
     | Some output_filename' -> output_filename'
   in
   let prefix = match output_decorated_dir with Some dir_name -> dir_name | None -> "" in

--- a/runtime/libcn/libexec/cn-runtime-single-file.sh
+++ b/runtime/libcn/libexec/cn-runtime-single-file.sh
@@ -58,7 +58,7 @@ EXEC_DIR=$(mktemp -d -t 'cn-exec.XXXX')
 # INPUT_FN="${EXEC_DIR}/${INPUT_BASENAME}.pp.c"
 
 # Instrument code with CN
-if cn verify "${VIP}" "${INPUT_FN}" \
+if cn runtime-test "${VIP}" "${INPUT_FN}" \
     --output-decorated="${INPUT_BASENAME}-exec.c" \
     --output-decorated-dir="${EXEC_DIR}" \
     ${CHECK_OWNERSHIP}; then

--- a/runtime/libcn/libexec/cn-runtime-single-file.sh
+++ b/runtime/libcn/libexec/cn-runtime-single-file.sh
@@ -58,7 +58,7 @@ EXEC_DIR=$(mktemp -d -t 'cn-exec.XXXX')
 # INPUT_FN="${EXEC_DIR}/${INPUT_BASENAME}.pp.c"
 
 # Instrument code with CN
-if cn runtime-test "${VIP}" "${INPUT_FN}" \
+if cn instrument "${VIP}" "${INPUT_FN}" \
     --output-decorated="${INPUT_BASENAME}-exec.c" \
     --output-decorated-dir="${EXEC_DIR}" \
     ${CHECK_OWNERSHIP}; then

--- a/tests/run-cn-test-gen.sh
+++ b/tests/run-cn-test-gen.sh
@@ -24,7 +24,7 @@ for TEST in $FILES; do
   CLEANUP="rm -rf decorated/*"
 
   # Instrument file
-  $CN verify "$TEST" --output-decorated="$(basename "$TEST")" --output-decorated-dir=decorated/
+  $CN runtime-test "$TEST" --output-decorated="$(basename "$TEST")" --output-decorated-dir=decorated/
   RET=$?
   if [[ "$RET" != 0 ]]; then
     echo "$TEST -- Error during executable spec decoration"

--- a/tests/run-cn-test-gen.sh
+++ b/tests/run-cn-test-gen.sh
@@ -24,7 +24,7 @@ for TEST in $FILES; do
   CLEANUP="rm -rf decorated/*"
 
   # Instrument file
-  $CN runtime-test "$TEST" --output-decorated="$(basename "$TEST")" --output-decorated-dir=decorated/
+  $CN instrument "$TEST" --output-decorated="$(basename "$TEST")" --output-decorated-dir=decorated/
   RET=$?
   if [[ "$RET" != 0 ]]; then
     echo "$TEST -- Error during executable spec decoration"


### PR DESCRIPTION
Add `instrument` subcommand for CN executable spec generation. CN verification mode has been separated from executable spec mode in the following way:

* Providing values for any of the `Executable_spec_flags` no longer affects the `verify` subcommand in any way
* Calling `cn instrument <FILE>` without any of the `Executable_spec_flags` defined should now work, whereas before the `--output-decorated` flag needed to be set with some output filename for executable specs to be generated at all

Fixes https://github.com/rems-project/cerberus/issues/480
