### PR TITLE
[CN-Test-Gen] Various fixes

### DIFF
--- a/backend/cn/bin/main.ml
+++ b/backend/cn/bin/main.ml
@@ -847,21 +847,28 @@ module Testing_flags = struct
     Arg.(value & flag & info [ "no-run" ] ~doc)
 
 
-  let gen_max_unfolds =
-    let doc = "Set the maximum number of unfolds for recursive predicates" in
-    Arg.(value & opt int 5 & info [ "max-unfolds" ] ~doc)
-
-
-  let test_max_array_length =
-    let doc = "Set the maximum length for an array generated" in
-    Arg.(value & opt int 5 & info [ "max-array-length" ] ~doc)
-
-
   let gen_backtrack_attempts =
     let doc =
       "Set the maximum attempts to satisfy a constraint before backtracking further"
     in
-    Arg.(value & opt int 5 & info [ "backtrack-attempts" ] ~doc)
+    Arg.(
+      value
+      & opt int TestGeneration.default_cfg.max_backtracks
+      & info [ "backtrack-attempts" ] ~doc)
+
+
+  let gen_max_unfolds =
+    let doc = "Set the maximum number of unfolds for recursive predicates" in
+    Arg.(
+      value & opt int TestGeneration.default_cfg.max_unfolds & info [ "max-unfolds" ] ~doc)
+
+
+  let test_max_array_length =
+    let doc = "Set the maximum length for an array generated" in
+    Arg.(
+      value
+      & opt int TestGeneration.default_cfg.max_array_length
+      & info [ "max-array-length" ] ~doc)
 end
 
 let testing_cmd =

--- a/backend/cn/lib/testGeneration/genBuiltins.ml
+++ b/backend/cn/lib/testGeneration/genBuiltins.ml
@@ -17,7 +17,7 @@ let gen_syms_bits (name : string) : (BT.t * Sym.t) list =
                name;
                Option.get (Utils.get_typedef_string (CtA.bt_to_ail_ctype bt))
              ]) )
-    | None -> failwith __LOC__
+    | None -> failwith Pp.(plain (BT.pp bt ^^ space ^^ at ^^ space ^^ string __LOC__))
   in
   [ aux (BT.Bits (Unsigned, 8));
     aux (BT.Bits (Signed, 8));

--- a/backend/cn/lib/testGeneration/genDistribute.ml
+++ b/backend/cn/lib/testGeneration/genDistribute.ml
@@ -8,7 +8,9 @@ module SymMap = Map.Make (Sym)
 module Config = TestGenConfig
 
 let generated_size (bt : BT.t) : int =
-  match bt with Datatype _ -> failwith __LOC__ | _ -> 0
+  match bt with
+  | Datatype _ -> failwith Pp.(plain (BT.pp bt ^^ space ^^ at ^^ space ^^ string __LOC__))
+  | _ -> 0
 
 
 let allocations (gt : GT.t) : GT.t =
@@ -64,8 +66,8 @@ let default_weights (gt : GT.t) : GT.t =
       match gt_ with
       | Arbitrary ->
         (match bt with
-         | Map (_k_bt, _v_bt) -> failwith __LOC__
-         | Loc () -> failwith __LOC__
+         | Map _ | Loc () ->
+           failwith Pp.(plain (BT.pp bt ^^ space ^^ at ^^ space ^^ string __LOC__))
          | _ -> GT.Uniform (generated_size bt))
       | _ -> gt_
     in

--- a/backend/cn/lib/testGeneration/genDistribute.ml
+++ b/backend/cn/lib/testGeneration/genDistribute.ml
@@ -7,7 +7,9 @@ module GA = GenAnalysis
 module SymMap = Map.Make (Sym)
 module Config = TestGenConfig
 
-let generated_size (bt : BT.t) : int = match bt with Datatype _ -> 100 | _ -> 100
+let generated_size (bt : BT.t) : int =
+  match bt with Datatype _ -> failwith __LOC__ | _ -> 0
+
 
 let allocations (gt : GT.t) : GT.t =
   let aux (gt : GT.t) : GT.t =

--- a/backend/cn/lib/testGeneration/genNormalize.ml
+++ b/backend/cn/lib/testGeneration/genNormalize.ml
@@ -19,7 +19,19 @@ let rec arbitrary_of_sctype (sct : Sctypes.t) loc : GT.t =
             loc ),
         arbitrary_of_sctype ct' loc )
       loc
-  | Array (_, None) -> failwith __LOC__
+  | Array (_, None) ->
+    failwith
+      Pp.(
+        plain
+          (Sctypes.pp sct
+           ^^ space
+           ^^ at
+           ^^ space
+           ^^ Locations.pp loc
+           ^^ space
+           ^^ at
+           ^^ space
+           ^^ string __LOC__))
   | _ -> GT.arbitrary_ (Memory.bt_of_sct sct) loc
 
 

