### PR TITLE
[CN-Exec/CN-Test-Gen] Generate functions for assuming ownership

### DIFF
--- a/backend/cn/bin/main.ml
+++ b/backend/cn/bin/main.ml
@@ -496,7 +496,13 @@ let run_tests
               interactive
             }
           in
-          TestGeneration.run ~output_dir ~filename config sigma prog5;
+          TestGeneration.run
+            ~output_dir
+            ~filename
+            ~with_ownership_checking
+            config
+            sigma
+            prog5;
           if not dont_run then
             Unix.execv (Filename.concat output_dir "run_tests.sh") (Array.of_list []))
         ();

--- a/backend/cn/lib/cn_internal_to_ail.mli
+++ b/backend/cn/lib/cn_internal_to_ail.mli
@@ -57,7 +57,12 @@ type ail_executable_spec =
     in_stmt : (Locations.t * ail_bindings_and_statements) list
   }
 
-val generate_ownership_function
+val generate_check_ownership_function
+  :  with_ownership_checking:bool ->
+  C.ctype ->
+  A.sigma_declaration * CF.GenTypes.genTypeCategory A.sigma_function_definition
+
+val generate_assume_ownership_function
   :  with_ownership_checking:bool ->
   C.ctype ->
   A.sigma_declaration * CF.GenTypes.genTypeCategory A.sigma_function_definition
@@ -169,3 +174,19 @@ val cn_to_ail_pre_post_internal
   C.ctype ->
   Core_to_mucore.fn_spec_instrumentation option ->
   ail_executable_spec
+
+val cn_to_ail_assume_predicates_internal
+  :  (Sym.t * ResourcePredicates.definition) list ->
+  A.sigma_cn_datatype list ->
+  (Sym.t * C.ctype) list ->
+  (Sym.t * ResourcePredicates.definition) list ->
+  (A.sigma_declaration * CF.GenTypes.genTypeCategory A.sigma_function_definition) list
+
+val cn_to_ail_assume_pre_internal
+  :  A.sigma_cn_datatype list ->
+  C.union_tag ->
+  (C.union_tag * (BT.t * C.ctype)) list ->
+  (C.union_tag * C.ctype) list ->
+  (C.union_tag * ResourcePredicates.definition) list ->
+  'a LogicalArgumentTypes.t ->
+  A.sigma_declaration * CF.GenTypes.genTypeCategory A.sigma_function_definition

--- a/backend/cn/lib/testGeneration/specTests.ml
+++ b/backend/cn/lib/testGeneration/specTests.ml
@@ -6,6 +6,7 @@ module AT = ArgumentTypes
 module LAT = LogicalArgumentTypes
 module CtA = Cn_internal_to_ail
 module Utils = Executable_spec_utils
+module ESpecInternal = Executable_spec_internal
 module Config = TestGenConfig
 module SymSet = Set.Make (Sym)
 
@@ -207,7 +208,50 @@ let compile_random_tests
   concat_map (compile_random_test_case prog5 args_map convert_from) insts
 
 
+let compile_assumes
+  ~(with_ownership_checking : bool)
+  (sigma : CF.GenTypes.genTypeCategory A.sigma)
+  (prog5 : unit Mucore.file)
+  (insts : Core_to_mucore.instrumentation list)
+  : Pp.document
+  =
+  let declarations, function_definitions =
+    List.split
+      (List.map
+         (fun ctype ->
+           Cn_internal_to_ail.generate_assume_ownership_function
+             ~with_ownership_checking
+             ctype)
+         (let module CtypeSet =
+            Set.Make (struct
+              type t = C.ctype
+
+              let compare a b = compare (Hashtbl.hash a) (Hashtbl.hash b)
+            end)
+          in
+         !CtA.ownership_ctypes |> CtypeSet.of_list |> CtypeSet.to_seq |> List.of_seq)
+       @ Cn_internal_to_ail.cn_to_ail_assume_predicates_internal
+           prog5.resource_predicates
+           sigma.cn_datatypes
+           []
+           prog5.resource_predicates
+       @ ESpecInternal.generate_c_assume_pres_internal insts sigma prog5)
+  in
+  let open Pp in
+  separate_map
+    (twice hardline)
+    (fun (tag, (_, _, decl)) ->
+      CF.Pp_ail.pp_function_prototype ~executable_spec:true tag decl)
+    declarations
+  ^^ twice hardline
+  ^^ CF.Pp_ail.pp_program
+       ~executable_spec:true
+       ~show_include:true
+       (None, { A.empty_sigma with declarations; function_definitions })
+
+
 let compile_tests
+  ~(with_ownership_checking : bool)
   (filename_base : string)
   (sigma : CF.GenTypes.genTypeCategory A.sigma)
   (prog5 : unit Mucore.file)
