### PR TITLE
[CN-Exec] Add logging levels to runtime library

### DIFF
--- a/backend/cn/lib/testGeneration/specTests.ml
+++ b/backend/cn/lib/testGeneration/specTests.ml
@@ -219,10 +219,10 @@ let compile_script ~(output_dir : string) ~(test_file : string) : Pp.document =
   ^^ string "# Run"
   ^^ hardline
   ^^ separate_map space string [ "if"; "./tests.out"; ";"; "then" ]
-  ^^ nest 4 (hardline ^^ string "echo \"Tests passed\"")
+  ^^ nest 4 (hardline ^^ string "exit 0")
   ^^ hardline
   ^^ string "else"
-  ^^ nest 4 (hardline ^^ string "echo \"Tests failed\"; exit 1")
+  ^^ nest 4 (hardline ^^ string "exit 1")
   ^^ hardline
   ^^ string "fi"
   ^^ hardline

--- a/runtime/libcn/include/cn-executable/utils.h
+++ b/runtime/libcn/include/cn-executable/utils.h
@@ -16,6 +16,22 @@
 extern "C" {
 #endif
 
+enum cn_logging_level {
+    CN_LOGGING_NONE = 0,
+    CN_LOGGING_ERROR = 1,
+    CN_LOGGING_INFO = 2
+};
+
+enum cn_logging_level get_cn_logging_level(void);
+
+/** Sets the logging level, returning the previous one */
+enum cn_logging_level set_cn_logging_level(enum cn_logging_level new_level);
+
+#define cn_printf(level, ...)\
+    if (get_cn_logging_level() >= level) {\
+        printf(__VA_ARGS__);\
+    }
+
 struct cn_error_message_info {
     const char *function_name;
     char *file_name;
@@ -515,15 +531,15 @@ void c_ownership_check(uintptr_t generic_c_ptr, int offset);
 
 static inline void cn_load(void *ptr, size_t size)
 {
-  printf("  \x1b[31mLOAD\x1b[0m[%lu] - ptr: %p\n", size, ptr);
+  cn_printf(CN_LOGGING_INFO, "  \x1b[31mLOAD\x1b[0m[%lu] - ptr: %p\n", size, ptr);
 }
 static inline void cn_store(void *ptr, size_t size)
 {
-  printf("  \x1b[31mSTORE\x1b[0m[%lu] - ptr: %p\n", size, ptr);
+  cn_printf(CN_LOGGING_INFO, "  \x1b[31mSTORE\x1b[0m[%lu] - ptr: %p\n", size, ptr);
 }
 static inline void cn_postfix(void *ptr, size_t size)
 {
-  printf("  \x1b[31mPOSTFIX\x1b[0m[%lu] - ptr: %p\n", size, ptr);
+  cn_printf(CN_LOGGING_INFO, "  \x1b[31mPOSTFIX\x1b[0m[%lu] - ptr: %p\n", size, ptr);
 }
 
 // use this macro to wrap an argument to another macro that contains commas 

--- a/runtime/libcn/include/cn-testing/rand.h
+++ b/runtime/libcn/include/cn-testing/rand.h
@@ -7,8 +7,6 @@
 extern "C" {
 #endif
 
-    void cn_gen_set_rand_inject(uint8_t inject);
-
     void cn_gen_srand(uint64_t seed);
 
     uint64_t cn_gen_rand(void);
@@ -20,6 +18,8 @@ extern "C" {
     cn_gen_rand_checkpoint cn_gen_rand_save(void);
 
     void cn_gen_rand_restore(cn_gen_rand_checkpoint checkpoint);
+
+    void cn_gen_rand_replace(cn_gen_rand_checkpoint checkpoint);
 
 #ifdef __cplusplus
 }

--- a/runtime/libcn/include/cn-testing/test.h
+++ b/runtime/libcn/include/cn-testing/test.h
@@ -22,6 +22,7 @@ void cn_register_test_case(char* suite, char* name, cn_test_case_fn* func);
         }                                                                               \
         set_cn_exit_cb(&cn_test_##Suite##_##Name##_fail);                               \
                                                                                         \
+        cn_gen_rand_checkpoint checkpoint = cn_gen_rand_save();                         \
         for (int i = 0; i < Samples; i++) {                                             \
             CN_TEST_INIT();                                                             \
             struct cn_gen_##Name##_record *res = cn_gen_##Name();                       \
@@ -29,6 +30,7 @@ void cn_register_test_case(char* suite, char* name, cn_test_case_fn* func);
                 return CN_TEST_GEN_FAIL;                                                \
             }                                                                           \
             Name(__VA_ARGS__);                                                          \
+            cn_gen_rand_replace(checkpoint);                                            \
         }                                                                               \
                                                                                         \
         return CN_TEST_PASS;                                                            \

--- a/runtime/libcn/src/cn-testing/gen_alloc.c
+++ b/runtime/libcn/src/cn-testing/gen_alloc.c
@@ -19,7 +19,7 @@ cn_pointer* cn_gen_alloc(cn_bits_u64* sz) {
 
     if (bytes == 0) {
         void* p;
-        uint64_t rnd = convert_from_cn_bits_u64(cn_gen_uniform_cn_bits_u64(-1));
+        uint64_t rnd = convert_from_cn_bits_u64(cn_gen_uniform_cn_bits_u64(0));
         if ((rnd % 2) == 0) {
             p = NULL;
         }

--- a/runtime/libcn/src/cn-testing/rand.c
+++ b/runtime/libcn/src/cn-testing/rand.c
@@ -1,5 +1,6 @@
 #include <stdint.h>
 #include <stdlib.h>
+#include <stdio.h>
 #include <assert.h>
 
 #include <cn-testing/rand.h>
@@ -111,13 +112,7 @@ void cn_gen_srand(uint64_t seed) {
     }
 }
 
-static uint8_t cn_gen_rand_inject = 0;
-
-void cn_gen_set_rand_inject(uint8_t inject) {
-    cn_gen_rand_inject = inject;
-}
-
-uint64_t rand_normal(void) {
+uint64_t cn_gen_rand(void) {
     if (choice_history != 0 && choice_history->next != 0)
     {
         choice_history = choice_history->next;
@@ -142,33 +137,6 @@ uint64_t rand_normal(void) {
         choice_history = new_node;
 
         return choice;
-    }
-}
-
-uint64_t rand_inject() {
-    uint64_t choice = genrand();
-
-    struct choice_list* next = (choice_history != 0) ? choice_history->next : 0;
-
-    struct choice_list* new_node = malloc(sizeof(struct choice_list));
-    *new_node = (struct choice_list){
-        .choice = choice,
-        .next = next,
-        .prev = choice_history
-    };
-
-    choice_history = new_node;
-
-    return choice;
-}
-
-uint64_t cn_gen_rand() {
-    if (cn_gen_rand_inject) {
-        return rand_inject();
-    }
-    else
-    {
-        return rand_normal();
     }
 }
 
@@ -197,4 +165,9 @@ cn_gen_rand_checkpoint cn_gen_rand_save(void) {
 
 void cn_gen_rand_restore(cn_gen_rand_checkpoint checkpoint) {
     choice_history = checkpoint;
+}
+
+void cn_gen_rand_replace(cn_gen_rand_checkpoint checkpoint) {
+    cn_gen_rand_restore(checkpoint);
+    choice_history->next = 0;
 }

--- a/runtime/libcn/src/cn-testing/test.c
+++ b/runtime/libcn/src/cn-testing/test.c
@@ -41,11 +41,16 @@ int cn_test_main(int argc, char* argv[]) {
 
     cn_gen_srand(time(NULL));
     uint64_t seed = cn_gen_rand();
+    enum cn_logging_level logging_level = CN_LOGGING_ERROR;
     for (int i = 0; i < argc; i++) {
         char* arg = argv[i];
 
         if (strcmp("-S", arg) == 0 || strcmp("--seed", arg) == 0) {
             seed = strtoull(argv[i + 1], NULL, 16);
+            i++;
+        }
+        else if (strcmp("--logging-level", arg) == 0) {
+            logging_level = strtol(argv[i + 1], NULL, 10);
             i++;
         }
     }
@@ -74,7 +79,7 @@ int cn_test_main(int argc, char* argv[]) {
         case CN_TEST_FAIL:
             failed++;
             printf("FAILED\n");
-            set_cn_logging_level(CN_LOGGING_ERROR);
+            set_cn_logging_level(logging_level);
             cn_gen_rand_restore(checkpoints[i]);
             test_case->func();
             set_cn_logging_level(CN_LOGGING_NONE);

--- a/runtime/libcn/src/cn-testing/test.c
+++ b/runtime/libcn/src/cn-testing/test.c
@@ -37,6 +37,8 @@ void cn_register_test_case(char* suite, char* name, cn_test_case_fn* func) {
 }
 
 int cn_test_main(int argc, char* argv[]) {
+    set_cn_logging_level(CN_LOGGING_NONE);
+
     cn_gen_srand(time(NULL));
     uint64_t seed = cn_gen_rand();
     for (int i = 0; i < argc; i++) {
@@ -67,22 +69,25 @@ int cn_test_main(int argc, char* argv[]) {
         switch (results[i]) {
         case CN_TEST_PASS:
             passed++;
-            printf("PASSED");
+            printf("PASSED\n");
             break;
         case CN_TEST_FAIL:
             failed++;
-            printf("FAILED");
+            printf("FAILED\n");
+            set_cn_logging_level(CN_LOGGING_ERROR);
+            cn_gen_rand_restore(checkpoints[i]);
+            test_case->func();
+            set_cn_logging_level(CN_LOGGING_NONE);
             break;
         case CN_TEST_GEN_FAIL:
             errored++;
-            printf("FAILED TO GENERATE VALID INPUT");
+            printf("FAILED TO GENERATE VALID INPUT\n");
             break;
         case CN_TEST_SKIP:
             skipped++;
-            printf("SKIPPED");
+            printf("SKIPPED\n");
             break;
         }
-        printf("\n");
     }
 
     printf("\nTesting Summary:\n");


### PR DESCRIPTION
In the case of random testing, I don't think we want all of these logs, except for a failing input.

Instead I think we want to:
- disable logging
- test many random inputs
- if we find a failing one
  - re-enable logging at the error level
  - rerun the failing input
- we allow the user to re-run it again with the full logs