### PR TITLE
Interval analysis to simplify resource type permissions.

### DIFF
--- a/backend/cn/lib/explain.ml
+++ b/backend/cn/lib/explain.ml
@@ -132,7 +132,9 @@ let rec simp_resource eval r =
     else
       LAT.Constraint (ct, info, simp_resource eval more)
   | LAT.Define (x, i, more) -> LAT.Define (x, i, simp_resource eval more)
-  | LAT.Resource (x, i, more) -> LAT.Resource (x, i, simp_resource eval more)
+  | LAT.Resource ((x,(rt,bt)), i, more) ->
+    let rt1 = Interval.Solver.simp_rt eval rt in
+    LAT.Resource ((x,(rt1,bt)), i, simp_resource eval more)
   | I i -> I i
 
 
@@ -248,9 +250,11 @@ let state ctxt model_with_q extras =
           | _ -> true)
         diff_res
     in
+    let evaluate it = Solver.eval ctxt.global model it in
+    let pp_res (rt,args) = RE.pp (Interval.Solver.simp_rt evaluate rt, args) in
     let interesting =
-      List.map (fun re -> RE.pp re ^^^ parens !^"same type") same_res
-      @ List.map RE.pp interesting_diff_res
+      List.map (fun re -> pp_res re ^^^ parens !^"same type") same_res
+      @ List.map pp_res interesting_diff_res
     in
     let uninteresting = List.map RE.pp uninteresting_diff_res in
     (interesting, uninteresting)

--- a/backend/cn/lib/explain.ml
+++ b/backend/cn/lib/explain.ml
@@ -220,15 +220,14 @@ let state ctxt model_with_q extras =
           match IT.bt it with BT.Unit -> false | BT.Loc () -> false | _ -> true)
         filtered
     in
-    add_labeled lab_interesting (List.map snd interesting) (
-    add_labeled lab_uninteresting (List.map snd uninteresting) (
-    labeled_empty))
+    add_labeled
+      lab_interesting
+      (List.map snd interesting)
+      (add_labeled lab_uninteresting (List.map snd uninteresting) labeled_empty)
   in
   let constraints =
     let render c =
-          { original = LC.pp c;
-            simplified = List.map LC.pp (simp_constraint evaluate c)
-          }
+      { original = LC.pp c; simplified = List.map LC.pp (simp_constraint evaluate c) }
     in
     let interesting, uninteresting =
       List.partition
@@ -238,11 +237,12 @@ let state ctxt model_with_q extras =
           | LC.T (IT (Representable _, _, _)) -> false
           | LC.T (IT (Good _, _, _)) -> false
           | _ -> true)
-          (LCSet.elements ctxt.constraints)
+        (LCSet.elements ctxt.constraints)
     in
-    add_labeled lab_interesting (List.map render interesting) (
-      add_labeled lab_uninteresting (List.map render uninteresting) (
-        labeled_empty))
+    add_labeled
+      lab_interesting
+      (List.map render interesting)
+      (add_labeled lab_uninteresting (List.map render uninteresting) labeled_empty)
   in
   let resources =
     let same_res, diff_res =
@@ -260,24 +260,22 @@ let state ctxt model_with_q extras =
         diff_res
     in
     let evaluate it = Solver.eval ctxt.global model it in
-    let with_suff mb x =
-      match mb with
-      | None -> x
-      | Some d -> d ^^^ x
-    in
+    let with_suff mb x = match mb with None -> x | Some d -> d ^^^ x in
     let pp_res mb_suff (rt, args) =
-         { original = with_suff mb_suff (RE.pp (rt,args));
-           simplified = [with_suff mb_suff (RE.pp (Interval.Solver.simp_rt evaluate rt, args))]
-         } 
+      { original = with_suff mb_suff (RE.pp (rt, args));
+        simplified =
+          [ with_suff mb_suff (RE.pp (Interval.Solver.simp_rt evaluate rt, args)) ]
+      }
     in
     let interesting =
       List.map (fun re -> pp_res (Some (parens !^"same type")) re) same_res
       @ List.map (pp_res None) interesting_diff_res
     in
     let uninteresting = List.map (pp_res None) uninteresting_diff_res in
-    add_labeled lab_interesting interesting (
-      add_labeled lab_uninteresting uninteresting (
-        labeled_empty))
+    add_labeled
+      lab_interesting
+      interesting
+      (add_labeled lab_uninteresting uninteresting labeled_empty)
   in
   { where; terms; resources; constraints }
 

--- a/backend/cn/lib/explain.ml
+++ b/backend/cn/lib/explain.ml
@@ -220,9 +220,16 @@ let state ctxt model_with_q extras =
           match IT.bt it with BT.Unit -> false | BT.Loc () -> false | _ -> true)
         filtered
     in
-    (List.map snd interesting, List.map snd uninteresting)
+    add_labeled lab_interesting (List.map snd interesting) (
+    add_labeled lab_uninteresting (List.map snd uninteresting) (
+    labeled_empty))
   in
   let constraints =
+    let render c =
+          { original = LC.pp c;
+            simplified = List.map LC.pp (simp_constraint evaluate c)
+          }
+    in
     let interesting, uninteresting =
       List.partition
         (fun lc ->
@@ -231,9 +238,11 @@ let state ctxt model_with_q extras =
           | LC.T (IT (Representable _, _, _)) -> false
           | LC.T (IT (Good _, _, _)) -> false
           | _ -> true)
-        (List.concat_map (simp_constraint evaluate) (LCSet.elements ctxt.constraints))
+          (LCSet.elements ctxt.constraints)
     in
-    (List.map LC.pp interesting, List.map LC.pp uninteresting)
+    add_labeled lab_interesting (List.map render interesting) (
+      add_labeled lab_uninteresting (List.map render uninteresting) (
+        labeled_empty))
   in
   let resources =
     let same_res, diff_res =
@@ -251,13 +260,24 @@ let state ctxt model_with_q extras =
         diff_res
     in
     let evaluate it = Solver.eval ctxt.global model it in
-    let pp_res (rt, args) = RE.pp (Interval.Solver.simp_rt evaluate rt, args) in
-    let interesting =
-      List.map (fun re -> pp_res re ^^^ parens !^"same type") same_res
-      @ List.map pp_res interesting_diff_res
+    let with_suff mb x =
+      match mb with
+      | None -> x
+      | Some d -> d ^^^ x
     in
-    let uninteresting = List.map RE.pp uninteresting_diff_res in
-    (interesting, uninteresting)
+    let pp_res mb_suff (rt, args) =
+         { original = with_suff mb_suff (RE.pp (rt,args));
+           simplified = [with_suff mb_suff (RE.pp (Interval.Solver.simp_rt evaluate rt, args))]
+         } 
+    in
+    let interesting =
+      List.map (fun re -> pp_res (Some (parens !^"same type")) re) same_res
+      @ List.map (pp_res None) interesting_diff_res
+    in
+    let uninteresting = List.map (pp_res None) uninteresting_diff_res in
+    add_labeled lab_interesting interesting (
+      add_labeled lab_uninteresting uninteresting (
+        labeled_empty))
   in
   { where; terms; resources; constraints }
 

