### PR TITLE
[CN-exec] Remove (some) unnecessary allocations from CN runtime library

### DIFF
--- a/backend/cn/lib/cn_internal_to_ail.ml
+++ b/backend/cn/lib/cn_internal_to_ail.ml
@@ -1563,7 +1563,8 @@ let generate_map_get sym =
       A.(
         AilEcall
           ( mk_expr (AilEident (Sym.fresh_pretty "ht_get")),
-            [ mk_expr (AilEident param1_sym); mk_expr (AilEunary (Address, key_val_mem)) ] ))
+            [ mk_expr (AilEident param1_sym); mk_expr (AilEunary (Address, key_val_mem)) ]
+          ))
   in
   let ret_decl = A.(AilSdeclaration [ (ret_sym, Some ht_get_fcall) ]) in
   let ret_ident = A.(AilEident ret_sym) in
@@ -2364,9 +2365,7 @@ let generate_record_default_function dts (sym, (members : BT.member_types)) =
   [ (decl, def) ]
 
 
-let generate_record_map_get (sym, _) =
-  generate_map_get sym
-
+let generate_record_map_get (sym, _) = generate_map_get sym
 
 let cn_to_ail_struct
   ((sym, (loc, attrs, tag_def)) :

--- a/backend/cn/lib/cn_internal_to_ail.ml
+++ b/backend/cn/lib/cn_internal_to_ail.ml
@@ -1537,8 +1537,8 @@ let cn_to_ail_pred_records map_bindings =
   List.map generate_struct_definition flipped_bindings
 
 
-(* Generic map get for structs and datatypes *)
-(* Used in generate_struct_map_get and generate_datatype_map_get *)
+(* Generic map get for structs, datatypes and records *)
+(* Used in generate_struct_map_get, generate_datatype_map_get and generate_record_map_get *)
 let generate_map_get sym =
   let ctype_str = "struct_" ^ Sym.pp_string sym in
   let fn_str = "cn_map_get_" ^ ctype_str in
@@ -1563,7 +1563,7 @@ let generate_map_get sym =
       A.(
         AilEcall
           ( mk_expr (AilEident (Sym.fresh_pretty "ht_get")),
-            [ mk_expr (AilEident param1_sym); key_val_mem ] ))
+            [ mk_expr (AilEident param1_sym); mk_expr (AilEunary (Address, key_val_mem)) ] ))
   in
   let ret_decl = A.(AilSdeclaration [ (ret_sym, Some ht_get_fcall) ]) in
   let ret_ident = A.(AilEident ret_sym) in
@@ -2364,76 +2364,8 @@ let generate_record_default_function dts (sym, (members : BT.member_types)) =
   [ (decl, def) ]
 
 
-let generate_record_map_get dts (sym, (members : BT.member_types)) =
-  let cn_sym = sym in
-  let ctype_str = "struct_" ^ Sym.pp_string cn_sym in
-  let fn_str = "cn_map_get_" ^ ctype_str in
-  let void_ptr_type = C.(mk_ctype_pointer empty_qualifiers (mk_ctype Void)) in
-  let param1_sym = Sym.fresh_pretty "m" in
-  let param2_sym = Sym.fresh_pretty "key" in
-  let param_syms = [ param1_sym; param2_sym ] in
-  let param_types =
-    List.map bt_to_ail_ctype [ BT.Map (Integer, Struct cn_sym); BT.Integer ]
-  in
-  let param_types =
-    List.map (fun ctype -> (empty_qualifiers, ctype, false)) param_types
-  in
-  let fn_sym = Sym.fresh_pretty fn_str in
-  let ret_sym = Sym.fresh_pretty "ret" in
-  let ret_binding = create_binding ret_sym void_ptr_type in
-  let key_val_mem =
-    mk_expr A.(AilEmemberofptr (mk_expr (AilEident param2_sym), Id.id "val"))
-  in
-  let ht_get_fcall =
-    mk_expr
-      A.(
-        AilEcall
-          ( mk_expr (AilEident (Sym.fresh_pretty "ht_get")),
-            [ mk_expr (AilEident param1_sym); key_val_mem ] ))
-  in
-  let ret_decl = A.(AilSdeclaration [ (ret_sym, Some ht_get_fcall) ]) in
-  let ret_ident = A.(AilEident ret_sym) in
-  (* Function body *)
-  let if_cond =
-    mk_expr
-      A.(
-        AilEbinary
-          ( mk_expr A.(AilEconst (ConstantInteger (IConstant (Z.of_int 0, Decimal, None)))),
-            Eq,
-            mk_expr ret_ident ))
-  in
-  let default_fcall =
-    A.(AilEcall (mk_expr (AilEident (Sym.fresh_pretty ("default_" ^ ctype_str))), []))
-  in
-  let cast_expr = A.(AilEcast (empty_qualifiers, void_ptr_type, mk_expr default_fcall)) in
-  let if_stmt =
-    A.(
-      AilSif
-        ( if_cond,
-          mk_stmt (AilSreturn (mk_expr cast_expr)),
-          mk_stmt (AilSreturn (mk_expr ret_ident)) ))
-  in
-  let ret_type = void_ptr_type in
-  (* Generating function declaration *)
-  let decl =
-    ( fn_sym,
-      ( Cerb_location.unknown,
-        empty_attributes,
-        A.(
-          Decl_function
-            (false, (empty_qualifiers, ret_type), param_types, false, false, false)) ) )
-  in
-  (* Generating function definition *)
-  let def =
-    ( fn_sym,
-      ( Cerb_location.unknown,
-        0,
-        empty_attributes,
-        param_syms,
-        mk_stmt A.(AilSblock ([ ret_binding ], List.map mk_stmt [ ret_decl; if_stmt ])) )
-    )
-  in
-  [ (decl, def) ]
+let generate_record_map_get (sym, _) =
+  generate_map_get sym
 
 
 let cn_to_ail_struct

