### PR TITLE
CN: Fix #598 (solver crash) reduce mutability

### DIFF
--- a/tests/cn/solver_crash.error.c
+++ b/tests/cn/solver_crash.error.c
@@ -1,0 +1,22 @@
+// This example used to cause the solver to crash with VIP enabled
+
+struct str {
+  int x;
+  int y;
+};
+
+int f (int x)
+/*@ requires (0i32 <= x) && (x < 200i32); @*/
+{
+  struct str str_inst = {
+    .x = x + 2,
+    .y = str_inst.x + 3,
+  };
+
+  return str_inst.y;
+}
+
+int main()
+{
+    f(4);
+}


### PR DESCRIPTION
PR #251 added support for a new solver backend, but also introduced a bug which, with `--vip` enabled, caused the solver to crash.

The root cause was that calls to `provable` were interfering with `model_evaluator` because of unnecessary shared mutability.

This can be fixed by calling `Int_Table.copy` in `copy_solver_frame`, but instead this removes the two-layer hashtable and replaces it with a simpler pair-lookup map.