--- a/backend/cn/lib/explain.ml
+++ b/backend/cn/lib/explain.ml
@@ -132,9 +132,9 @@ let rec simp_resource eval r =
     else
       LAT.Constraint (ct, info, simp_resource eval more)
   | LAT.Define (x, i, more) -> LAT.Define (x, i, simp_resource eval more)
-  | LAT.Resource ((x,(rt,bt)), i, more) ->
+  | LAT.Resource ((x, (rt, bt)), i, more) ->
     let rt1 = Interval.Solver.simp_rt eval rt in
-    LAT.Resource ((x,(rt1,bt)), i, simp_resource eval more)
+    LAT.Resource ((x, (rt1, bt)), i, simp_resource eval more)
   | I i -> I i
 
 
@@ -251,7 +251,7 @@ let state ctxt model_with_q extras =
         diff_res
     in
     let evaluate it = Solver.eval ctxt.global model it in
-    let pp_res (rt,args) = RE.pp (Interval.Solver.simp_rt evaluate rt, args) in
+    let pp_res (rt, args) = RE.pp (Interval.Solver.simp_rt evaluate rt, args) in
     let interesting =
       List.map (fun re -> pp_res re ^^^ parens !^"same type") same_res
       @ List.map pp_res interesting_diff_res

--- a/backend/cn/lib/interval.ml
+++ b/backend/cn/lib/interval.ml
@@ -1,165 +1,165 @@
-
-
-let both f a b =
-  match a,b with
-  | Some x, Some y -> Some (f x y)
-  | _              -> None
+let both f a b = match (a, b) with Some x, Some y -> Some (f x y) | _ -> None
 
 let either f a b =
-    match a,b with
-    | None, _ -> b
-    | _, None -> a
-    | Some x, Some y -> Some (f x y)
-    
+  match (a, b) with None, _ -> b | _, None -> a | Some x, Some y -> Some (f x y)
+
+
 (* Single continuous interval *)
 module Interval = struct
-
   (* Closed below (unless no lower bound), open above *)
-  type t = { lower: Z.t option; upper: Z.t option }
+  type t =
+    { lower : Z.t option;
+      upper : Z.t option
+    }
 
   let empty = { lower = Some Z.zero; upper = Some Z.zero }
 
   let is_empty i =
-    match i.lower, i.upper with
-    | Some x, Some y -> Z.geq x y
-    | _              -> false
-  
+    match (i.lower, i.upper) with Some x, Some y -> Z.geq x y | _ -> false
+
+
   let is_const i =
-    match i.lower, i.upper with
+    match (i.lower, i.upper) with
     | Some x, Some y when Z.equal (Z.succ x) y -> Some x
     | _ -> None
 
+
   let to_string i =
-      if is_empty i then "[]" else
+    if is_empty i then
+      "[]"
+    else (
       match is_const i with
       | Some i -> "[" ^ Z.to_string i ^ "]"
       | None ->
-          let left = 
-            match i.lower with
-            | None   -> "(-inf"
-            | Some i -> "[" ^ Z.to_string i in
-          let right =
-            match i.upper with
-            | None -> "inf"
-            | Some i -> Z.to_string i in
-          left ^ "," ^ right ^ ")"
+        let left = match i.lower with None -> "(-inf" | Some i -> "[" ^ Z.to_string i in
+        let right = match i.upper with None -> "inf" | Some i -> Z.to_string i in
+        left ^ "," ^ right ^ ")")
+
 
   (* Is the first interval completely below the second one *)
-  let is_known_below i j =
-    Option.value (both Z.leq i.upper j.lower) ~default:false
+  let is_known_below i j = Option.value (both Z.leq i.upper j.lower) ~default:false
 
   let combine i j =
-    if is_empty i || is_empty j then (empty, empty, empty) else
-    if is_known_below i j then (i, empty, j) else
-    if is_known_below j i then (j, empty, i) else
-    let il = either Z.max i.lower j.lower in (* lower bound of intersection *)
-    let left =
-          match il with
-          | None -> empty
-          | Some u -> { lower = both Z.min i.lower j.lower;
-                        upper = Some u } in
-    
-      let iu = either Z.min i.upper j.upper in (* upper bound of intersection *)
+    if is_empty i || is_empty j then
+      (empty, empty, empty)
+    else if is_known_below i j then
+      (i, empty, j)
+    else if is_known_below j i then
+      (j, empty, i)
+    else (
+      let il = either Z.max i.lower j.lower in
+      (* lower bound of intersection *)
+      let left =
+        match il with
+        | None -> empty
+        | Some u -> { lower = both Z.min i.lower j.lower; upper = Some u }
+      in
+      let iu = either Z.min i.upper j.upper in
+      (* upper bound of intersection *)
       let right =
-            match iu with
-            | None -> empty
-            | Some l -> { lower = Some l;
-                          upper = both Z.max i.upper j.upper } in
-      (left, { lower = il; upper = iu }, right)
+        match iu with
+        | None -> empty
+        | Some l -> { lower = Some l; upper = both Z.max i.upper j.upper }
+      in
+      (left, { lower = il; upper = iu }, right))
+
 
   let const k = { lower = Some k; upper = Some (Z.succ k) }
+
   let int = { lower = None; upper = None }
+
   let nat = { lower = Some Z.zero; upper = None }
-  
-  let uint n =
-    { lower = Some Z.zero; upper = Some (Z.shift_left Z.one n) }
-  
+
+  let uint n = { lower = Some Z.zero; upper = Some (Z.shift_left Z.one n) }
+
   let sint n =
-    let u = Z.shift_left Z.one (n-1) in
-    { lower = Some (Z.neg u);
-      upper = Some u }
+    let u = Z.shift_left Z.one (n - 1) in
+    { lower = Some (Z.neg u); upper = Some u }
+
 
   let lt i = { lower = None; upper = Some i }
+
   let gt i = { lower = Some (Z.succ i); upper = None }
 
   let leq i = { lower = None; upper = Some (Z.succ i) }
+
   let geq i = { lower = Some i; upper = None }
-  
 end
-
-
 
 module Intervals = struct
   (* Separated, non-empty, sorted from smallest integers to largest. *)
   type t = Interval.t list
 
   let to_intervals t = t
-  let of_interval i = [i]
+
+  let of_interval i = [ i ]
 
   let rec to_string is =
     match is with
     | [] -> "[]"
-    | [i] -> Interval.to_string i
+    | [ i ] -> Interval.to_string i
     | i :: more -> Interval.to_string i ^ " || " ^ to_string more
 
+
   let rec intersect is js =