@@ -239,6 +283,9 @@ let compile_tests
   ^^ string "#include "
   ^^ dquotes (string "cn.c")
   ^^ twice hardline
+  ^^ pp_label "Assume Ownership Functions"
+  ^^ twice hardline
+  ^^ compile_assumes ~with_ownership_checking sigma prog5 insts
   ^^ pp_label "Unit tests"
   ^^ twice hardline
   ^^ unit_tests_doc
@@ -422,6 +469,7 @@ let save ?(perm = 0o666) (output_dir : string) (filename : string) (doc : Pp.doc
 let generate
   ~(output_dir : string)
   ~(filename : string)
+  ~(with_ownership_checking : bool)
   (sigma : CF.GenTypes.genTypeCategory A.sigma)
   (prog5 : unit Mucore.file)
   : unit
@@ -443,7 +491,9 @@ let generate
   let generators_doc = compile_generators sigma prog5 insts in
   let generators_fn = filename_base ^ "_gen.h" in
   save output_dir generators_fn generators_doc;
-  let tests_doc = compile_tests filename_base sigma prog5 insts in
+  let tests_doc =
+    compile_tests ~with_ownership_checking filename_base sigma prog5 insts
+  in
   let test_file = filename_base ^ "_test.c" in
   save output_dir test_file tests_doc;
   let script_doc = compile_script ~output_dir ~test_file in

--- a/backend/cn/lib/testGeneration/specTests.mli
+++ b/backend/cn/lib/testGeneration/specTests.mli
@@ -4,6 +4,7 @@ module A = CF.AilSyntax
 val generate
   :  output_dir:string ->
   filename:string ->
+  with_ownership_checking:bool ->
   CF.GenTypes.genTypeCategory A.sigma ->
   unit Mucore.file ->
   unit

--- a/backend/cn/lib/testGeneration/testGeneration.ml
+++ b/backend/cn/lib/testGeneration/testGeneration.ml
@@ -7,6 +7,7 @@ let default_cfg : config = Config.default
 let run
   ~output_dir
   ~filename
+  ~with_ownership_checking
   (cfg : config)
   (sigma : Cerb_frontend.GenTypes.genTypeCategory Cerb_frontend.AilSyntax.sigma)
   (prog5 : unit Mucore.file)
@@ -16,5 +17,5 @@ let run
   if Option.is_some prog5.main then
     failwith "Cannot test a file with a `main` function";
   Cerb_debug.begin_csv_timing ();
-  SpecTests.generate ~output_dir ~filename sigma prog5;
+  SpecTests.generate ~output_dir ~filename ~with_ownership_checking sigma prog5;
   Cerb_debug.end_csv_timing "specification test generation"

--- a/backend/cn/lib/testGeneration/testGeneration.mli
+++ b/backend/cn/lib/testGeneration/testGeneration.mli
@@ -5,6 +5,7 @@ val default_cfg : config
 val run
   :  output_dir:string ->
   filename:string ->
+  with_ownership_checking:bool ->
   config ->
   Cerb_frontend.GenTypes.genTypeCategory Cerb_frontend.AilSyntax.sigma ->
   unit Mucore.file ->

--- a/runtime/libcn/include/cn-testing/dsl.h
+++ b/runtime/libcn/include/cn-testing/dsl.h
@@ -48,8 +48,7 @@
         goto cn_label_##last_var##_backtrack;                                           \
     }                                                                                   \
     void *tmp##_ptr = convert_from_cn_pointer(cn_pointer_add_cn_bits_u64(p, offset));   \
-    *(addr_ty*)tmp##_ptr = value;                                                       \
-    cn_assume_ownership(tmp##_ptr, sizeof(addr_ty), (char*)gen_name);
+    *(addr_ty*)tmp##_ptr = value;
 
 #define CN_GEN_LET_BEGIN(backtracks, var)                                               \
     int var##_backtracks = backtracks;                                                  \

--- a/runtime/libcn/include/cn-testing/test.h
+++ b/runtime/libcn/include/cn-testing/test.h
@@ -48,6 +48,7 @@ void cn_register_test_case(char* suite, char* name, cn_test_case_fn* func);
             if (cn_gen_backtrack_type() != CN_GEN_BACKTRACK_NONE) {                     \
                 return CN_TEST_GEN_FAIL;                                                \
             }                                                                           \
+            assume_##Name(__VA_ARGS__);                                                 \
             Init(res);                                                                  \
             Name(__VA_ARGS__);                                                          \
             cn_gen_rand_replace(checkpoint);                                            \


### PR DESCRIPTION
Allows separating generation and assuming ownership.
Would make memory management much simpler and cleaner for test case generation.