### PR TITLE
Track total benchmark time in CI

### DIFF
--- a/tests/run-ci-benchmarks.sh
+++ b/tests/run-ci-benchmarks.sh
@@ -3,6 +3,7 @@ set -euo pipefail -o noclobber
 # set -xv # uncomment to debug variables
 
 JSON_FILE="benchmark-data.json"
+TMP_FILE=$(mktemp)
 
 echo "[" >> "${JSON_FILE}"
 
@@ -16,16 +17,18 @@ for TEST in ${TESTS}; do
 done
 
 INDEX=0
+TOTAL=0
 for TEST in ${TESTS}; do
 
   # Record wall clock time in seconds
   /usr/bin/time --quiet -f "%e" -o /tmp/time cn verify "${TEST}" || true
   TIME=$(cat /tmp/time)
+  TOTAL="$(echo "${TOTAL} + ${TIME}" | bc -l)"
 
   # If we're last, don't print a trailing comma.
   if [[ ${INDEX} -eq ${COUNT}-1 ]]; then
     # Hack to output JSON.
-    cat << EOF >> ${JSON_FILE}
+    cat << EOF >> ${TMP_FILE}
     {
 	"name": "${TEST}",
         "unit": "Seconds",
@@ -33,7 +36,7 @@ for TEST in ${TESTS}; do
     }
 EOF
   else
-    cat << EOF >> ${JSON_FILE}
+    cat << EOF >> ${TMP_FILE}
     {
 	"name": "${TEST}",
         "unit": "Seconds",
@@ -44,6 +47,16 @@ EOF
 
   let INDEX=${INDEX}+1
 done
+
+cat << EOF >> ${JSON_FILE}
+    {
+        "name": "Total benchmark time",
+        "unit": "Seconds",
+        "value": ${TOTAL}
+    },
+EOF
+
+cat ${TMP_FILE} >> ${JSON_FILE}
 
 echo "]" >> "${JSON_FILE}"
 


### PR DESCRIPTION
As requested by @cp526, this records the total benchmarking time and includes it in the graphs generated by the CI.

Update: A passing run against our fork can be found [here](https://github.com/GaloisInc/cerberus/actions/runs/10929961223/job/30341845391). 