-    match is, js with
+    match (is, js) with
     | [], _ -> []
     | _, [] -> []
     | i :: is1, j :: js1 ->
-      let (_below,common,above) = Interval.combine i j in
-      let (is2,js2) =
-          if Interval.is_empty above
-            then (is1,js1)
-            else if Interval.is_known_below i above
-                    then (is1, above :: js1)
-                    else (above :: is, js1) in
-      if Interval.is_empty common
-        then intersect is2 js2
-        else common :: intersect is2 js2
+      let _below, common, above = Interval.combine i j in
+      let is2, js2 =
+        if Interval.is_empty above then
+          (is1, js1)
+        else if Interval.is_known_below i above then
+          (is1, above :: js1)
+        else
+          (above :: is, js1)
+      in
+      if Interval.is_empty common then
+        intersect is2 js2
+      else
+        common :: intersect is2 js2
+
 
   let rec union is js =
-    match is, js with
+    match (is, js) with
     | [], _ -> js
     | _, [] -> is
     | i :: is1, j :: js1 ->
-      let (below,common,above) = Interval.combine i j in
-      let (is2,js2) =
-        if Interval.is_empty above         then (is1, js1) else
-        if Interval.is_known_below i above then (is1, above :: js1) else
-        (above :: is1, js1)
+      let below, common, above = Interval.combine i j in
+      let is2, js2 =
+        if Interval.is_empty above then
+          (is1, js1)
+        else if Interval.is_known_below i above then
+          (is1, above :: js1)
+        else
+          (above :: is1, js1)
       in
       let cons x xs =
-           if Interval.is_empty x then xs else
-           match xs with
-           | [] -> [x]
-           | y :: ys ->
-             match x.upper, y.lower with
+        if Interval.is_empty x then
+          xs
+        else (
+          match xs with
+          | [] -> [ x ]
+          | y :: ys ->
+            (match (x.upper, y.lower) with
              | Some u, Some l when Z.equal u l ->
-                { lower = x.lower; upper = y.upper } :: ys
-             | _ -> x :: xs in
+               { lower = x.lower; upper = y.upper } :: ys
+             | _ -> x :: xs))
+      in
       cons below (cons common (union is2 js2))
 
-  let complement (is: t): t =
-    let rec
-      loop (from: Z.t option) (next: t): t =
-        match next with
-        | [] -> [ { lower = from; upper = None } ]
-        | i :: is ->
-          let rest =
-            match i.upper with
-            | None -> []
-            | u    -> loop u is
-          in
-          match i.lower with
-          | None  -> rest
-          | l     -> { lower = from; upper = l } :: rest
-    in loop None is
 
-
-
+  let complement (is : t) : t =
+    let rec loop (from : Z.t option) (next : t) : t =
+      match next with
+      | [] -> [ { lower = from; upper = None } ]
+      | i :: is ->
+        let rest = match i.upper with None -> [] | u -> loop u is in
+        (match i.lower with None -> rest | l -> { lower = from; upper = l } :: rest)
+    in
+    loop None is
 end
-
 
 module Solver = struct
   module IT = IndexTerms
@@ -167,107 +167,97 @@ module Solver = struct
   open Terms
   open BaseTypes
 
-
-  let interval_for (eval: IT.t -> IT.t option) q tyi =
-    let is_q i =
-      match IT.term i with
-      | Sym y -> Sym.equal q y
-      | _     -> false in
-
+  let interval_for (eval : IT.t -> IT.t option) q tyi =
+    let is_q i = match IT.term i with Sym y -> Sym.equal q y | _ -> false in
     let eval_k e =
-      if IT.SymSet.mem q (IT.free_vars e)
-        then None
-    else Option.bind (eval e) (fun v ->
-         match IT.term v with
-         | Const (Z z) -> Some z
-         | Const (Bits (_,z)) -> Some z
-         | _ -> None) in
-
+      if IT.SymSet.mem q (IT.free_vars e) then
+        None
+      else
+        Option.bind (eval e) (fun v ->
+          match IT.term v with
+          | Const (Z z) -> Some z
+          | Const (Bits (_, z)) -> Some z
+          | _ -> None)
+    in
     let mkI i = Intervals.intersect tyi i in
-
     let var_k f x y =
       let mk b v = mkI (Intervals.of_interval (f b v)) in
       match () with
       | _ when is_q x -> Option.map (mk false) (eval_k y)
-      | _ when is_q y -> Option.map (mk true) (eval_k x) 
+      | _ when is_q y -> Option.map (mk true) (eval_k x)
       | _ -> None
     in
-
     let do_eq = var_k (fun _ -> Interval.const) in
     let do_lt = var_k (fun swap -> if swap then Interval.geq else Interval.lt) in
-    let do_le = var_k (fun swap -> if swap then Interval.gt  else Interval.leq) in
+    let do_le = var_k (fun swap -> if swap then Interval.gt else Interval.leq) in
     let do_compl i = mkI (Intervals.complement i) in
     let do_impl i j = Intervals.union (do_compl i) j in
-
     let rec interval p =
       match IT.term p with
-      | Const (Bool true)       -> Some tyi
-      | Const (Bool false)      -> Some (Intervals.of_interval Interval.empty)
-      | Unop  (Not,term)        -> Option.map do_compl (interval term)
-      | Binop (And,lhs,rhs)     -> both Intervals.intersect (interval lhs) (interval rhs)
-      | Binop (Or,lhs,rhs)      -> both Intervals.union (interval lhs) (interval rhs)
-      | Binop (Implies,lhs,rhs) ->
+      | Const (Bool true) -> Some tyi
+      | Const (Bool false) -> Some (Intervals.of_interval Interval.empty)
+      | Unop (Not, term) -> Option.map do_compl (interval term)
+      | Binop (And, lhs, rhs) -> both Intervals.intersect (interval lhs) (interval rhs)
+      | Binop (Or, lhs, rhs) -> both Intervals.union (interval lhs) (interval rhs)
+      | Binop (Implies, lhs, rhs) ->
         (match eval lhs with
-        | None -> both do_impl (interval lhs) (interval rhs)
-        | Some (IT (Const (Bool b),_,_)) -> if b then interval rhs else Some tyi
-        | _ -> None)
-      | Binop (EQ,lhs,rhs)      -> do_eq lhs rhs
-      | Binop (LT,lhs,rhs)      -> do_lt lhs rhs
-      | Binop (LE,lhs,rhs)      -> do_le lhs rhs
+         | None -> both do_impl (interval lhs) (interval rhs)
+         | Some (IT (Const (Bool b), _, _)) -> if b then interval rhs else Some tyi
+         | _ -> None)
+      | Binop (EQ, lhs, rhs) -> do_eq lhs rhs
+      | Binop (LT, lhs, rhs) -> do_lt lhs rhs
+      | Binop (LE, lhs, rhs) -> do_le lhs rhs
       | _ -> None
