### PR TITLE
CN VIP: Add byte rep constraints for ptr & ints

### DIFF
--- a/backend/cn/lib/wellTyped.ml
+++ b/backend/cn/lib/wellTyped.ml
@@ -960,17 +960,17 @@ module WIT = struct
       fail (illtyped_index_term loc it (IT.bt it) ~expected ~reason))
 end
 
+let quantifier_bt = BT.Bits (Unsigned, 64)
+
 (* Throws a warning when the given index term is not a `u64`. *)
-let warn_when_not_u64
+let warn_when_not_quantifier_bt
   (ident : string)
   (loc : Locations.t)
   (bt : BaseTypes.t)
   (sym : document option)
   : unit
   =
-  match bt with
-  | Bits (Unsigned, 64) -> ()
-  | _t ->
+  if not (BT.equal bt quantifier_bt) then
     warn
       loc
       (squotes (string ident)
@@ -1017,7 +1017,7 @@ module WRET = struct
       assert (BT.equal (snd p.q) qbt);
       (*normalisation does not change bit types. If this assertion fails, we have to
         adjust the later code to use qbt.*)
-      warn_when_not_u64 "each" loc qbt (Some (Sym.pp (fst p.q)));
+      warn_when_not_quantifier_bt "each" loc qbt (Some (Sym.pp (fst p.q)));
       let@ step = WIT.check loc (snd p.q) p.step in
       let@ step =
         match step with
@@ -1861,7 +1861,11 @@ module BaseTyping = struct
         | E_Everything -> return ()
       in
       let@ it = WIT.infer it in
-      warn_when_not_u64 "extract" (IT.loc it) (IT.bt it) (Some (IndexTerms.pp it));
+      warn_when_not_quantifier_bt
+        "extract"
+        (IT.loc it)
+        (IT.bt it)
+        (Some (IndexTerms.pp it));
       return (Extract (attrs, to_extract, it))
     | Unfold (f, its) ->
       let@ def = get_logical_function_def loc f in

--- a/tests/cn/before_from_bytes.error.c
+++ b/tests/cn/before_from_bytes.error.c
@@ -1,0 +1,10 @@
+int main()
+{
+    int x = 0;
+    int *p = &x;
+    char *p_char = (char *)p;
+    /*@ to_bytes Owned<int>(p); @*/
+    /*@ extract Owned<char>, 2u64; @*/
+    p_char[2] = 0xff;
+    *p;
+}

--- a/tests/cn/before_to_bytes.error.c
+++ b/tests/cn/before_to_bytes.error.c
@@ -1,0 +1,7 @@
+int main()
+{
+    int x = 0;
+    int *p = &x;
+    char *p_char = (char *)p;
+    p_char[2] = 0xff;
+}

--- a/tests/cn/partial_init_bytes.error.c
+++ b/tests/cn/partial_init_bytes.error.c
@@ -1,0 +1,10 @@
+int main()
+{
+    int x;
+    int *p = &x;
+    /*@ to_bytes Block(p); @*/
+    char *p_char = (char *)p;
+    /*@ extract Block<char>, 2u64; @*/
+    p_char[2] = 0xff;
+    /*@ from_bytes Owned<int>(p); @*/
+}

--- a/tests/cn/to_bytes.error.c
+++ b/tests/cn/to_bytes.error.c
@@ -2,6 +2,5 @@ int main()
 {
     int x = 0;
     int *p = &x;
-    /*@ to_bytes Alloc(p); @*/ // <-- proof fails here, but this is a no-op in runtime
-    /*@ assert(false); @*/     // <-- so this is so that runtime testing also fails
+    /*@ to_bytes Alloc(p); @*/
 }

--- a/tests/cn/to_from_bytes_owned.c
+++ b/tests/cn/to_from_bytes_owned.c
@@ -3,7 +3,12 @@ int main()
     int x = 0;
     int *p = &x;
     /*@ to_bytes Owned(p); @*/
+    char *p_char = (char *)p;
+    /*@ extract Owned<char>, 2u64; @*/
+    p_char[2] = 0xff;
     /*@ from_bytes Owned<int>(p); @*/
+    /*@ assert (x == 16711680i32); @*/
     /*@ to_bytes Owned<int>(p); @*/
     /*@ from_bytes Owned<int>(p); @*/
+    /*@ assert (x == 16711680i32); @*/
 }

--- a/tests/run-cn-exec.sh
+++ b/tests/run-cn-exec.sh
@@ -178,6 +178,10 @@ SHOULD_FAIL=$(find cn -name '*.error.c' \
   ! -name "pointer_to_char_cast.error.c" \
   ! -name "pointer_to_unsigned_int_cast.error.c" \
   ! -name "ptr_diff2.error.c" \
+  ! -name "to_bytes.error.c" \
+  ! -name "before_from_bytes.error.c" \
+  ! -name "partial_init_bytes.error.c" \
+  ! -name "before_to_bytes.error.c" \
 )
 
 FAILED=""


### PR DESCRIPTION
For now, this commit ignores the issue of provenance for pointers and just representing the address. Also, it hard-codes endianness (big) but this should be switchable.