--- a/backend/cn/lib/executable_spec_internal.ml
+++ b/backend/cn/lib/executable_spec_internal.ml
@@ -404,10 +404,7 @@ let generate_c_record_funs
          cn_record_info)
   in
   let record_map_get_functions =
-    List.concat
-      (List.map
-         Cn_internal_to_ail.generate_record_map_get
-         cn_record_info)
+    List.concat (List.map Cn_internal_to_ail.generate_record_map_get cn_record_info)
   in
   let eq_decls, eq_defs = List.split record_equality_functions in
   let default_decls, default_defs = List.split record_default_functions in

--- a/backend/cn/lib/executable_spec_internal.ml
+++ b/backend/cn/lib/executable_spec_internal.ml
@@ -406,7 +406,7 @@ let generate_c_record_funs
   let record_map_get_functions =
     List.concat
       (List.map
-         (Cn_internal_to_ail.generate_record_map_get sigm.cn_datatypes)
+         Cn_internal_to_ail.generate_record_map_get
          cn_record_info)
   in
   let eq_decls, eq_defs = List.split record_equality_functions in

--- a/runtime/libcn/include/cn-executable/utils.h
+++ b/runtime/libcn/include/cn-executable/utils.h
@@ -44,42 +44,42 @@ void update_error_message_info_(const char *function_name, char *file_name, int 
 /* Signed bitvectors */
 
 typedef struct cn_bits_i8 {
-    int8_t *val;
+    int8_t val;
 } cn_bits_i8;
 
 typedef struct cn_bits_i16 {
-    int16_t *val;
+    int16_t val;
 } cn_bits_i16;
 
 typedef struct cn_bits_i32 {
-    int32_t *val;
+    int32_t val;
 } cn_bits_i32;
 
 typedef struct cn_bits_i64 {
-    int64_t *val;
+    int64_t val;
 } cn_bits_i64;
 
 /* Unsigned bitvectors */
 
 typedef struct cn_bits_u8 {
-    uint8_t *val;
+    uint8_t val;
 } cn_bits_u8;
 
 typedef struct cn_bits_u16 {
-    uint16_t *val;
+    uint16_t val;
 } cn_bits_u16;
 
 typedef struct cn_bits_u32 {
-    uint32_t *val;
+    uint32_t val;
 } cn_bits_u32;
 
 typedef struct cn_bits_u64 {
-    uint64_t *val;
+    uint64_t val;
 } cn_bits_u64;
 
 
 typedef struct cn_integer {
-    signed long *val;
+    signed long val;
 } cn_integer;
 
 typedef struct cn_pointer {
@@ -91,7 +91,7 @@ typedef struct cn_bool {
 } cn_bool;
 
 typedef struct cn_alloc_id {
-    uint8_t *val;
+    uint8_t val;
 } cn_alloc_id;
 
 
@@ -159,95 +159,88 @@ cn_bool *cn_pointer_gt(cn_pointer *i1, cn_pointer *i2);
 
 #define CN_GEN_EQUALITY_(CNTYPE)\
     static inline cn_bool *CNTYPE##_equality(void *i1, void *i2){\
-        return convert_to_cn_bool((*((CNTYPE *) i1)->val) == (*((CNTYPE *) i2)->val));\
+        return convert_to_cn_bool(((CNTYPE *) i1)->val == ((CNTYPE *) i2)->val);\
     }
 
 #define CN_GEN_CONVERT(CTYPE, CNTYPE)\
     static inline CNTYPE *convert_to_##CNTYPE(CTYPE i) {\
         CNTYPE *ret = (CNTYPE *) alloc(sizeof(CNTYPE));\
-        ret->val = (CTYPE *) alloc(sizeof(CTYPE));\
-        *(ret->val) = i;\
+        ret->val = i;\
         return ret;\
     }
 
 #define CN_GEN_CONVERT_FROM(CTYPE, CNTYPE)\
     static inline CTYPE convert_from_##CNTYPE(CNTYPE *i) {\