-      in
+    in
     interval
 
 
-  let supported_type loc ty: (Interval.t * (Z.t -> IT.t)) option =
+  let supported_type loc ty : (Interval.t * (Z.t -> IT.t)) option =
     let yes i k = Some (i, fun v -> IT (Const (k v), ty, loc)) in
     match ty with
-    | Integer -> yes (Interval.int) (fun v -> Z v) 
-    | Bits (sign,w) -> (
-      match sign with
-      | Signed   -> yes (Interval.sint w) (fun v -> Bits ((sign,w),v))
-      | Unsigned -> yes (Interval.uint w) (fun v -> Bits ((sign,w),v))
-    )
+    | Integer -> yes Interval.int (fun v -> Z v)
+    | Bits (sign, w) ->
+      (match sign with
+       | Signed -> yes (Interval.sint w) (fun v -> Bits ((sign, w), v))
+       | Unsigned -> yes (Interval.uint w) (fun v -> Bits ((sign, w), v)))
     | _ -> None
 
 
-  let simp_rt eval (rt: RT.resource_type): RT.resource_type =
-  match rt with 
-  | RT.P _ -> rt
-  | RT.Q qpred ->
-    let (x,t) = qpred.q in
-    let loc = IT.loc qpred.permission in
-    match supported_type loc t with
-    | None -> rt
-    | Some (tyi,k) ->
-    let xt = IT.sym_ (x,t,loc) in    
-
-    let interval_to_term i =
-      match Interval.is_const i with
-      | Some v -> IT.eq_ (xt, k v) loc
-      | None ->
-        let has_lower =
-             Option.bind i.lower (fun l ->
-            match tyi.lower with
-            | Some tl when Z.equal l tl -> None
-            | _ -> Some (IT.le_ (k l, xt) loc)) in
-        let has_upper =
-            Option.bind i.upper (fun u ->
-              match tyi.upper with
-              | Some tu when Z.equal u tu -> None
-              | _ -> Some (IT.lt_ (xt, k u) loc)) in
-
-        (match has_lower, has_upper with
-        | Some l, Some u -> IT.and2_ (l,u) loc
-        | None, Some u -> u
-        | Some l, None -> l
-        | None, None -> IT.bool_ true loc) in
-    
-    match interval_for eval x (Intervals.of_interval tyi) qpred.permission with
-    | None -> rt
-    | Some is ->
-      let ps = List.map interval_to_term (Intervals.to_intervals is) in
-      RT.Q { qpred with permission = IT.or_ ps loc }
-
+  let simp_rt eval (rt : RT.resource_type) : RT.resource_type =
+    match rt with
+    | RT.P _ -> rt
+    | RT.Q qpred ->
+      let x, t = qpred.q in
+      let loc = IT.loc qpred.permission in
+      (match supported_type loc t with
+       | None -> rt
+       | Some (tyi, k) ->
+         let xt = IT.sym_ (x, t, loc) in
+         let interval_to_term i =
+           match Interval.is_const i with
+           | Some v -> IT.eq_ (xt, k v) loc
+           | None ->
+             let has_lower =
+               Option.bind i.lower (fun l ->
+                 match tyi.lower with
+                 | Some tl when Z.equal l tl -> None
+                 | _ -> Some (IT.le_ (k l, xt) loc))
+             in
+             let has_upper =
+               Option.bind i.upper (fun u ->
+                 match tyi.upper with
+                 | Some tu when Z.equal u tu -> None
+                 | _ -> Some (IT.lt_ (xt, k u) loc))
+             in
+             (match (has_lower, has_upper) with
+              | Some l, Some u -> IT.and2_ (l, u) loc
+              | None, Some u -> u
+              | Some l, None -> l
+              | None, None -> IT.bool_ true loc)
+         in
+         (match interval_for eval x (Intervals.of_interval tyi) qpred.permission with
+          | None -> rt
+          | Some is ->
+            let ps = List.map interval_to_term (Intervals.to_intervals is) in
+            RT.Q { qpred with permission = IT.or_ ps loc }))
 end
-

