### PR TITLE
CHERI: fixing last Admit with new lemmas from `coq-cheri-capabilies`

### DIFF
--- a/coq/Morello/CapabilitiesGS.v
+++ b/coq/Morello/CapabilitiesGS.v
@@ -259,7 +259,7 @@ Module Type CAPABILITY_GS
   Parameter cap_encode_length:
     forall c l t, encode c = Some (l, t) -> List.length l = sizeof_cap.
 
-  Parameter cap_exact_encode_decode:
-    forall c c' t l, encode c = Some (l, t) -> decode l t = Some c' -> eqb c
-c' = true.
+  Parameter cap_encode_decode:
+    forall cap bytes t, encode cap = Some (bytes, t) -> decode bytes t = Some cap.
+
 End CAPABILITY_GS.

--- a/coq/Morello/CapabilitiesGS.v
+++ b/coq/Morello/CapabilitiesGS.v
@@ -259,7 +259,14 @@ Module Type CAPABILITY_GS
   Parameter cap_encode_length:
     forall c l t, encode c = Some (l, t) -> List.length l = sizeof_cap.
 
-  Parameter cap_encode_decode:
-    forall cap bytes t, encode cap = Some (bytes, t) -> decode bytes t = Some cap.
+  Parameter cap_encode_valid:
+    forall cap cb b,
+      cap_is_valid cap = true -> encode cap = Some (cb, b) -> b = true.
+
+  Parameter cap_encode_decode_bounds:
+    forall cap bytes t,
+      encode cap = Some (bytes, t) ->
+      exists cap', decode bytes t = Some cap'
+              /\ cap_get_bounds cap = cap_get_bounds cap'.
 
 End CAPABILITY_GS.

--- a/coq/Morello/MorelloCapsGS.v
+++ b/coq/Morello/MorelloCapsGS.v
@@ -238,16 +238,15 @@ Module Capability_GS <: CAPABILITY_GS (MorelloCaps.AddressValue) (MorelloCaps.Fl
     apply H.
   Qed.
 
-  Lemma cap_exact_encode_decode:
-    forall c c' t l, encode c = Some (l, t) -> decode l t = Some c' -> eqb c c' = true.
-  Proof.
+  Lemma cap_encode_decode:
+    forall cap bytes t, encode cap = Some (bytes, t) -> decode bytes t = Some cap.
     intros.
-    apply Capability.cap_exact_encode_decode with (t:=t0) (l:=l).
-    auto.
-    unfold decode in H0.
-    destruct (Capability.decode l t0); inversion H0.
-    reflexivity.
-  Qed.
+    apply Capability.cap_encode_decode in H.
+    unfold decode.
+    destruct (Capability.decode bytes t0); inversion H.
+    clear.
+    (* This could not be proven as it does not preserve ghost state *)
+  Admitted.
 
 End Capability_GS.  
 

--- a/coq/Morello/MorelloCapsGS.v
+++ b/coq/Morello/MorelloCapsGS.v
@@ -238,15 +238,28 @@ Module Capability_GS <: CAPABILITY_GS (MorelloCaps.AddressValue) (MorelloCaps.Fl
     apply H.
   Qed.
 
-  Lemma cap_encode_decode:
-    forall cap bytes t, encode cap = Some (bytes, t) -> decode bytes t = Some cap.
-    intros.
-    apply Capability.cap_encode_decode in H.
+  Lemma cap_encode_valid:
+    forall cap cb b,
+      cap_is_valid cap = true -> encode cap = Some (cb, b) -> b = true.
+  Proof.
+    intros c cb b V E.
+    eapply Capability.cap_encode_valid; eauto.
+  Qed.
+
+  Lemma cap_encode_decode_bounds:
+    forall cap bytes t,
+      encode cap = Some (bytes, t) ->
+      exists cap', decode bytes t = Some cap'
+              /\ cap_get_bounds cap = cap_get_bounds cap'.
+  Proof.
+    intros cap0 bytes t E.
+    apply Capability.cap_encode_decode_bounds in E.
+    destruct E as [cap' [D E]].
     unfold decode.
-    destruct (Capability.decode bytes t0); inversion H.
-    clear.
-    (* This could not be proven as it does not preserve ghost state *)
-  Admitted.
+    exists (add_gs cap').
+    rewrite D.
+    split;auto.
+  Qed.
 
 End Capability_GS.  
 

--- a/coq/Proofs/Revocation.v
+++ b/coq/Proofs/Revocation.v
@@ -5577,34 +5577,6 @@ Module CheriMemoryImplWithProofs
     apply MorelloImpl.pointer_size_cap_size.
   Qed.
 
-  (* This one should be in the coq-cheri-capabilties *)
-  Fact cap_encode_valid
-    (cap : Capability_GS.t)
-    (cb : list ascii)
-    (b : bool):
-    Capability_GS.cap_is_valid cap = true ->
-    Capability_GS.encode cap = Some (cb, b) -> b = true.
-  Proof.
-    destruct cap.
-    unfold Capability_GS.cap_is_valid.
-    unfold Capability_GS.encode.
-    cbn.
-    intros V E.
-  Admitted.
-
-  (* This one should be in the coq-cheri-capabilties *)
-  Lemma cap_encode_decode_bounds':
-    forall cap bytes t,
-      Capability_GS.encode cap = Some (bytes, t) ->
-      exists cap', Capability_GS.decode bytes t = Some cap'
-              /\ Capability_GS.cap_get_bounds cap = Capability_GS.cap_get_bounds cap'.
-  Proof.
-    intros cap bytes t H.
-    destruct cap.
-    unfold Capability_GS.decode.
-    cbn in *.
-  Admitted.
-
   Fact cap_encode_decode_bounds
     (cap : Capability_GS.t)
     (cb : list ascii):
@@ -5616,7 +5588,7 @@ Module CheriMemoryImplWithProofs
         Capability_GS.cap_get_bounds cap'.
   Proof.
     intros V H.
-    apply cap_encode_decode_bounds' in H.
+    apply Capability_GS.cap_encode_decode_bounds in H.
     destruct H as [cap' [D E]].
     exists cap'.
     split;[|assumption].
@@ -5683,7 +5655,7 @@ Module CheriMemoryImplWithProofs
       +
         apply AMap.P.F.add_mapsto_iff in M as [[_ M] | M]; [| tauto].
         tuple_inversion.
-        pose proof (cap_encode_valid cap cb b H0 E) as B.
+        pose proof (Capability_GS.cap_encode_valid cap cb b H0 E) as B.
         subst b.
         apply cap_encode_decode_bounds in E.
         destruct E as [cap' [DX EX]].


### PR DESCRIPTION
CHERI: fixing last Admit with new lemmas from `coq-cheri-capabilies`.
Requires CI cache purge.