-        return *i->val;\
+        return i->val;\
     }
 
 /* Arithmetic operators */
 
 #define CN_GEN_LT(CNTYPE)\
     static inline cn_bool *CNTYPE##_lt(CNTYPE *i1, CNTYPE *i2) {\
-        return convert_to_cn_bool(*(i1->val) < *(i2->val));\
+        return convert_to_cn_bool(i1->val < i2->val);\
     }
 
 #define CN_GEN_LE(CNTYPE)\
     static inline cn_bool *CNTYPE##_le(CNTYPE *i1, CNTYPE *i2) {\
-        return convert_to_cn_bool(*(i1->val) <= *(i2->val));\
+        return convert_to_cn_bool(i1->val <= i2->val);\
     }
 
 #define CN_GEN_GT(CNTYPE)\
     static inline cn_bool *CNTYPE##_gt(CNTYPE *i1, CNTYPE *i2) {\
-        return convert_to_cn_bool(*(i1->val) > *(i2->val));\
+        return convert_to_cn_bool(i1->val > i2->val);\
     }
 
 #define CN_GEN_GE(CNTYPE)\
     static inline cn_bool *CNTYPE##_ge(CNTYPE *i1, CNTYPE *i2) {\
-        return convert_to_cn_bool(*(i1->val) >= *(i2->val));\
+        return convert_to_cn_bool(i1->val >= i2->val);\
     }
 
 #define CN_GEN_NEGATE(CNTYPE)\
     static inline CNTYPE *CNTYPE##_negate(CNTYPE *i) {\
-        return convert_to_##CNTYPE(-(*i->val));\
+        return convert_to_##CNTYPE(-(i->val));\
     }
 
 
 #define CN_GEN_ADD(CTYPE, CNTYPE)\
     static inline CNTYPE *CNTYPE##_add(CNTYPE *i1, CNTYPE *i2) {\
         CNTYPE *res = (CNTYPE *) alloc(sizeof(CNTYPE));\
-        res->val = (CTYPE *) alloc(sizeof(CTYPE));\
-        *(res->val) = *(i1->val) + *(i2->val);\
+        res->val = i1->val + i2->val;\
         return res;\
     }
 
 #define CN_GEN_SUB(CTYPE, CNTYPE)\
     static inline CNTYPE *CNTYPE##_sub(CNTYPE *i1, CNTYPE *i2) {\
         CNTYPE *res = (CNTYPE *) alloc(sizeof(CNTYPE));\
-        res->val = (CTYPE *) alloc(sizeof(CTYPE));\
-        *(res->val) = *(i1->val) - *(i2->val);\
+        res->val = i1->val - i2->val;\
         return res;\
     }
 
 #define CN_GEN_MUL(CTYPE, CNTYPE)\
     static inline CNTYPE *CNTYPE##_multiply(CNTYPE *i1, CNTYPE *i2) {\
         CNTYPE *res = (CNTYPE *) alloc(sizeof(CNTYPE));\
-        res->val = (CTYPE *) alloc(sizeof(CTYPE));\
-        *(res->val) = *(i1->val) * *(i2->val);\
+        res->val = i1->val * i2->val;\
         return res;\
     }
 
 #define CN_GEN_DIV(CTYPE, CNTYPE)\
     static inline CNTYPE *CNTYPE##_divide(CNTYPE *i1, CNTYPE *i2) {\
         CNTYPE *res = (CNTYPE *) alloc(sizeof(CNTYPE));\