--- a/backend/cn/lib/interval.ml
+++ b/backend/cn/lib/interval.ml
@@ -1,0 +1,273 @@
+
+
+let both f a b =
+  match a,b with
+  | Some x, Some y -> Some (f x y)
+  | _              -> None
+
+let either f a b =
+    match a,b with
+    | None, _ -> b
+    | _, None -> a
+    | Some x, Some y -> Some (f x y)
+    
+(* Single continuous interval *)
+module Interval = struct
+
+  (* Closed below (unless no lower bound), open above *)
+  type t = { lower: Z.t option; upper: Z.t option }
+
+  let empty = { lower = Some Z.zero; upper = Some Z.zero }
+
+  let is_empty i =
+    match i.lower, i.upper with
+    | Some x, Some y -> Z.geq x y
+    | _              -> false
+  
+  let is_const i =
+    match i.lower, i.upper with
+    | Some x, Some y when Z.equal (Z.succ x) y -> Some x
+    | _ -> None
+
+  let to_string i =
+      if is_empty i then "[]" else
+      match is_const i with
+      | Some i -> "[" ^ Z.to_string i ^ "]"
+      | None ->
+          let left = 
+            match i.lower with
+            | None   -> "(-inf"
+            | Some i -> "[" ^ Z.to_string i in
+          let right =
+            match i.upper with
+            | None -> "inf"
+            | Some i -> Z.to_string i in
+          left ^ "," ^ right ^ ")"
+
+  (* Is the first interval completely below the second one *)
+  let is_known_below i j =
+    Option.value (both Z.leq i.upper j.lower) ~default:false
+
+  let combine i j =
+    if is_empty i || is_empty j then (empty, empty, empty) else
+    if is_known_below i j then (i, empty, j) else
+    if is_known_below j i then (j, empty, i) else
+    let il = either Z.max i.lower j.lower in (* lower bound of intersection *)
+    let left =
+          match il with
+          | None -> empty
+          | Some u -> { lower = both Z.min i.lower j.lower;
+                        upper = Some u } in
+    
+      let iu = either Z.min i.upper j.upper in (* upper bound of intersection *)
+      let right =
+            match iu with
+            | None -> empty
+            | Some l -> { lower = Some l;
+                          upper = both Z.max i.upper j.upper } in
+      (left, { lower = il; upper = iu }, right)
+
+  let const k = { lower = Some k; upper = Some (Z.succ k) }
+  let int = { lower = None; upper = None }
+  let nat = { lower = Some Z.zero; upper = None }
+  
+  let uint n =
+    { lower = Some Z.zero; upper = Some (Z.shift_left Z.one n) }
+  
+  let sint n =
+    let u = Z.shift_left Z.one (n-1) in
+    { lower = Some (Z.neg u);
+      upper = Some u }
+
+  let lt i = { lower = None; upper = Some i }
+  let gt i = { lower = Some (Z.succ i); upper = None }
+
+  let leq i = { lower = None; upper = Some (Z.succ i) }
+  let geq i = { lower = Some i; upper = None }
+  
+end
+
+
+
+module Intervals = struct
+  (* Separated, non-empty, sorted from smallest integers to largest. *)
+  type t = Interval.t list
+
+  let to_intervals t = t
+  let of_interval i = [i]
+
+  let rec to_string is =
+    match is with
+    | [] -> "[]"
+    | [i] -> Interval.to_string i
+    | i :: more -> Interval.to_string i ^ " || " ^ to_string more
+
+  let rec intersect is js =
+    match is, js with
+    | [], _ -> []
+    | _, [] -> []
+    | i :: is1, j :: js1 ->
+      let (_below,common,above) = Interval.combine i j in
+      let (is2,js2) =
+          if Interval.is_empty above
+            then (is1,js1)
+            else if Interval.is_known_below i above
+                    then (is1, above :: js1)
+                    else (above :: is, js1) in
+      if Interval.is_empty common
+        then intersect is2 js2
+        else common :: intersect is2 js2
+
+  let rec union is js =
+    match is, js with
+    | [], _ -> js
+    | _, [] -> is
+    | i :: is1, j :: js1 ->
+      let (below,common,above) = Interval.combine i j in
+      let (is2,js2) =
+        if Interval.is_empty above         then (is1, js1) else
+        if Interval.is_known_below i above then (is1, above :: js1) else
+        (above :: is1, js1)
+      in
+      let cons x xs =
+           if Interval.is_empty x then xs else
+           match xs with
+           | [] -> [x]
+           | y :: ys ->
+             match x.upper, y.lower with
+             | Some u, Some l when Z.equal u l ->
+                { lower = x.lower; upper = y.upper } :: ys
+             | _ -> x :: xs in
+      cons below (cons common (union is2 js2))
+
+  let complement (is: t): t =
+    let rec
+      loop (from: Z.t option) (next: t): t =
+        match next with
+        | [] -> [ { lower = from; upper = None } ]
+        | i :: is ->
+          let rest =
+            match i.upper with
+            | None -> []
+            | u    -> loop u is
+          in
+          match i.lower with
+          | None  -> rest
+          | l     -> { lower = from; upper = l } :: rest
+    in loop None is
+
+
+
+end
+
+
+module Solver = struct
+  module IT = IndexTerms
+  module RT = ResourceTypes
+  open Terms
+  open BaseTypes
+
+
+  let interval_for (eval: IT.t -> IT.t option) q tyi =
+    let is_q i =
+      match IT.term i with
+      | Sym y -> Sym.equal q y
+      | _     -> false in
+
+    let eval_k e =
+      if IT.SymSet.mem q (IT.free_vars e)
+        then None
+    else Option.bind (eval e) (fun v ->
+         match IT.term v with
+         | Const (Z z) -> Some z
+         | Const (Bits (_,z)) -> Some z
+         | _ -> None) in
+
+    let mkI i = Intervals.intersect tyi i in
+
+    let var_k f x y =
+      let mk b v = mkI (Intervals.of_interval (f b v)) in
+      match () with
+      | _ when is_q x -> Option.map (mk false) (eval_k y)
+      | _ when is_q y -> Option.map (mk true) (eval_k x) 
+      | _ -> None
+    in
+
+    let do_eq = var_k (fun _ -> Interval.const) in
+    let do_lt = var_k (fun swap -> if swap then Interval.geq else Interval.lt) in
+    let do_le = var_k (fun swap -> if swap then Interval.gt  else Interval.leq) in
+    let do_compl i = mkI (Intervals.complement i) in
+    let do_impl i j = Intervals.union (do_compl i) j in
+
+    let rec interval p =
+      match IT.term p with
+      | Const (Bool true)       -> Some tyi
+      | Const (Bool false)      -> Some (Intervals.of_interval Interval.empty)
+      | Unop  (Not,term)        -> Option.map do_compl (interval term)
+      | Binop (And,lhs,rhs)     -> both Intervals.intersect (interval lhs) (interval rhs)
+      | Binop (Or,lhs,rhs)      -> both Intervals.union (interval lhs) (interval rhs)
+      | Binop (Implies,lhs,rhs) ->
+        (match eval lhs with
+        | None -> both do_impl (interval lhs) (interval rhs)
+        | Some (IT (Const (Bool b),_,_)) -> if b then interval rhs else Some tyi
+        | _ -> None)
+      | Binop (EQ,lhs,rhs)      -> do_eq lhs rhs
+      | Binop (LT,lhs,rhs)      -> do_lt lhs rhs
+      | Binop (LE,lhs,rhs)      -> do_le lhs rhs
+      | _ -> None
+      in
+    interval
+
+
+  let supported_type loc ty: (Interval.t * (Z.t -> IT.t)) option =
+    let yes i k = Some (i, fun v -> IT (Const (k v), ty, loc)) in
+    match ty with
+    | Integer -> yes (Interval.int) (fun v -> Z v) 
+    | Bits (sign,w) -> (
+      match sign with
+      | Signed   -> yes (Interval.sint w) (fun v -> Bits ((sign,w),v))
+      | Unsigned -> yes (Interval.uint w) (fun v -> Bits ((sign,w),v))
+    )
+    | _ -> None
+
+
+  let simp_rt eval (rt: RT.resource_type): RT.resource_type =
+  match rt with 
+  | RT.P _ -> rt
+  | RT.Q qpred ->
+    let (x,t) = qpred.q in
+    let loc = IT.loc qpred.permission in
+    match supported_type loc t with
+    | None -> rt
+    | Some (tyi,k) ->
+    let xt = IT.sym_ (x,t,loc) in    
+
+    let interval_to_term i =
+      match Interval.is_const i with
+      | Some v -> IT.eq_ (xt, k v) loc
+      | None ->
+        let has_lower =
+             Option.bind i.lower (fun l ->
+            match tyi.lower with
+            | Some tl when Z.equal l tl -> None
+            | _ -> Some (IT.le_ (k l, xt) loc)) in
+        let has_upper =
+            Option.bind i.upper (fun u ->
+              match tyi.upper with
+              | Some tu when Z.equal u tu -> None
+              | _ -> Some (IT.lt_ (xt, k u) loc)) in
+
+        (match has_lower, has_upper with
+        | Some l, Some u -> IT.and2_ (l,u) loc
+        | None, Some u -> u
+        | Some l, None -> l
+        | None, None -> IT.bool_ true loc) in
+    
+    match interval_for eval x (Intervals.of_interval tyi) qpred.permission with
+    | None -> rt
+    | Some is ->
+      let ps = List.map interval_to_term (Intervals.to_intervals is) in
+      RT.Q { qpred with permission = IT.or_ ps loc }
+
+end
+

