### PR TITLE
[CN] Flip `WellTyped.use_ity` default

### DIFF
--- a/backend/cn/lib/wellTyped.ml
+++ b/backend/cn/lib/wellTyped.ml
@@ -17,7 +17,7 @@ open Typing
 
 open Effectful.Make (Typing)
 
-let use_ity = ref false
+let use_ity = ref true
 
 let ensure_base_type = Typing.ensure_base_type
 


### PR DESCRIPTION
The default value for `use_ity` was originally `false`, but was flipped in commit ac79195, w.r.t to the CLI default. However, the actual default value was not updated. This changes it to be consistent.