### PR TITLE
CN VIP: Add int to pointer rules

### DIFF
--- a/backend/cn/lib/indexTerms.ml
+++ b/backend/cn/lib/indexTerms.ml
@@ -719,8 +719,6 @@ let gePointer_ (it, it') loc = lePointer_ (it', it) loc
 
 let cast_ bt it loc = IT (Cast (bt, it), bt, loc)
 
-let integerToPointerCast_ it loc = cast_ (Loc ()) it loc
-
 let uintptr_const_ n loc = num_lit_ n Memory.uintptr_bt loc
 
 let uintptr_int_ n loc = uintptr_const_ (Z.of_int n) loc

--- a/tests/cn/int_to_ptr.c
+++ b/tests/cn/int_to_ptr.c
@@ -1,0 +1,15 @@
+void* cast(unsigned long long addr)
+/*@
+ensures
+    addr == 0u64 && is_null(return) || addr != 0u64 && has_alloc_id(return) && (u64) return == addr;
+@*/
+{
+    return (void*)addr;
+}
+
+int main()
+{
+    int x = 0;
+    void* p = cast((unsigned long long)&x);
+    /*@ assert ((u64) &x == 0u64 || has_alloc_id(p) && (u64) p == (u64) &x); @*/
+}

--- a/tests/cn/int_to_ptr.error.c
+++ b/tests/cn/int_to_ptr.error.c
@@ -1,0 +1,17 @@
+int* cast(unsigned long long addr)
+/*@
+ensures
+    addr == 0u64 && is_null(return) || addr != 0u64 && has_alloc_id(return) && (u64) return == addr;
+@*/
+{
+    return (void*)addr;
+}
+
+int main()
+{
+    int x = 0;
+    int* p = cast((unsigned long long)&x);
+    // The cast is successful, but has an unconstrained allocation ID, and so
+    // can't be used
+    return *p == 0;
+}

--- a/tests/cn/null_to_int.c
+++ b/tests/cn/null_to_int.c
@@ -1,0 +1,15 @@
+unsigned long long f(int *p)
+/*@
+requires
+    ptr_eq(p, NULL);
+ensures
+    return == 0u64;
+@*/
+{
+    return (unsigned long long)p;
+}
+
+int main()
+{
+    return f((int*)0);
+}

--- a/tests/run-cn-exec.sh
+++ b/tests/run-cn-exec.sh
@@ -99,6 +99,8 @@ SUCCESS=$(find cn -name '*.c' \
     ! -name "previously_inconsistent_assumptions2.c" \
     ! -name "ptr_relop.c" \
     ! -name "ptr_relop.error.c" \
+    ! -name "int_to_ptr.c" \
+    ! -name "int_to_ptr.error.c" \
 )
 
 # Include files which cause error for proof but not testing
@@ -162,6 +164,8 @@ BUGGY="cn/division_casting.c \
        cn/previously_inconsistent_assumptions2.c \
        cn/ptr_relop.c \
        cn/ptr_relop.error.c \
+       cn/int_to_ptr.c \
+       cn/int_to_ptr.error.c \
        "
 
 # Exclude files which cause error for proof but not testing


### PR DESCRIPTION
0 addresses are mapped to NULL, otherwise mapped to a pointer with an unconstrained provenance.