--- a/backend/cn/lib/interval.ml
+++ b/backend/cn/lib/interval.ml
@@ -188,8 +188,8 @@ module Solver = struct
       | _ -> None
     in
     let do_eq = var_k (fun _ -> Interval.const) in
-    let do_lt = var_k (fun swap -> if swap then Interval.geq else Interval.lt) in
-    let do_le = var_k (fun swap -> if swap then Interval.gt else Interval.leq) in
+    let do_lt = var_k (fun swap -> if swap then Interval.gt else Interval.lt) in
+    let do_le = var_k (fun swap -> if swap then Interval.geq else Interval.leq) in
     let do_compl i = mkI (Intervals.complement i) in
     let do_impl i j = Intervals.union (do_compl i) j in
     let rec interval p =

--- a/backend/cn/lib/interval.mli
+++ b/backend/cn/lib/interval.mli
@@ -1,0 +1,90 @@
+
+module Interval: sig
+  (** A interval on integers *)
+  type t
+
+  (** Empty interval *)
+  val empty: t
+
+  (** A singleton interval containing just the given integer. *)
+  val const: Z.t -> t
+
+  (** Entire integer range *)
+  val int: t
+
+  (** Non-negative numbers *)
+  val nat: t
+
+  (** [uint n] is the interval for unsigned integers of [n] bits. [n >= 0] *)
+  val uint: int -> t
+
+  (** [sint n] is the interval for signed integers of [n] bits. [n >= 1] *)
+  val sint: int -> t
+
+  (** Integers less than the given one *)
+  val lt: Z.t -> t
+
+  (** Integers greater than the given one *)
+  val gt: Z.t -> t
+
+  (** Integers less-than or equal-to the given one *)
+  val leq: Z.t -> t
+
+  (** Integers greater-than or equal-to the given one *)
+  val geq: Z.t -> t
+
+  (** [combine i j] is a triple [(below,common,above)] where
+    [common] is the values in both intervals, [below] is the smaller values
+    that are only in one of intervals, and [above] are the larger values
+    that are only in one of the intervals. *)
+  val combine: t -> t -> t * t * t
+
+  (** Is this interval empty *)
+  val is_empty: t -> bool
+
+  (** Is this a singleton interval. *)
+  val is_const: t -> Z.t option
+
+  (** [true] if the first interval is completely below the second
+      (i.e., the two do not overlap) *)
+  val is_known_below: t -> t -> bool
+
+  (** String rendition of an interval *)
+  val to_string: t -> string
+
+end
+
+
+module Intervals: sig
+  (** A subset of the integers *)
+  type t
+
+  (** A single interval *)
+  val of_interval: Interval.t -> t
+
+  (** The intervals for this type.  Empty list if the interval is empty.
+      The intervals are disjoint, separated, sorted. *)
+  val to_intervals: t -> Interval.t list
+
+  (** Intersection of two integer subsets *)
+  val intersect: t -> t -> t
+
+  (** Union of two integer subsets *)
+  val union: t -> t -> t
+
+  (** Complement of two integer subsets *)
+  val complement: t -> t
+
+  (** Convert to string *)
+  val to_string: t -> string
+end
+
+module Solver: sig
+  module IT = IndexTerms
+  module RT = ResourceTypes
+
+ (** Try to simplify a resource type *)
+ val simp_rt:
+    (IT.t -> IT.t option) -> RT.resource_type -> RT.resource_type
+
+end

--- a/backend/cn/lib/interval.mli
+++ b/backend/cn/lib/interval.mli
@@ -1,90 +1,85 @@
-
-module Interval: sig
+module Interval : sig
   (** A interval on integers *)
   type t
 
   (** Empty interval *)
-  val empty: t
+  val empty : t
 
   (** A singleton interval containing just the given integer. *)
-  val const: Z.t -> t
+  val const : Z.t -> t
 
   (** Entire integer range *)
-  val int: t
+  val int : t
 
   (** Non-negative numbers *)
-  val nat: t
+  val nat : t
 
   (** [uint n] is the interval for unsigned integers of [n] bits. [n >= 0] *)
-  val uint: int -> t
+  val uint : int -> t
 
   (** [sint n] is the interval for signed integers of [n] bits. [n >= 1] *)
-  val sint: int -> t
+  val sint : int -> t
 
   (** Integers less than the given one *)
-  val lt: Z.t -> t
+  val lt : Z.t -> t
 
   (** Integers greater than the given one *)
-  val gt: Z.t -> t
+  val gt : Z.t -> t
 
   (** Integers less-than or equal-to the given one *)
-  val leq: Z.t -> t
+  val leq : Z.t -> t
 
   (** Integers greater-than or equal-to the given one *)
-  val geq: Z.t -> t
+  val geq : Z.t -> t
 
   (** [combine i j] is a triple [(below,common,above)] where
-    [common] is the values in both intervals, [below] is the smaller values
-    that are only in one of intervals, and [above] are the larger values
-    that are only in one of the intervals. *)
-  val combine: t -> t -> t * t * t
+      [common] is the values in both intervals, [below] is the smaller values
+      that are only in one of intervals, and [above] are the larger values
+      that are only in one of the intervals. *)
+  val combine : t -> t -> t * t * t
 
   (** Is this interval empty *)
-  val is_empty: t -> bool
+  val is_empty : t -> bool
 
   (** Is this a singleton interval. *)
-  val is_const: t -> Z.t option
+  val is_const : t -> Z.t option
 
   (** [true] if the first interval is completely below the second
       (i.e., the two do not overlap) *)
-  val is_known_below: t -> t -> bool
+  val is_known_below : t -> t -> bool
 
   (** String rendition of an interval *)
-  val to_string: t -> string
-
+  val to_string : t -> string
 end
 
-
-module Intervals: sig
+module Intervals : sig
   (** A subset of the integers *)
   type t
 
   (** A single interval *)
-  val of_interval: Interval.t -> t
+  val of_interval : Interval.t -> t
 
   (** The intervals for this type.  Empty list if the interval is empty.
       The intervals are disjoint, separated, sorted. *)
-  val to_intervals: t -> Interval.t list
+  val to_intervals : t -> Interval.t list
 
   (** Intersection of two integer subsets *)
-  val intersect: t -> t -> t
+  val intersect : t -> t -> t
 
   (** Union of two integer subsets *)
-  val union: t -> t -> t
+  val union : t -> t -> t
 
   (** Complement of two integer subsets *)
-  val complement: t -> t
+  val complement : t -> t
 
   (** Convert to string *)
-  val to_string: t -> string
+  val to_string : t -> string
 end
 
-module Solver: sig
+module Solver : sig
   module IT = IndexTerms
   module RT = ResourceTypes
 
- (** Try to simplify a resource type *)
- val simp_rt:
-    (IT.t -> IT.t option) -> RT.resource_type -> RT.resource_type
-
+  (** Try to simplify a resource type *)
+  val simp_rt : (IT.t -> IT.t option) -> RT.resource_type -> RT.resource_type
 end

