### PR TITLE
CN: Refactor resourceInference.ml

### DIFF
--- a/backend/cn/lib/check.ml
+++ b/backend/cn/lib/check.ml
@@ -1322,12 +1322,10 @@ let rec check_expr labels (e : BT.t mu_expr) (k : IT.t -> unit m) : unit m =
                 let@ model = model () in
                 fail (fun ctxt -> { loc; msg = Undefined_behaviour { ub; ctxt; model } })
               | `True ->
-                let@ (_alloc_or_owned, RE.O base_len), _ =
-                  RI.Special.of_live_alloc loc Ptr_diff arg1
-                in
+                let@ base_size = RI.Special.get_live_alloc loc Ptr_diff arg1 in
                 let@ () =
                   if !use_vip then (
-                    let base, size = Alloc.History.get_base_size base_len here in
+                    let base, size = Alloc.History.get_base_size base_size here in
                     let addr1, addr2 = (addr_ arg1 here, addr_ arg2 here) in
                     let lower1, lower2 =
                       (le_ (base, addr1) here, le_ (base, addr2) here)

--- a/backend/cn/lib/indexTerms.ml
+++ b/backend/cn/lib/indexTerms.ml
@@ -18,10 +18,13 @@ type t = BT.t term
 
 let basetype : 'a. 'a Terms.term -> 'a = function IT (_, bt, _) -> bt
 
+(* TODO rename this get_bt *)
 let bt = basetype
 
+(* TODO rename this get_term *)
 let term (IT (t, _, _)) = t
 
+(* TODO rename this get_loc *)
 let loc (IT (_, _, l)) = l
 
 let term_of_sterm : sterm -> typed = Terms.map_term SurfaceBaseTypes.to_basetype

--- a/backend/cn/lib/resourceInference.mli
+++ b/backend/cn/lib/resourceInference.mli
@@ -1,0 +1,33 @@
+val debug_constraint_failure_diagnostics
+  :  int ->
+  Solver.model_with_q ->
+  Global.t ->
+  Simplify.simp_ctxt ->
+  LogicalConstraints.logical_constraint ->
+  unit
+
+module General : sig
+  type uiinfo = TypeErrors.situation * TypeErrors.request_chain
+
+  val ftyp_args_request_step
+    :  ([ `Rename of Sym.t | `Term of IndexTerms.t ] Subst.t -> 'a -> 'a) ->
+    Locations.t ->
+    uiinfo ->
+    'b ->
+    'a LogicalArgumentTypes.t ->
+    'a LogicalArgumentTypes.t Typing.m
+end
+
+module Special : sig
+  val get_live_alloc
+    :  Locations.t ->
+    TypeErrors.situation ->
+    IndexTerms.t ->
+    IndexTerms.t Typing.m
+
+  val predicate_request
+    :  Locations.t ->
+    TypeErrors.situation ->
+    ResourceTypes.predicate_type * (Locations.t * string) option ->
+    ((ResourceTypes.predicate_type * Resources.oargs) * int list) Typing.m
+end


### PR DESCRIPTION
This file removes a bunch of unnecessary `open Modules` from the resource inference file and also adds an `.mli` file for it.