-        res->val = (CTYPE *) alloc(sizeof(CTYPE));\
-        *(res->val) = *(i1->val) / *(i2->val);\
+        res->val = i1->val / i2->val;\
         return res;\
     }
 
 #define CN_GEN_SHIFT_LEFT(CTYPE, CNTYPE)\
     static inline CNTYPE *CNTYPE##_shift_left(CNTYPE *i1, CNTYPE *i2) {\
         CNTYPE *res = (CNTYPE *) alloc(sizeof(CNTYPE));\
-        res->val = (CTYPE *) alloc(sizeof(CTYPE));\
-        *(res->val) = *(i1->val) << *(i2->val);\
+        res->val = i1->val << i2->val;\
         return res;\
     }
 
 #define CN_GEN_SHIFT_RIGHT(CTYPE, CNTYPE)\
     static inline CNTYPE *CNTYPE##_shift_right(CNTYPE *i1, CNTYPE *i2) {\
         CNTYPE *res = (CNTYPE *) alloc(sizeof(CNTYPE));\
-        res->val = (CTYPE *) alloc(sizeof(CTYPE));\
-        *(res->val) = *(i1->val) >> *(i2->val);\
+        res->val = i1->val >> i2->val;\
         return res;\
     }
 
@@ -264,8 +257,7 @@ cn_bool *cn_pointer_gt(cn_pointer *i1, cn_pointer *i2);
 #define CN_GEN_MOD(CTYPE, CNTYPE)\
     static inline CNTYPE *CNTYPE##_mod(CNTYPE *i1, CNTYPE *i2) {\
         CNTYPE *res = (CNTYPE *) alloc(sizeof(CNTYPE));\
-        res->val = (CTYPE *) alloc(sizeof(CTYPE));\
-        *(res->val) = *(i1->val) % *(i2->val);\
+        res->val = i1->val % i2->val;\
         return res;\
     }
 

--- a/runtime/libcn/include/cn-executable/utils.h
+++ b/runtime/libcn/include/cn-executable/utils.h
@@ -264,24 +264,21 @@ cn_bool *cn_pointer_gt(cn_pointer *i1, cn_pointer *i2);
 #define CN_GEN_XOR(CTYPE, CNTYPE)\
     static inline CNTYPE *CNTYPE##_xor(CNTYPE *i1, CNTYPE *i2) {\
         CNTYPE *res = (CNTYPE *) alloc(sizeof(CNTYPE));\
-        res->val = (CTYPE *) alloc(sizeof(CTYPE));\
-        *(res->val) = *(i1->val) ^ *(i2->val);\
+        res->val = i1->val ^ i2->val;\
         return res;\
     }
 
 #define CN_GEN_BWAND(CTYPE, CNTYPE)\
     static inline CNTYPE *CNTYPE##_bwand(CNTYPE *i1, CNTYPE *i2) {\
         CNTYPE *res = (CNTYPE *) alloc(sizeof(CNTYPE));\
-        res->val = (CTYPE *) alloc(sizeof(CTYPE));\
-        *(res->val) = *(i1->val) & *(i2->val);\
+        res->val = i1->val & i2->val;\
         return res;\
     }
 
 #define CN_GEN_BWOR(CTYPE, CNTYPE)\
     static inline CNTYPE *CNTYPE##_bwor(CNTYPE *i1, CNTYPE *i2) {\
         CNTYPE *res = (CNTYPE *) alloc(sizeof(CNTYPE));\
-        res->val = (CTYPE *) alloc(sizeof(CTYPE));\
-        *(res->val) = *(i1->val) | *(i2->val);\
+        res->val = i1->val | i2->val;\
         return res;\
     }
 
@@ -307,30 +304,14 @@ static inline int ipow(int base, int exp)
 #define CN_GEN_POW(CTYPE, CNTYPE)\
     static inline CNTYPE *CNTYPE##_pow(CNTYPE *i1, CNTYPE *i2) {\
         CNTYPE *res = (CNTYPE *) alloc(sizeof(CNTYPE));\
-        res->val = (CTYPE *) alloc(sizeof(CTYPE));\
-        *(res->val) = ipow(*(i1->val), *(i2->val));\
+        res->val = ipow(i1->val, i2->val);\
         return res;\
     }
 
 