--- a/backend/cn/lib/report.ml
+++ b/backend/cn/lib/report.ml
@@ -20,12 +20,28 @@ type where_report =
     loc_head : string (* loc_pos: string; *)
   }
 
+(* Different forms of a document. *)
+type simp_view = {
+  original:   Pp.document;        (* original view *)
+  simplified: Pp.document list;   (* simplified based on model *)
+}
+
+type label = string
+let lab_interesting: label = "interesting"
+let lab_uninteresting: label = "uninteresting"
+module StrMap = Map.Make(String)
+
+(* Things classified in various ways. 
+   To start we just have "interesting" and "uninteresting", but we could add more *)
+type 'a labeled_view = ('a list) StrMap.t
+let labeled_empty = StrMap.empty
+let add_labeled lab view mp = StrMap.add lab view mp
+
 type state_report =
   { where : where_report;
-    (* variables : var_entry list; *)
-    resources : Pp.document list * Pp.document list;
-    constraints : Pp.document list * Pp.document list; (* interesting/uninteresting *)
-    terms : term_entry list * term_entry list
+    resources : simp_view labeled_view;
+    constraints : simp_view labeled_view;
+    terms : term_entry labeled_view
   }
 
 type report =
@@ -139,52 +155,38 @@ let make_predicate_hints predicate_hints =
 (*         (List.map (fun re -> [Pp.plain re.res; Pp.plain re.res_span]) resources) *)
 (*   ) *)
 
-let interesting_uninteresting
-  (interesting_table, interesting_data)
-  (uninteresting_table, uninteresting_data)
-  =
-  match (interesting_data, uninteresting_data) with
-  | [], [] -> "(none)"
-  | _, [] -> interesting_table
-  | [], _ -> details "more" uninteresting_table
-  | _, _ -> interesting_table ^ details "more" uninteresting_table
+let interesting_uninteresting mk_table render data =
+  let get_data lab =
+      match StrMap.find_opt lab data with
+      | None    -> ("", true)
+      | Some xs -> (mk_table (List.map render xs), List.is_empty xs)
+  in
+  let (interesting_table, no_interesting) = get_data lab_interesting in
+  let (uninteresting_table, no_uninteresting) = get_data lab_uninteresting in
+  match (no_interesting, no_uninteresting) with
+  | true, true -> "(none)"
+  | _, true    -> interesting_table
+  | true, _    -> details "more" uninteresting_table
+  | _, _       -> interesting_table ^ details "more" uninteresting_table
+
+let simp_view s =
+  let btn  = div ~clss:"toggle" [] in
+  let val_orig = Pp.plain s.original in
+  let val_simp = Pp.plain (Pp.separate Pp.hardline s.simplified) in
+  if String.equal val_orig val_simp
+      then [val_orig] 
+      else [div [btn; div [val_simp]; div [val_orig]]]
 
 
-let make_resources (interesting, uninteresting) =
-  let make = List.map (fun re -> [ Pp.plain re (* Pp.plain re.res_span *) ]) in
-  let interesting_table = table_without_head (make interesting) in
-  let uninteresting_table = table_without_head (make uninteresting) in
-  h
-    1
-    "Available resources"
-    (interesting_uninteresting
-       (interesting_table, interesting)
-       (uninteresting_table, uninteresting))
+let make_resources rs =
+  h 1 "Available resources" (interesting_uninteresting table_without_head simp_view rs)
 
+let make_terms ts =
+  let render v = [ Pp.plain v.term; Pp.plain v.value ] in
+  h 1 "Terms" (interesting_uninteresting (table ["term"; "value"]) render ts)
 
-let make_terms (interesting, uninteresting) =
-  let make = List.map (fun v -> [ Pp.plain v.term; Pp.plain v.value ]) in
-  let interesting_table = table [ "term"; "value" ] (make interesting) in
-  let uninteresting_table = table [ "term"; "value" ] (make uninteresting) in
-  h
-    1
-    "Terms"
-    (interesting_uninteresting
-       (interesting_table, interesting)
-       (uninteresting_table, uninteresting))
-
-
-let make_constraints (interesting, uninteresting) =
-  let make = List.map (fun c -> [ Pp.plain c ]) in
-  let interesting_table = table_without_head (make interesting) in
-  let uninteresting_table = table_without_head (make uninteresting) in
-  h
-    1
-    "Constraints"
-    (interesting_uninteresting
-       (interesting_table, interesting)
-       (uninteresting_table, uninteresting))
-
+let make_constraints cs =
+  h 1 "Constraints" (interesting_uninteresting table_without_head simp_view cs)
 
 let css =
   {|
@@ -271,6 +273,13 @@ th {
 .menu button {
   all: unset;
   padding: 7px;
+}
+
+.toggle {
+  border-radius: 2px;
+  display: inline-block;
+  font-size: small;
+  cursor: pointer;
 }
 
 #pageinfo {
@@ -374,6 +383,11 @@ th {
     color: rgb(150, 150, 150);
     background-color: rgb(50, 50, 50);
   }
+  
+  .toggle {
+    background-color: #CCCCCC;
+    color: black;
+  }
 }
 
 @media (prefers-color-scheme: light) {
@@ -421,6 +435,11 @@ th {
     width: 35px;
     color: rgb(150, 150, 150);
     background-color: rgb(230, 230, 230);
+  }
+
+  .toggle {
+    background-color: #333333;
+    color: white;
   }
 }
 |}
@@ -581,7 +600,32 @@ function create_line(n, str) {
   return ret
 }
 
