### PR TITLE
CN VIP: Fix #588 - refactor live alloc check

### DIFF
--- a/backend/cn/lib/check.ml
+++ b/backend/cn/lib/check.ml
@@ -473,8 +473,8 @@ let check_both_eq_alloc loc arg1 arg2 ub =
   | `True -> return ()
 
 
-let check_live_alloc_bounds loc arg ub constr =
-  let@ base_size = RI.Special.get_live_alloc loc Ptr_diff_or_compare arg in
+let check_live_alloc_bounds reason loc arg ub constr =
+  let@ base_size = RI.Special.get_live_alloc reason loc arg in
   let here = Locations.other __FUNCTION__ in
   let base, size = Alloc.History.get_base_size base_size here in
   if !use_vip then (
@@ -1381,7 +1381,9 @@ let rec check_expr labels (e : BT.t Mu.mu_expr) (k : IT.t -> unit m) : unit m =
          check_pexpr pe1 (fun arg1 ->
            check_pexpr pe2 (fun arg2 ->
              let@ () = check_both_eq_alloc loc arg1 arg2 ub in
-             let@ () = check_live_alloc_bounds loc arg1 ub (both_in_bounds arg1 arg2) in
+             let@ () =
+               check_live_alloc_bounds `Ptr_cmp loc arg1 ub (both_in_bounds arg1 arg2)
+             in
              k (op (arg1, arg2))))
        in
        (match memop with
@@ -1407,7 +1409,9 @@ let rec check_expr labels (e : BT.t Mu.mu_expr) (k : IT.t -> unit m) : unit m =
               let ub_unspec = CF.Undefined.UB_unspec_pointer_sub in
               let ub = CF.Undefined.(UB_CERB004_unspecified ub_unspec) in
               let@ () = check_both_eq_alloc loc arg1 arg2 ub in
-              let@ () = check_live_alloc_bounds loc arg1 ub (both_in_bounds arg1 arg2) in
+              let@ () =
+                check_live_alloc_bounds `Ptr_diff loc arg1 ub (both_in_bounds arg1 arg2)
+              in
               let ptr_diff_bt = Memory.bt_of_sct (Integer Ptrdiff_t) in
               let value =
                 (* TODO: confirm that the cast from uintptr_t to ptrdiff_t
@@ -1501,7 +1505,7 @@ let rec check_expr labels (e : BT.t Mu.mu_expr) (k : IT.t -> unit m) : unit m =
               let@ () = check_has_alloc_id loc vt1 ub_unspec in
               let here = Locations.other __FUNCTION__ in
               let@ () =
-                check_live_alloc_bounds loc vt1 ub (fun ~base ~size ->
+                check_live_alloc_bounds `ISO_array_shift loc vt1 ub (fun ~base ~size ->
                   let addr = addr_ result here in
                   let lower = le_ (base, addr) here in
                   let upper = le_ (addr, add_ (base, size) here) here in
@@ -1526,7 +1530,7 @@ let rec check_expr labels (e : BT.t Mu.mu_expr) (k : IT.t -> unit m) : unit m =
               let@ () = check_has_alloc_id loc vt2 ub_unspec in
               let ub = CF.Undefined.(UB_CERB004_unspecified ub_unspec) in
               let@ () =
-                check_live_alloc_bounds loc vt2 ub (fun ~base ~size ->
+                check_live_alloc_bounds `Copy_alloc_id loc vt2 ub (fun ~base ~size ->
                   let addr = vt1 in
                   let lower = le_ (base, addr) here in
                   let upper = le_ (addr, add_ (base, size) here) here in

--- a/backend/cn/lib/resourceInference.mli
+++ b/backend/cn/lib/resourceInference.mli
@@ -20,8 +20,8 @@ end
 
 module Special : sig
   val get_live_alloc
-    :  Locations.t ->
-    TypeErrors.situation ->
+    :  [ `Copy_alloc_id | `Ptr_cmp | `Ptr_diff | `ISO_array_shift ] ->
+    Locations.t ->
     IndexTerms.t ->
     IndexTerms.t Typing.m
 

--- a/backend/cn/lib/resourceTypes.ml
+++ b/backend/cn/lib/resourceTypes.ml
@@ -47,13 +47,12 @@ type qpredicate_type =
   }
 [@@deriving eq, ord]
 
-let subsumed ~alloc_owned p1 p2 =
+let subsumed p1 p2 =
   (* p1 subsumed by p2 *)
   equal_predicate_name p1 p2
   ||
   match (p1, p2) with
   | Owned (ct, Uninit), Owned (ct', Init) when Sctypes.equal ct ct' -> true
-  | _, Owned _ when alloc_owned && equal_predicate_name p1 alloc -> true
   | _ -> false
 
 


### PR DESCRIPTION
This commit refactors the live allocation check so that the resource inference loop can remove the special case for checking whether an allocation is live or not.