### PR TITLE
[CN-exec] Fix CN map set

### DIFF
--- a/backend/cn/lib/cn_internal_to_ail.ml
+++ b/backend/cn/lib/cn_internal_to_ail.ml
@@ -1218,10 +1218,16 @@ let rec cn_to_ail_expr_aux_internal
     let b3, s3, e3 =
       cn_to_ail_expr_aux_internal const_prop pred_name dts globals value PassBack
     in
-    let map_set_fcall =
-      A.(AilEcall (mk_expr (AilEident (Sym.fresh_pretty "cn_map_set")), [ e1; e2; e3 ]))
+    let new_map_sym = Sym.fresh () in 
+    let new_map_binding = create_binding new_map_sym (bt_to_ail_ctype (IT.bt m)) in 
+    let map_deep_copy_fcall = 
+      A.(AilEcall (mk_expr (AilEident (Sym.fresh_pretty "cn_map_deep_copy")), [ e1 ]))
     in
-    dest d (b1 @ b2 @ b3, s1 @ s2 @ s3, mk_expr map_set_fcall)
+    let new_map_decl = A.(AilSdeclaration [(new_map_sym, Some (mk_expr map_deep_copy_fcall))]) in 
+    let map_set_fcall =
+      A.(AilEcall (mk_expr (AilEident (Sym.fresh_pretty "cn_map_set")), [ (mk_expr A.(AilEident new_map_sym)); e2; e3 ]))
+    in
+    dest d (b1 @ b2 @ b3 @ [new_map_binding], s1 @ s2 @ s3 @ [new_map_decl], mk_expr map_set_fcall)
   | MapGet (m, key) ->
     (* Only works when index is a cn_integer *)
     let b1, s1, e1 =

--- a/backend/cn/lib/cn_internal_to_ail.ml
+++ b/backend/cn/lib/cn_internal_to_ail.ml
@@ -1218,16 +1218,25 @@ let rec cn_to_ail_expr_aux_internal
     let b3, s3, e3 =
       cn_to_ail_expr_aux_internal const_prop pred_name dts globals value PassBack
     in
-    let new_map_sym = Sym.fresh () in 
-    let new_map_binding = create_binding new_map_sym (bt_to_ail_ctype (IT.bt m)) in 
-    let map_deep_copy_fcall = 
+    let new_map_sym = Sym.fresh () in
+    let new_map_binding = create_binding new_map_sym (bt_to_ail_ctype (IT.bt m)) in
+    let map_deep_copy_fcall =
       A.(AilEcall (mk_expr (AilEident (Sym.fresh_pretty "cn_map_deep_copy")), [ e1 ]))
     in
-    let new_map_decl = A.(AilSdeclaration [(new_map_sym, Some (mk_expr map_deep_copy_fcall))]) in 
-    let map_set_fcall =
-      A.(AilEcall (mk_expr (AilEident (Sym.fresh_pretty "cn_map_set")), [ (mk_expr A.(AilEident new_map_sym)); e2; e3 ]))
+    let new_map_decl =
+      A.(AilSdeclaration [ (new_map_sym, Some (mk_expr map_deep_copy_fcall)) ])
     in
-    dest d (b1 @ b2 @ b3 @ [new_map_binding], s1 @ s2 @ s3 @ [new_map_decl], mk_expr map_set_fcall)
+    let map_set_fcall =
+      A.(
+        AilEcall
+          ( mk_expr (AilEident (Sym.fresh_pretty "cn_map_set")),
+            [ mk_expr A.(AilEident new_map_sym); e2; e3 ] ))
+    in
+    dest
+      d
+      ( b1 @ b2 @ b3 @ [ new_map_binding ],
+        s1 @ s2 @ s3 @ [ new_map_decl ],
+        mk_expr map_set_fcall )
   | MapGet (m, key) ->
     (* Only works when index is a cn_integer *)
     let b1, s1, e1 =

--- a/runtime/libcn/include/cn-executable/utils.h
+++ b/runtime/libcn/include/cn-executable/utils.h
@@ -129,6 +129,7 @@ void *cn_ite(cn_bool *b, void *e1, void *e2);
 
 cn_map *map_create(void);
 cn_map *cn_map_set(cn_map *m, cn_integer *key, void *value);
+cn_map *cn_map_deep_copy(cn_map *m1);
 cn_bool *cn_map_equality(cn_map *m1, cn_map *m2, cn_bool *(value_equality_fun)(void *, void *));
 
 #define convert_to_cn_map(c_ptr, cntype_conversion_fn, num_elements)({\

--- a/runtime/libcn/src/utils.c
+++ b/runtime/libcn/src/utils.c
@@ -282,19 +282,28 @@ void c_ownership_check(uintptr_t generic_c_ptr, int offset) {
 // }
 
 
-// void *cn_map_get(cn_map *m, cn_integer *key) {
-//     // const char key_arr[1] = {key};
-//     void *res = ht_get(m, key->val);
-//     if (!res) { printf("NULL being returned for key %ld\n", *(key->val)); exit (1); }
-//     return res;
-// }
-
 cn_map *cn_map_set(cn_map *m, cn_integer *key, void *value) {
     signed long *key_ptr = alloc(sizeof(signed long));
     *key_ptr = key->val;
     ht_set(m, key_ptr, value);
     return m;
 }
+
+
+cn_map *cn_map_deep_copy(cn_map *m1) {
+    cn_map *m2 = map_create();
+
+    hash_table_iterator hti = ht_iterator(m1);
+
+    while (ht_next(&hti)) {
+        signed long* curr_key = hti.key;
+        void *val = ht_get(m1, curr_key);
+        ht_set(m2, curr_key, val);
+    }
+
+    return m2;
+}
+
 
 cn_map *default_cn_map(void) {
     return map_create();


### PR DESCRIPTION
Change runtime translation of CN map set to always deep-copy the map passed in and then to update the copy of the map. Previously was an in-place update of the map, which was causing problems in [`swap_array.c`](https://github.com/rems-project/cn-tutorial/blob/main/src/examples/swap_array.c) in the [CN tutorial](https://github.com/rems-project/cn-tutorial/tree/main).

Specifically in this example, the postcondition on line 8 checks:

```c
/*@ a2 == a1[i: a1[j], j: a1[i]]; @*/
```

which was previously translating the RHS expression (parsed as a `CNExpr_arrayindexupdates`) to sequential in-place updates of `a1` at runtime, resulting in the wrong final value for `a1` and, therefore, a C runtime assertion failure for the postcondition.