-// #define CN_GEN_ARRAY_SHIFT(CNTYPE)\
-//     static inline cn_pointer *cn_array_shift_##CNTYPE(cn_pointer *ptr, CNTYPE *i) {\
-//         cn_pointer *res = alloc(sizeof(cn_pointer));\
-//         res->ptr = (CTYPE *) ptr->ptr + *(i->val);\
-//         return res;\
-//     }
-
 #define cn_array_shift(cn_ptr, size, index)\
-    convert_to_cn_pointer((char *) cn_ptr->ptr + (*(index->val) * size)) 
+    convert_to_cn_pointer((char *) cn_ptr->ptr + (index->val * size)) 
 
-
-/* 
-
-member_shift<hyp_pool>(pool_pointer, free_area);
-
-pool_pointer
-
-*/
 
 #define cn_member_shift(cn_ptr, tag, member_name)\
   convert_to_cn_pointer(&(((struct tag *) cn_ptr->ptr)->member_name))
@@ -339,14 +320,14 @@ pool_pointer
 
 #define CN_GEN_INCREMENT(CNTYPE)\
     static inline CNTYPE *CNTYPE##_increment(CNTYPE *i) {\
-        *(i->val) = *(i->val) + 1;\
+        i->val = i->val + 1;\
         return i;\
     }
 
 #define CN_GEN_PTR_ADD(CNTYPE)\
     static inline cn_pointer *cn_pointer_add_##CNTYPE(cn_pointer *ptr, CNTYPE *i) {\
         cn_pointer *res = (cn_pointer *) alloc(sizeof(cn_pointer));\
-        res->ptr = (char *) ptr->ptr + *(i->val);\
+        res->ptr = (char *) ptr->ptr + i->val;\
         return res;\
     }
 
@@ -356,15 +337,14 @@ pool_pointer
 #define CN_GEN_CAST_TO_PTR(CNTYPE, INTPTR_TYPE)\
     static inline cn_pointer *cast_##CNTYPE##_to_cn_pointer(CNTYPE *i) {\
         cn_pointer *res = (cn_pointer *) alloc(sizeof(cn_pointer));\
-        res->ptr = (void *) (INTPTR_TYPE) *(i->val);\
+        res->ptr = (void *) (INTPTR_TYPE) i->val;\
         return res;\
     }
 
 #define CN_GEN_CAST_FROM_PTR(CTYPE, CNTYPE, INTPTR_TYPE)\
     static inline CNTYPE *cast_cn_pointer_to_##CNTYPE(cn_pointer *ptr) {\
         CNTYPE *res = (CNTYPE *) alloc(sizeof(CNTYPE));\
-        res->val = (CTYPE *) alloc(sizeof(CTYPE));\
-        *(res->val) = (CTYPE) (INTPTR_TYPE) (ptr->ptr);\
+        res->val = (CTYPE) (INTPTR_TYPE) (ptr->ptr);\
         return res;\
     }
 
@@ -372,8 +352,7 @@ pool_pointer
 #define CN_GEN_CAST_INT_TYPES(CNTYPE1, CTYPE2, CNTYPE2)\
     static inline CNTYPE2 *cast_##CNTYPE1##_to_##CNTYPE2(CNTYPE1 *i) {\
         CNTYPE2 *res = (CNTYPE2 *) alloc(sizeof(CNTYPE2));\
-        res->val = (CTYPE2 *) alloc(sizeof(CTYPE2));\
-        *(res->val) = (CTYPE2) *(i->val);\
+        res->val = (CTYPE2) i->val;\
         return res;\
     }
 
@@ -387,7 +366,9 @@ cn_bool *default_cn_bool(void);
 
 #define CN_GEN_MAP_GET(CNTYPE)\
     static inline void *cn_map_get_##CNTYPE(cn_map *m, cn_integer *key) {   \
-        void *res = ht_get(m, key->val);                                    \
+        signed long *key_ptr = alloc(sizeof(signed long));                  \
+        *key_ptr = key->val;                                                \
+        void *res = ht_get(m, key_ptr);                                     \
         if (!res) { return (void *) default_##CNTYPE(); }                   \
         return res;                                                         \
     }

