### PR TITLE
CN VIP: Add support for ptr diff

### DIFF
--- a/backend/cn/lib/alloc.ml
+++ b/backend/cn/lib/alloc.ml
@@ -29,6 +29,12 @@ module History = struct
     IndexTerms.(map_get_ it (allocId_ ptr loc') loc')
 
 
+  let get_base_size ptr loc' =
+    IndexTerms.
+      ( recordMember_ ~member_bt:base_bt (ptr, base_id) loc',
+        recordMember_ ~member_bt:size_bt (ptr, size_id) loc' )
+
+
   let sbt = SurfaceBaseTypes.of_basetype bt
 end
 
@@ -38,18 +44,4 @@ module Predicate = struct
   let loc = Locations.other __MODULE__
 
   let sym = Sym.fresh_named str
-
-  let pred_name = ResourceTypes.PName sym
-
-  let make pointer : ResourceTypes.predicate_type =
-    { name = pred_name; pointer; iargs = [] }
-
-
-  let def : ResourcePredicates.definition =
-    { loc = Locations.other (__FILE__ ^ ":" ^ string_of_int __LINE__);
-      pointer = Sym.fresh_named "ptr";
-      iargs = [];
-      oarg_bt = History.value_bt;
-      clauses = None
-    }
 end

--- a/backend/cn/lib/alloc.mli
+++ b/backend/cn/lib/alloc.mli
@@ -23,6 +23,8 @@ module History : sig
 
   val lookup_ptr : IndexTerms.t -> Locations.t -> IndexTerms.t
 
+  val get_base_size : IndexTerms.t -> Cerb_location.t -> IndexTerms.t * IndexTerms.t
+
   val sbt : SurfaceBaseTypes.t
 end
 
@@ -32,10 +34,4 @@ module Predicate : sig
   val loc : Locations.t
 
   val sym : Sym.t
-
-  val pred_name : ResourceTypes.predicate_name
-
-  val make : IndexTerms.t -> ResourceTypes.predicate_type
-
-  val def : ResourcePredicates.definition
 end

--- a/backend/cn/lib/compile.ml
+++ b/backend/cn/lib/compile.ml
@@ -47,7 +47,7 @@ type env =
   }
 
 let init_env tagDefs fetch_enum_expr fetch_typedef =
-  let alloc_sig = { pred_iargs = []; pred_output = Alloc.Predicate.def.oarg_bt } in
+  let alloc_sig = { pred_iargs = []; pred_output = ResourcePredicates.alloc.oarg_bt } in
   { computationals = SymMap.empty;
     logicals = SymMap.(empty |> add Alloc.History.sym Alloc.History.sbt);
     predicates = SymMap.(empty |> add Alloc.Predicate.sym alloc_sig);
@@ -1274,7 +1274,7 @@ let allocation_token loc addr_s =
     | SD_ObjectAddress obj_name -> Sym.fresh_make_uniq ("A_" ^ obj_name)
     | _ -> assert false
   in
-  let alloc_ret = Alloc.Predicate.make (IT.sym_ (addr_s, BT.Loc, loc)) in
+  let alloc_ret = ResourceTypes.make_alloc (IT.sym_ (addr_s, BT.Loc, loc)) in
   ((name, (ResourceTypes.P alloc_ret, Alloc.History.value_bt)), (loc, None))
 
 

--- a/backend/cn/lib/explain.ml
+++ b/backend/cn/lib/explain.ml
@@ -244,7 +244,7 @@ let state ctxt model_with_q extras =
       List.partition
         (fun (ret, _o) ->
           match ret with
-          | P ret when equal_predicate_name ret.name Alloc.Predicate.pred_name -> false
+          | P ret when equal_predicate_name ret.name ResourceTypes.alloc -> false
           | _ -> true)
         diff_res
     in

--- a/backend/cn/lib/global.ml
+++ b/backend/cn/lib/global.ml
@@ -22,7 +22,8 @@ let empty =
     datatype_constrs = SymMap.empty;
     datatype_order = None;
     fun_decls = SymMap.empty;
-    resource_predicates = SymMap.(empty |> add Alloc.Predicate.sym Alloc.Predicate.def);
+    resource_predicates =
+      SymMap.(empty |> add Alloc.Predicate.sym ResourcePredicates.alloc);
     logical_functions = SymMap.empty;
     lemmata = SymMap.empty
   }

--- a/backend/cn/lib/resourcePredicates.ml
+++ b/backend/cn/lib/resourcePredicates.ml
@@ -3,7 +3,6 @@ module IT = IndexTerms
 module LS = LogicalSorts
 module LRT = LogicalReturnTypes
 module LC = LogicalConstraints
-module RE = Resources
 module AT = ArgumentTypes
 module LAT = LogicalArgumentTypes
 module StringMap = Map.Make (String)
@@ -44,6 +43,15 @@ type definition =
     oarg_bt : LS.t;
     clauses : clause list option
   }
