### PR TITLE
CN: Enable VIP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
       run: |
         opam switch ${{ matrix.version }}
         eval $(opam env --switch=${{ matrix.version }})
-        cd tests; USE_OPAM='' ./run-cn.sh -v
+        cd tests; USE_OPAM='' ./run-cn.sh
 
     - name: Run CN Tutorial CI tests
       run: |

--- a/backend/cn/bin/main.ml
+++ b/backend/cn/bin/main.ml
@@ -284,7 +284,7 @@ let verify
   solver_path
   solver_type
   astprints
-  use_vip
+  dont_use_vip
   no_use_ity
   use_peval
   fail_fast
@@ -314,7 +314,7 @@ let verify
   Solver.solver_type := solver_type;
   Solver.solver_flags := solver_flags;
   Check.skip_and_only := (opt_comma_split skip, opt_comma_split only);
-  IndexTerms.use_vip := use_vip;
+  IndexTerms.use_vip := not dont_use_vip;
   Check.fail_fast := fail_fast;
   Diagnostics.diag_string := diag;
   WellTyped.use_ity := not no_use_ity;
@@ -362,7 +362,7 @@ let generate_executable_specs
   csv_times
   log_times
   astprints
-  use_vip
+  dont_use_vip
   no_use_ity
   use_peval
   fail_fast
@@ -387,7 +387,7 @@ let generate_executable_specs
   CF.Pp_symbol.pp_cn_sym_nums := print_sym_nums;
   Pp.print_timestamps := not no_timestamps;
   Check.skip_and_only := (opt_comma_split skip, opt_comma_split only);
-  IndexTerms.use_vip := use_vip;
+  IndexTerms.use_vip := not dont_use_vip;
   Check.fail_fast := fail_fast;
   Diagnostics.diag_string := diag;
   WellTyped.use_ity := not no_use_ity;
@@ -683,9 +683,9 @@ module Verify_flags = struct
 
 
   (* TODO remove this when VIP impl complete *)
-  let use_vip =
-    let doc = "use experimental VIP rules" in
-    Arg.(value & flag & info [ "vip" ] ~doc)
+  let dont_use_vip =
+    let doc = "(temporary) disable VIP rules" in
+    Arg.(value & flag & info [ "no-vip" ] ~doc)
 
 
   let json =
@@ -800,7 +800,7 @@ let verify_t : unit Term.t =
   $ Verify_flags.solver_path
   $ Verify_flags.solver_type
   $ Common_flags.astprints
-  $ Verify_flags.use_vip
+  $ Verify_flags.dont_use_vip
   $ Common_flags.no_use_ity
   $ Common_flags.use_peval
   $ Verify_flags.fail_fast
@@ -889,7 +889,7 @@ let instrument_cmd =
     $ Common_flags.csv_times
     $ Common_flags.log_times
     $ Common_flags.astprints
-    $ Verify_flags.use_vip
+    $ Verify_flags.dont_use_vip
     $ Common_flags.no_use_ity
     $ Common_flags.use_peval
     $ Verify_flags.fail_fast

--- a/backend/cn/lib/indexTerms.ml
+++ b/backend/cn/lib/indexTerms.ml
@@ -471,7 +471,7 @@ let is_member = function IT (StructMember (it, id), _, _) -> Some (it, id) | _ -
 
 (* shorthands *)
 
-let use_vip = ref false
+let use_vip = ref true
 
 (* lit *)
 let sym_ (sym, bt, loc) = IT (Sym sym, bt, loc)

--- a/runtime/libcn/libexec/cn-runtime-single-file.sh
+++ b/runtime/libcn/libexec/cn-runtime-single-file.sh
@@ -10,9 +10,8 @@ function echo_and_err() {
 
 QUIET=""
 CHECK_OWNERSHIP=""
-VIP=""
 
-while getopts "hovq" flag; do
+while getopts "hoq" flag; do
  case "$flag" in
    h)
    printf "${USAGE}"
@@ -20,9 +19,6 @@ while getopts "hovq" flag; do
    ;;
    o)
    CHECK_OWNERSHIP="--with-ownership-checking"
-   ;;
-   v)
-   VIP="--vip"
    ;;
    q)
    QUIET=1
@@ -58,7 +54,7 @@ EXEC_DIR=$(mktemp -d -t 'cn-exec.XXXX')
 # INPUT_FN="${EXEC_DIR}/${INPUT_BASENAME}.pp.c"
 
 # Instrument code with CN
-if cn instrument "${VIP}" "${INPUT_FN}" \
+if cn instrument "${INPUT_FN}" \
     --output-decorated="${INPUT_BASENAME}-exec.c" \
     --output-decorated-dir="${EXEC_DIR}" \
     ${CHECK_OWNERSHIP}; then

--- a/tests/run-cn-exec.sh
+++ b/tests/run-cn-exec.sh
@@ -17,7 +17,7 @@ CHECK_SCRIPT="${RUNTIME_PREFIX}/libexec/cn-runtime-single-file.sh"
 
 [ -f "${CHECK_SCRIPT}" ] || echo_and_err "Could not find single file helper script: ${CHECK_SCRIPT}"
 
-SCRIPT_OPT="-ovq"
+SCRIPT_OPT="-oq"
 
 function exits_with_code() {
   local file=$1

--- a/tests/run-cn.sh
+++ b/tests/run-cn.sh
@@ -14,9 +14,8 @@ function echo_and_err() {
 }
 
 LEMMATA=0
-VIP=""
 
-while getopts "hlv" flag; do
+while getopts "hl" flag; do
  case "$flag" in
    h)
    printf "%s\n" "${USAGE}"
@@ -24,9 +23,6 @@ while getopts "hlv" flag; do
    ;;
    l)
    LEMMATA=1
-   ;;
-   v)
-   VIP="--vip"
    ;;
    \?)
    echo_and_err "${USAGE}"
@@ -62,13 +58,13 @@ FAIL=$(find "${DIRNAME}"/cn -name '*.error.c')
 FAILED=""
 
 for TEST in ${SUCC}; do
-  if ! exits_with_code "cn verify ${VIP}" "${TEST}" 0; then
+  if ! exits_with_code "cn verify" "${TEST}" 0; then
     FAILED+=" ${TEST}"
   fi
 done
 
 for TEST in ${FAIL}; do
-  if ! exits_with_code "cn verify ${VIP}" "${TEST}" "(1 2)"; then
+  if ! exits_with_code "cn verify" "${TEST}" "(1 2)"; then
     FAILED+=" ${TEST}"
   fi
 done


### PR DESCRIPTION
This commit enables VIP by default on CN and removes the flag for it. Two features are missing:
* Round-trip casts - these may be added later.
* Byte representations - these will be added next.