### PR TITLE
Fixes #563

### DIFF
--- a/backend/cn/lib/dune
+++ b/backend/cn/lib/dune
@@ -15,8 +15,7 @@
   ocamlgraph
   result
   str
-  unix
-  z3)
+  unix)
  (preprocess
   (pps
    ppx_deriving.eq


### PR DESCRIPTION
Just remove the `dune` dependency on `z3` as we are using the solver in a separate process at the moment.