+
+let alloc =
+  { loc = Locations.other (__FILE__ ^ ":" ^ string_of_int __LINE__);
+    pointer = Sym.fresh_named "ptr";
+    iargs = [];
+    oarg_bt = Alloc.History.value_bt;
+    clauses = None
+  }
+
 
 let pp_definition def =
   item "pointer" (Sym.pp def.pointer)

--- a/backend/cn/lib/resourceTypes.ml
+++ b/backend/cn/lib/resourceTypes.ml
@@ -17,6 +17,8 @@ type predicate_name =
   | PName of Sym.t
 [@@deriving eq, ord]
 
+let alloc = PName Alloc.Predicate.sym
+
 let pp_init = function Init -> !^"Init" | Uninit -> !^"Uninit"
 
 let pp_predicate_name = function
@@ -32,6 +34,8 @@ type predicate_type =
   }
 [@@deriving eq, ord]
 
+let make_alloc pointer = { name = alloc; pointer; iargs = [] }
+
 type qpredicate_type =
   { name : predicate_name;
     pointer : IT.t; (* I *)
@@ -43,12 +47,13 @@ type qpredicate_type =
   }
 [@@deriving eq, ord]
 
-let subsumed p1 p2 =
+let subsumed ~alloc_owned p1 p2 =
   (* p1 subsumed by p2 *)
   equal_predicate_name p1 p2
   ||
   match (p1, p2) with
   | Owned (ct, Uninit), Owned (ct', Init) when Sctypes.equal ct ct' -> true
+  | _, Owned _ when alloc_owned && equal_predicate_name p1 alloc -> true
   | _ -> false
 
 

--- a/backend/cn/lib/resources.ml
+++ b/backend/cn/lib/resources.ml
@@ -34,23 +34,28 @@ let range_size ct =
   IT.num_lit_ (Z.of_int size) Memory.uintptr_bt here
 
 
-let upper_bound addr ct =
-  let here = Locations.other (__FUNCTION__ ^ ":" ^ string_of_int __LINE__) in
-  IT.add_ (addr, range_size ct) here
-
-
-let addr_of pointer =
-  let here = Locations.other (__FUNCTION__ ^ ":" ^ string_of_int __LINE__) in
-  IT.addr_ pointer here
-
+let upper_bound addr ct loc = IT.add_ (addr, range_size ct) loc
 
 (* assumption: the resource is owned *)
-let derived_lc1 (resource, _) =
+let derived_lc1 (resource, O oarg) =
   let here = Locations.other (__FUNCTION__ ^ ":" ^ string_of_int __LINE__) in
   match resource with
   | P { name = Owned (ct, _); pointer; iargs = _ } ->
-    let addr = addr_of pointer in
-    [ IT.hasAllocId_ pointer here; IT.(lt_ (addr, upper_bound addr ct) here) ]
+    let addr = IT.addr_ pointer here in
+    let upper = upper_bound addr ct here in
+    let alloc_bounds =
+      if !IT.use_vip then (
+        let lookup = Alloc.History.lookup_ptr pointer here in
+        let base, size = Alloc.History.get_base_size lookup here in
+        [ IT.(le_ (base, addr) here); IT.(le_ (upper, add_ (base, size) here) here) ])
+      else
+        []
+    in
+    [ IT.hasAllocId_ pointer here; IT.(le_ (addr, upper) here) ] @ alloc_bounds
+  | P { name; pointer; iargs = [] } when !IT.use_vip && equal_predicate_name name alloc ->
+    let lookup = Alloc.History.lookup_ptr pointer here in
+    let base, size = Alloc.History.get_base_size lookup here in
+    [ IT.(eq_ (lookup, oarg) here); IT.(le_ (base, add_ (base, size) here) here) ]
   | Q { name = Owned _; pointer; _ } -> [ IT.hasAllocId_ pointer here ]
   | P { name = PName _; pointer = _; iargs = _ } | Q { name = PName _; _ } -> []
 
@@ -62,10 +67,10 @@ let derived_lc2 (resource, _) (resource', _) =
   | ( P { name = Owned (ct1, _); pointer = p1; iargs = _ },
       P { name = Owned (ct2, _); pointer = p2; iargs = _ } ) ->
     let here = Locations.other (__FUNCTION__ ^ ":" ^ string_of_int __LINE__) in
-    let addr1 = addr_of p1 in
-    let addr2 = addr_of p2 in
-    let up1 = upper_bound addr1 ct1 in
-    let up2 = upper_bound addr2 ct2 in
+    let addr1 = IT.addr_ p1 here in
+    let addr2 = IT.addr_ p2 here in
+    let up1 = upper_bound addr1 ct1 here in
+    let up2 = upper_bound addr2 ct2 here in
     [ IT.(or2_ (le_ (up2, addr1) here, le_ (up1, addr2) here) here) ]
   | _ -> []
 

--- a/backend/cn/lib/typeErrors.ml
+++ b/backend/cn/lib/typeErrors.ml
@@ -37,6 +37,7 @@ let call_prefix = function
 
 
 type situation =
+  | Ptr_diff
   | Access of access
   | Call of call_situation
 
@@ -58,6 +59,7 @@ let call_situation = function
 
 let checking_situation = function
   | Access _ -> !^"checking access"
+  | Ptr_diff -> !^"checking pointer difference"
   | Call s -> call_situation s
 
 
@@ -71,6 +73,7 @@ let for_access = function
 
 let for_situation = function
   | Access access -> for_access access
+  | Ptr_diff -> !^"for subtracting pointers"
   | Call s ->
     (match s with
      | FunctionCall fsym -> !^"for calling function" ^^^ Sym.pp fsym

--- a/runtime/libcn/libexec/cn-runtime-single-file.sh
+++ b/runtime/libcn/libexec/cn-runtime-single-file.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail -o noclobber
 
-USAGE="USAGE: $0 -h\n       $0 [-oq] FILE.c"
+USAGE="USAGE: $0 -h\n       $0 [-ovq] FILE.c"
 
 function echo_and_err() {
     printf "$1\n"

--- a/tests/cn/ptr_diff.c
+++ b/tests/cn/ptr_diff.c
@@ -1,17 +1,44 @@
+int g(int *p, int *q)
+/*@
+ requires
+    take P = Owned(p);
+    take Q = Owned(q);
+    ptr_eq(q, array_shift(p, 10i32));
+ensures
+    take P2 = Owned(p);
+    P == P2;
+    take Q2 = Owned(q);
+    Q == Q2;
+    return == -10i32;
+@*/
+{
+  return p - q;
+}
+
 int f(int *p, int *q)
 /*@
  requires
     !is_null(p);
     ptr_eq(q, array_shift(p, 10i32));
+    take A = Alloc(p);
+    A.base <= (u64) p;
+    (u64) p <= (u64) q;
+    (u64) q <= A.base + A.size;
 ensures
     return == -10i32;
+    take A2 = Alloc(p);
+    A == A2;
 @*/
 {
-  return p - q; // intentionally p - q = -10;
+  /*@ assert(allocs[(alloc_id)p] == A); @*/
+  return p - q;
 }
 
 int main(void)
 {
     int arr[11] = { 0 };
     f(&arr[0], &arr[10]);
+    /*@ extract Owned<int>, 0u64; @*/
+    /*@ extract Owned<int>, 10u64; @*/
+    g(&arr[0], &arr[10]);
 }

--- a/tests/run-cn-exec.sh
+++ b/tests/run-cn-exec.sh
@@ -91,6 +91,7 @@ SUCCESS=$(find cn -name '*.c' \
     ! -name "has_alloc_id_ptr_neq.c" \
     ! -name "spec_null_shift.c" \
     ! -name "alloc_token.c" \
+    ! -name "ptr_diff.c" \
 )
 
 # Include files which cause error for proof but not testing
@@ -146,6 +147,7 @@ BUGGY="cn/division_casting.c \
        cn/has_alloc_id_ptr_neq.c \
        cn/spec_null_shift.c \
        cn/alloc_token.c \
+       cn/ptr_diff.c \
        "
 
 # Exclude files which cause error for proof but not testing


### PR DESCRIPTION
This commit adds support for the VIP ptr diff rule, which requires that both pointers come from the same live allocation.

To accommodate this without excessive annotation burden, it does so by (a) inferring `base <= (u64) p <= (u64) p + sizeof(ct) <= base + len` for `{ base, len } = allocs[(alloc_id)p]` from `Owned<ct>(p)` and (b) accepting an `Owned<ct>(p)` when looking for a `Alloc(q)` if `(alloc_id) q == (alloc_id) p` and `(u64) p <= (u64) q <= (u64) p + sizeof(ct)`.

It only does this for pointer difference for now (later, it will be used for pointer relational operators, copy_alloc_id and integer to pointer round-trip casts) with a special flag `alloc_or_owned` in the resource inference algorithm.