### PR TITLE
Inconsistent assumptions in labels again

### DIFF
--- a/tests/cn/previously_inconsistent_assumptions1.c
+++ b/tests/cn/previously_inconsistent_assumptions1.c
@@ -1,0 +1,13 @@
+/*@ https://github.com/rems-project/cerberus/issues/566 *@/
+
+struct in_addr {
+    int s_addr;  // load with inet_aton()
+};
+ 
+ 
+extern int test(struct in_addr* addr);
+/*@
+  spec test(pointer addr);
+  requires take x =Owned<struct in_addr>(addr);
+  ensures take x2 =Owned<struct in_addr>(addr);
+@*/

--- a/tests/cn/previously_inconsistent_assumptions1.c
+++ b/tests/cn/previously_inconsistent_assumptions1.c
@@ -1,4 +1,4 @@
-/*@ https://github.com/rems-project/cerberus/issues/566 *@/
+/* https://github.com/rems-project/cerberus/issues/566 */
 
 struct in_addr {
     int s_addr;  // load with inet_aton()

--- a/tests/cn/previously_inconsistent_assumptions2.c
+++ b/tests/cn/previously_inconsistent_assumptions2.c
@@ -1,0 +1,13 @@
+/*@ https://github.com/rems-project/cerberus/issues/551 @*/
+
+int s; 
+void a() 
+/*@
+  accesses s; 
+@*/
+{ 
+  while ( 1 )  // Same bug with for(;;) 
+  {
+    ; 
+  }
+}

--- a/tests/cn/previously_inconsistent_assumptions2.c
+++ b/tests/cn/previously_inconsistent_assumptions2.c
@@ -1,4 +1,4 @@
-/*@ https://github.com/rems-project/cerberus/issues/551 @*/
+/* https://github.com/rems-project/cerberus/issues/551 */
 
 int s; 
 void a() 

--- a/tests/run-cn-exec.sh
+++ b/tests/run-cn-exec.sh
@@ -93,6 +93,8 @@ SUCCESS=$(find cn -name '*.c' \
     ! -name "alloc_token.c" \
     ! -name "ptr_diff.c" \
     ! -name "mask_ptr.c" \
+    ! -name "previously_inconsistent_assumptions1.c" \
+    ! -name "previously_inconsistent_assumptions2.c" \
 )
 
 # Include files which cause error for proof but not testing
@@ -150,6 +152,8 @@ BUGGY="cn/division_casting.c \
        cn/alloc_token.c \
        cn/ptr_diff.c \
        cn/mask_ptr.c \
+       cn/previously_inconsistent_assumptions1.c \
+       cn/previously_inconsistent_assumptions2.c \
        "
 
 # Exclude files which cause error for proof but not testing


### PR DESCRIPTION
One more fix to CN's logic for detecting inconsistent assumptions, plus two tests by @septract that showed the previous problems.