### PR TITLE
[CN-Exec] Add `free_all` for bump allocator

### DIFF
--- a/runtime/libcn/include/cn-executable/alloc.h
+++ b/runtime/libcn/include/cn-executable/alloc.h
@@ -21,6 +21,7 @@ void *alloc_(long nbytes, const char *, int);
 #define alloc(x)\
     alloc_(x, __FILE__, __LINE__)
 
+void free_all(void);
 
 // void *alloc_zeros(long nbytes);
 

--- a/runtime/libcn/include/cn-executable/alloc.h
+++ b/runtime/libcn/include/cn-executable/alloc.h
@@ -21,6 +21,11 @@ void *alloc_(long nbytes, const char *, int);
 #define alloc(x)\
     alloc_(x, __FILE__, __LINE__)
 
+void *zalloc_(long nbytes, const char *, int);
+
+#define zalloc(x)\
+    zalloc_(x, __FILE__, __LINE__)
+
 void free_all(void);
 
 // void *alloc_zeros(long nbytes);

--- a/runtime/libcn/src/alloc.c
+++ b/runtime/libcn/src/alloc.c
@@ -53,6 +53,9 @@ void *alloc_(long nbytes, const char *str, int line) {
     //return malloc(nbytes);
 }
 
+void free_all(void) {
+    curr = buf;
+}
 
 // void *alloc_zeros(long nbytes) {
 //     void *res = alloc(nbytes);

--- a/runtime/libcn/src/alloc.c
+++ b/runtime/libcn/src/alloc.c
@@ -53,6 +53,14 @@ void *alloc_(long nbytes, const char *str, int line) {
     //return malloc(nbytes);
 }
 
+void *zalloc_(long nbytes, const char *str, int line) {
+    void *p = alloc_(nbytes, str, line);
+    if (p != NULL) {
+        memset(p, 0, nbytes);
+    }
+    return p;
+}
+
 void free_all(void) {
     curr = buf;
 }

--- a/runtime/libcn/src/hash_table.c
+++ b/runtime/libcn/src/hash_table.c
@@ -43,7 +43,7 @@ hash_table* ht_create(void) {
     table->capacity = INITIAL_CAPACITY;
 
     // Allocate (zero'd) space for entry buckets.
-    table->entries = alloc(table->capacity * sizeof(ht_entry));
+    table->entries = zalloc(table->capacity * sizeof(ht_entry));
     if (table->entries == NULL) {
         // free(table); // error, free table before we return!
         return NULL;
@@ -148,7 +148,7 @@ static _Bool ht_expand(hash_table* table) {
     if (new_capacity < table->capacity) {
         return 0;  // overflow (capacity would be too big)
     }
-    ht_entry* new_entries = alloc(new_capacity * sizeof(ht_entry));
+    ht_entry* new_entries = zalloc(new_capacity * sizeof(ht_entry));
     if (new_entries == NULL) {
         return 0;
     }


### PR DESCRIPTION
Each pass of the generate and test loop is independent of the others, so we can reset the bump allocator between them.