### PR TITLE
CN VIP: Add bounds checks for shifting

### DIFF
--- a/backend/cn/lib/typeErrors.ml
+++ b/backend/cn/lib/typeErrors.ml
@@ -201,6 +201,18 @@ type message =
         ctxt : Context.t * log;
         model : Solver.model_with_q
       }
+  | Needs_alloc_id of
+      { ptr : IT.t;
+        ub : CF.Undefined.undefined_behaviour;
+        ctxt : Context.t * log;
+        model : Solver.model_with_q
+      }
+  | Alloc_out_of_bounds of
+      { ptr : IT.t;
+        ub : CF.Undefined.undefined_behaviour;
+        ctxt : Context.t * log;
+        model : Solver.model_with_q
+      }
   (* | Implementation_defined_behaviour of document * state_report *)
   | Unspecified of CF.Ctype.ctype
   | StaticError of
@@ -475,6 +487,24 @@ let pp_message te =
     { short; descr = Some descr; state = Some state }
   | Undefined_behaviour { ub; ctxt; model } ->
     let short = !^"Undefined behaviour" in
+    let state = trace ctxt model Explain.no_ex in
+    let descr =
+      match CF.Undefined.std_of_undefined_behaviour ub with
+      | Some stdref -> !^(CF.Undefined.ub_short_string ub) ^^^ parens !^stdref
+      | None -> !^(CF.Undefined.ub_short_string ub)
+    in
+    { short; descr = Some descr; state = Some state }
+  | Needs_alloc_id { ptr; ub; ctxt; model } ->
+    let short = !^"Pointer " ^^ bquotes (IT.pp ptr) ^^ !^" needs allocation ID" in
+    let state = trace ctxt model Explain.no_ex in
+    let descr =
+      match CF.Undefined.std_of_undefined_behaviour ub with
+      | Some stdref -> !^(CF.Undefined.ub_short_string ub) ^^^ parens !^stdref
+      | None -> !^(CF.Undefined.ub_short_string ub)
+    in
+    { short; descr = Some descr; state = Some state }
+  | Alloc_out_of_bounds { ptr; ub; ctxt; model } ->
+    let short = !^"Pointer " ^^ bquotes (IT.pp ptr) ^^ !^" out of bounds" in
     let state = trace ctxt model Explain.no_ex in
     let descr =
       match CF.Undefined.std_of_undefined_behaviour ub with

--- a/tests/cn/ptr_diff2.c
+++ b/tests/cn/ptr_diff2.c
@@ -2,6 +2,10 @@ int* f(int *p)
 /*@
 requires
     has_alloc_id(p);
+    let A = allocs[(alloc_id)p];
+    A.base <= (u64) p - 4u64;
+    (u64) p - 4u64 < (u64) p;
+    (u64) p <= A.base + A.size;
 ensures
     ptr_eq(return, array_shift(p, -1i32));
 @*/
@@ -11,6 +15,6 @@ ensures
 
 int main(void)
 {
-    int arr = 0;
-    f(&arr + 1);
+    int arr[2] = { 0 };
+    f(arr + 1);
 }

--- a/tests/cn/tree16/as_mutual_dt/tree16.c
+++ b/tests/cn/tree16/as_mutual_dt/tree16.c
@@ -36,7 +36,8 @@ predicate {datatype tree t, i32 v, map <i32, datatype tree> children}
     return {t: Empty_Tree {}, v: 0i32, children: default_children ()};
   }
   else {
-    take V = Owned<int>(member_shift<node>(p,v));
+    take P = Owned<struct node>(p);
+    let V = P.v;
     let nodes_ptr = member_shift<node>(p,nodes);
     take Ns = each (i32 i; (0i32 <= i) && (i < NUM_NODES))
       {Indirect_Tree(array_shift<tree>(nodes_ptr, i))};
@@ -47,7 +48,6 @@ predicate {datatype tree t, i32 v, map <i32, datatype tree> children}
 
 predicate (datatype tree) Indirect_Tree (pointer p) {
   take V = Owned<tree>(p);
-  assert (is_null(V) || ((u64) V != 0u64));
   take T = Tree(V);
   return T.t;
 }
@@ -105,7 +105,7 @@ lemma in_tree_tree_v_lemma (datatype tree t, arc_in_array arc,
 
 int
 lookup_rec (tree t, int *path, int i, int path_len, int *v)
-/*@ requires is_null(t) || ((u64) t != 0u64);
+/*@ requires
              path_len <= LEN_LIMIT;
              take T = Tree(t);
              take Xs = each (i32 j; (0i32 <= j) && (j < path_len))

--- a/tests/cn/tree16/as_partial_map/tree16.c
+++ b/tests/cn/tree16/as_partial_map/tree16.c
@@ -49,7 +49,8 @@ predicate {map<datatype tree_arc, datatype tree_node_option> t,
     return {t: (empty ()), v: 0i32, ns: default_ns ()};
   }
   else {
-    take V = Owned<int>(member_shift<node>(p,v));
+    take P = Owned<struct node>(p);
+    let V = P.v;
     let nodes_ptr = member_shift<node>(p,nodes);
     take Ns = each (i32 i; (0i32 <= i) && (i < (num_nodes ())))
       {Indirect_Tree(array_shift<tree>(nodes_ptr, i))};
@@ -60,7 +61,6 @@ predicate {map<datatype tree_arc, datatype tree_node_option> t,
 
 predicate (map <datatype tree_arc, datatype tree_node_option>) Indirect_Tree (pointer p) {
   take V = Owned<tree>(p);
-  assert (is_null(V) || ((u64) V != 0u64));
   take T = Tree(V);
   return T.t;
 }
@@ -131,7 +131,7 @@ lemma construct_lemma (i32 v,
 
 int
 lookup_rec (tree t, int *path, int i, int path_len, int *v)
-/*@ requires is_null(t) || ((u64) t != 0u64);
+/*@ requires
              path_len <= LEN_LIMIT;
              take T = Tree(t);
              take Xs = each (i32 j; (0i32 <= j) && (j < path_len))

--- a/tests/run-cn.sh
+++ b/tests/run-cn.sh
@@ -40,7 +40,7 @@ function exits_with_code() {
   local -a expected_exit_codes=$3
 
   printf "[$file]...\n"
-  timeout 30 ${action} "$file"
+  timeout 60 ${action} "$file"
   local result=$?
 
   for code in "${expected_exit_codes[@]}"; do


### PR DESCRIPTION
This commit implements the VIP typing rules for member and array shifting. In particular, pure shifts do not require the allocation to be live, but the ISO version (PtrArrayShift) does. However, that AST construct is only produced if the appropriate switch is passed to Cerberus, and so conditioning on that is not required within the CN/checker code.