--- a/backend/cn/lib/testGeneration/genRuntime.ml
+++ b/backend/cn/lib/testGeneration/genRuntime.ml
@@ -220,7 +220,8 @@ let nice_names (inputs : SymSet.t) (gt : GT.t) : GT.t =
     match description sym with
     | SD_Id name | SD_CN_Id name | SD_ObjectAddress name | SD_FunArgValue name -> name
     | SD_None -> "fresh"
-    | _ -> failwith __LOC__
+    | _ ->
+      failwith Pp.(plain (Sym.pp_debug sym ^^ space ^^ at ^^ space ^^ string __LOC__))
   in
   let rec aux (vars : int StringMap.t) (gt : GT.t) : int StringMap.t * GT.t =
     let (GT (gt_, _, loc)) = gt in
@@ -345,7 +346,8 @@ let elaborate_gt (inputs : SymSet.t) (gt : GT.t) : term =
                if SymSet.is_empty (SymSet.diff (LC.free_vars prop) inputs) then
                  bennet
                else
-                 failwith __LOC__);
+                 failwith
+                   Pp.(plain (LC.pp prop ^^ space ^^ at ^^ space ^^ string __LOC__)));
           rest = aux vars rest
         }
     | ITE (cond, gt_then, gt_else) ->

--- a/backend/cn/lib/testGeneration/specTests.ml
+++ b/backend/cn/lib/testGeneration/specTests.ml
@@ -74,7 +74,15 @@ let compile_tests
           match List.assoc Sym.equal inst.fn declarations with
           | _, _, Decl_function (_, _, cts, _, _, _) ->
             List.combine xs (List.map (fun (_, ct, _) -> ct) cts)
-          | _ -> failwith __LOC__ ))
+          | _ ->
+            failwith
+              (String.concat
+                 " "
+                 [ "Function declaration not found for";
+                   Sym.pp_string inst.fn;
+                   "@";
+                   __LOC__
+                 ]) ))
       insts
   in
   let convert_from ((x, ct) : Sym.t * C.ctype) =

--- a/backend/cn/lib/testGeneration/specTests.ml
+++ b/backend/cn/lib/testGeneration/specTests.ml
@@ -110,9 +110,9 @@ let compile_tests
                  [ string suite;
                    Sym.pp inst.fn;
                    (if AT.count_computational (Option.get inst.internal) = 0 then
-                      Pp.int 1
+                      int 1
                     else
-                      Pp.int 100);
+                      int 100);
                    separate_map
                      (comma ^^ space)
                      convert_from

--- a/backend/cn/lib/testGeneration/testGenConfig.ml
+++ b/backend/cn/lib/testGeneration/testGenConfig.ml
@@ -4,7 +4,9 @@ type t =
     max_array_length : int
   }
 
-let instance = ref { max_backtracks = 10; max_unfolds = 10; max_array_length = 50 }
+let default = { max_backtracks = 10; max_unfolds = 10; max_array_length = 50 }
+
+let instance = ref default
 
 let initialize (cfg : t) = instance := cfg
 

--- a/backend/cn/lib/testGeneration/testGenConfig.mli
+++ b/backend/cn/lib/testGeneration/testGenConfig.mli
@@ -4,6 +4,8 @@ type t =
     max_array_length : int
   }
 
+val default : t
+
 val initialize : t -> unit
 
 val get_max_backtracks : unit -> int

--- a/backend/cn/lib/testGeneration/testGeneration.ml
+++ b/backend/cn/lib/testGeneration/testGeneration.ml
@@ -2,6 +2,8 @@ module Config = TestGenConfig
 
 type config = Config.t
 
+let default_cfg : config = Config.default
+
 let run
   ~output_dir
   ~filename

--- a/backend/cn/lib/testGeneration/testGeneration.mli
+++ b/backend/cn/lib/testGeneration/testGeneration.mli
@@ -1,5 +1,7 @@
 type config = TestGenConfig.t
 
+val default_cfg : config
+
 val run
   :  output_dir:string ->
   filename:string ->

--- a/runtime/libcn/include/cn-testing/test.h
+++ b/runtime/libcn/include/cn-testing/test.h
@@ -40,6 +40,7 @@ int cn_test_main(int argc, char* argv[]);
     free_all();                                                                         \
     initialise_ownership_ghost_state();                                                 \
     initialise_ghost_stack_depth();                                                     \
+    cn_gen_backtrack_reset();                                                           \
     cn_gen_alloc_reset();
 
 #define CN_TEST_GENERATE(name) ({                                                       \


### PR DESCRIPTION
- Allocation inference issue when it would refer to variables from later in the program
- Wasn't resetting backtrack metadata between runs
- Ensures that variable names are unique
- Reduce C warnings