+function make_toggles(className, labels) {     
+  for(const btn of document.getElementsByClassName(className)) {
+    const opts = []
+    for (let i = btn.nextSibling; i !== null; i = i.nextSibling) {
+      i.classList.add("hidden")
+      opts.push(i)
+    }
+    console.log(opts)
+    let cur = 0
+    function update() {
+      cur %= opts.length
+      const lab = labels && labels[cur] || ("Option " + (cur + 1))
+      btn.textContent = lab
+      opts[cur].classList.remove("hidden")
+    }
+    btn.addEventListener("click", () => {
+      opts[cur].classList.add("hidden")
+      ++cur
+      update()
+    })
+    update()
+  }
+}
+
 function init() {
+  make_toggles("toggle",["Simplified","Original"])
   lines = cn_code.textContent.split("\n")
   lines.forEach((e, n) => {
     if (n == 0) {

--- a/backend/cn/lib/report.ml
+++ b/backend/cn/lib/report.ml
@@ -21,20 +21,25 @@ type where_report =
   }
 
 (* Different forms of a document. *)
-type simp_view = {
-  original:   Pp.document;        (* original view *)
-  simplified: Pp.document list;   (* simplified based on model *)
-}
+type simp_view =
+  { original : Pp.document; (* original view *)
+    simplified : Pp.document list (* simplified based on model *)
+  }
 
 type label = string
-let lab_interesting: label = "interesting"
-let lab_uninteresting: label = "uninteresting"
-module StrMap = Map.Make(String)
 
-(* Things classified in various ways. 
+let lab_interesting : label = "interesting"
+
+let lab_uninteresting : label = "uninteresting"
+
+module StrMap = Map.Make (String)
+
+(* Things classified in various ways.
    To start we just have "interesting" and "uninteresting", but we could add more *)
-type 'a labeled_view = ('a list) StrMap.t
+type 'a labeled_view = 'a list StrMap.t
+
 let labeled_empty = StrMap.empty
+
 let add_labeled lab view mp = StrMap.add lab view mp
 
 type state_report =
@@ -157,36 +162,41 @@ let make_predicate_hints predicate_hints =
 
 let interesting_uninteresting mk_table render data =
   let get_data lab =
-      match StrMap.find_opt lab data with
-      | None    -> ("", true)
-      | Some xs -> (mk_table (List.map render xs), List.is_empty xs)
+    match StrMap.find_opt lab data with
+    | None -> ("", true)
+    | Some xs -> (mk_table (List.map render xs), List.is_empty xs)
   in
-  let (interesting_table, no_interesting) = get_data lab_interesting in
-  let (uninteresting_table, no_uninteresting) = get_data lab_uninteresting in
+  let interesting_table, no_interesting = get_data lab_interesting in
+  let uninteresting_table, no_uninteresting = get_data lab_uninteresting in
   match (no_interesting, no_uninteresting) with
   | true, true -> "(none)"
-  | _, true    -> interesting_table
-  | true, _    -> details "more" uninteresting_table
-  | _, _       -> interesting_table ^ details "more" uninteresting_table
+  | _, true -> interesting_table
+  | true, _ -> details "more" uninteresting_table
+  | _, _ -> interesting_table ^ details "more" uninteresting_table
+
 
 let simp_view s =
-  let btn  = div ~clss:"toggle" [] in
+  let btn = div ~clss:"toggle" [] in
   let val_orig = Pp.plain s.original in
   let val_simp = Pp.plain (Pp.separate Pp.hardline s.simplified) in
-  if String.equal val_orig val_simp
-      then [val_orig] 
-      else [div [btn; div [val_simp]; div [val_orig]]]
+  if String.equal val_orig val_simp then
+    [ val_orig ]
+  else
+    [ div [ btn; div [ val_simp ]; div [ val_orig ] ] ]
 
 
 let make_resources rs =
   h 1 "Available resources" (interesting_uninteresting table_without_head simp_view rs)
 
+
 let make_terms ts =
   let render v = [ Pp.plain v.term; Pp.plain v.value ] in
-  h 1 "Terms" (interesting_uninteresting (table ["term"; "value"]) render ts)
+  h 1 "Terms" (interesting_uninteresting (table [ "term"; "value" ]) render ts)
+
 
 let make_constraints cs =
   h 1 "Constraints" (interesting_uninteresting table_without_head simp_view cs)
+
 
 let css =
   {|

--- a/backend/cn/lib/report.mli
+++ b/backend/cn/lib/report.mli
@@ -24,30 +24,28 @@ type where_report =
   }
 
 (** Different forms of a document. *)
-type simp_view = {
-  original:   Pp.document;     (* original view *)
-  simplified: Pp.document list (* simplified based on model *)
-}
-
+type simp_view =
+  { original : Pp.document; (* original view *)
+    simplified : Pp.document list (* simplified based on model *)
+  }
 
 (** Labels for classifying itesm in a view *)
 type label
 
 (** Interesting things that are shown by default *)
-val lab_interesting: label
+val lab_interesting : label
 
 (** Uninteresting things that are hidden by default *)
-val lab_uninteresting: label
+val lab_uninteresting : label
 
 (** A collection of labeled things *)
 type 'a labeled_view
 
 (** Empty collection of labeld things *)
-val labeled_empty: 'a labeled_view
+val labeled_empty : 'a labeled_view
 
 (** Set the entities assocaited with a lable *)
-val add_labeled: label -> 'a list -> 'a labeled_view -> 'a labeled_view
-
+val add_labeled : label -> 'a list -> 'a labeled_view -> 'a labeled_view
 
 (** Information about a specific state of the computation.
     The resources, constraints, and terms are pairs because they classify
@@ -57,7 +55,7 @@ type state_report =
   { where : where_report; (** Location information *)
     resources : simp_view labeled_view;
     constraints : simp_view labeled_view;
-    terms : term_entry labeled_view;
+    terms : term_entry labeled_view
   }
 
 (** Parts of an HTML rendering of an error. *)

--- a/backend/cn/lib/report.mli
+++ b/backend/cn/lib/report.mli
@@ -23,15 +23,41 @@ type where_report =
     loc_head : string (** Name of what we are currently processing *)
   }
 
+(** Different forms of a document. *)
+type simp_view = {
+  original:   Pp.document;     (* original view *)
+  simplified: Pp.document list (* simplified based on model *)
+}
+
+
+(** Labels for classifying itesm in a view *)
+type label
+
+(** Interesting things that are shown by default *)
+val lab_interesting: label
+
+(** Uninteresting things that are hidden by default *)
+val lab_uninteresting: label
+
+(** A collection of labeled things *)
+type 'a labeled_view
+
+(** Empty collection of labeld things *)
+val labeled_empty: 'a labeled_view
+
+(** Set the entities assocaited with a lable *)
+val add_labeled: label -> 'a list -> 'a labeled_view -> 'a labeled_view
+
+
 (** Information about a specific state of the computation.
     The resources, constraints, and terms are pairs because they classify
     how relevant the thing might be:
     the first component is "interesting", the second is not. *)
 type state_report =
   { where : where_report; (** Location information *)
-    resources : Pp.document list * Pp.document list; (** Resources *)
-    constraints : Pp.document list * Pp.document list; (** Constraints *)
-    terms : term_entry list * term_entry list (** Term values *)
+    resources : simp_view labeled_view;
+    constraints : simp_view labeled_view;
+    terms : term_entry labeled_view;
   }
 
 (** Parts of an HTML rendering of an error. *)


### PR DESCRIPTION
Improves the situation with #389, fixes #351

This modifies `explain.ml` to call a function on quantified resource predicates, which simplifies their permission fields.
The idea is to compute the intervals based on the current model and present them in a normalized form.

For example, previously we would print:
```
each(u64 i; 0'u64 <= i && i < 48'u64 /* 0x30 */ && i != 0'u64 && !(true && 0'u64 <= i && i < 32'u64 /* 0x20 */) && i != 32'u64 /* 0x20 */)
```
after simplification we get:
```
each(u64 i; 1'u64 <= i && i < 32'u64 /* 0x20 */ || 33'u64 /* 0x21 */ <= i && i < 48'u64 /* 0x30 */)
```