--- a/runtime/libcn/src/utils.c
+++ b/runtime/libcn/src/utils.c
@@ -31,8 +31,6 @@ void print_error_msg_info(void) {
 cn_bool *convert_to_cn_bool(_Bool b) {
     cn_bool *res = alloc(sizeof(cn_bool));
     if (!res) exit(1);
-    // printf("%p\n", (void *) res);
-    // printf("%p\n", (void *) &(res->val));
     res->val = b;
     return res;
 }
@@ -292,7 +290,9 @@ void c_ownership_check(uintptr_t generic_c_ptr, int offset) {
 // }
 
 cn_map *cn_map_set(cn_map *m, cn_integer *key, void *value) {
-    ht_set(m, key->val, value);
+    signed long *key_ptr = alloc(sizeof(signed long));
+    *key_ptr = key->val;
+    ht_set(m, key_ptr, value);
     return m;
 }
 
@@ -400,20 +400,16 @@ static uint64_t cn_flsl(uint64_t x)
 
 cn_bits_u32 *cn_bits_u32_fls(cn_bits_u32 *i1) {
         cn_bits_u32 *res = (cn_bits_u32 *) alloc(sizeof(cn_bits_u32));
-        res->val = (uint32_t *) alloc(sizeof(uint32_t));
-        *(res->val) = cn_fls(*(i1->val));
+        res->val = cn_fls(i1->val);
         return res;
     }
 
 cn_bits_u64 *cn_bits_u64_flsl(cn_bits_u64 *i1) {
         cn_bits_u64 *res = (cn_bits_u64 *) alloc(sizeof(cn_bits_u64));
-        res->val = (uint64_t *) alloc(sizeof(uint64_t));
-        *(res->val) = cn_flsl(*(i1->val));
+        res->val = cn_flsl(i1->val);
         return res;
     }
 
-
-/* void *aligned_alloc(size_t align, size_t size); */
 
 void *cn_aligned_alloc(size_t align, size_t size) 
 {

--- a/tests/run-cn-exec.sh
+++ b/tests/run-cn-exec.sh
@@ -86,6 +86,7 @@ SUCCESS=$(find cn -name '*.c' \
     ! -name "b_xor.c" \
     ! -name "copy_alloc_id.c" \
     ! -name "has_alloc_id.c" \
+    ! -name "has_alloc_id_shift.c" \
     ! -name "ptr_diff2.c" \
     ! -name "has_alloc_id_ptr_neq.c" \
     ! -name "spec_null_shift.c" \
@@ -142,6 +143,7 @@ BUGGY="cn/division_casting.c \
        cn/b_xor.c \
        cn/copy_alloc_id.c \
        cn/has_alloc_id.c \
+       cn/has_alloc_id_shift.c \
        cn/ptr_diff2.c \
        cn/has_alloc_id_ptr_neq.c \
        cn/spec_null_shift.c \

--- a/tests/run-cn-exec.sh
+++ b/tests/run-cn-exec.sh
@@ -84,7 +84,6 @@ SUCCESS=$(find cn -name '*.c' \
     ! -name "bitwise_compl.c" \
     ! -name "fun_ptr_extern.c" \
     ! -name "b_xor.c" \
-    ! -name "mask_ptr.c" \
     ! -name "copy_alloc_id.c" \
     ! -name "has_alloc_id.c" \
     ! -name "ptr_diff2.c" \
@@ -141,7 +140,6 @@ BUGGY="cn/division_casting.c \
        cn/bitwise_compl.c \
        cn/fun_ptr_extern.c \
        cn/b_xor.c \
-       cn/mask_ptr.c \
        cn/copy_alloc_id.c \
        cn/has_alloc_id.c \
        cn/ptr_diff2.c \

--- a/tests/run-cn-exec.sh
+++ b/tests/run-cn-exec.sh
@@ -91,7 +91,7 @@ SUCCESS=$(find cn -name '*.c' \
     ! -name "spec_null_shift.c" \
     ! -name "alloc_token.c" \
     ! -name "ptr_diff.c" \
-    ! -name "has_alloc_id_shift.c" \
+    ! -name "mask_ptr.c" \
 )
 
 # Include files which cause error for proof but not testing
@@ -147,7 +147,7 @@ BUGGY="cn/division_casting.c \
        cn/spec_null_shift.c \
        cn/alloc_token.c \
        cn/ptr_diff.c \
-       cn/has_alloc_id_shift.c \
+       cn/mask_ptr.c \
        "
 
 # Exclude files which cause error for proof but not testing


### PR DESCRIPTION
Update CN runtime library (`runtime/libcn`) to represent CN basetypes as pointers to C structs, with each C struct containing a single value of the relevant C type as its member. Previously this struct member was a *pointer* to the relevant C type, requiring some unnecessary allocations to be made throughout the runtime library.

Aims to improve performance ever so slightly, although for a real performance upgrade we still need to implement a garbage collector.