### PR TITLE
CN-Exec: Add work-around for VST hash

### DIFF
--- a/backend/cn/lib/cn_internal_to_ail.ml
+++ b/backend/cn/lib/cn_internal_to_ail.ml
@@ -454,6 +454,7 @@ let wrap_with_convert_from ?sct ail_expr_ bt =
 
 let get_equality_fn_call bt e1 e2 _dts =
   match bt with
+  (* TODO (RB) Check if buggy: https://github.com/rems-project/cerberus/pull/652 *)
   | BT.Map (_, val_bt) ->
     let val_ctype_with_ptr = bt_to_ail_ctype val_bt in
     let val_ctype = get_ctype_without_ptr val_ctype_with_ptr in

--- a/runtime/libcn/include/cn-executable/utils.h
+++ b/runtime/libcn/include/cn-executable/utils.h
@@ -151,6 +151,9 @@ cn_map *map_create(void);
 cn_map *cn_map_set(cn_map *m, cn_integer *key, void *value);
 cn_map *cn_map_deep_copy(cn_map *m1);
 cn_bool *cn_map_equality(cn_map *m1, cn_map *m2, cn_bool *(value_equality_fun)(void *, void *));
+// TODO (RB) does this need to be in here, or should it be auto-generated?
+// See https://github.com/rems-project/cerberus/pull/652 for details
+cn_bool *void_pointer_equality(void *p1, void *p2);
 
 #define convert_to_cn_map(c_ptr, cntype_conversion_fn, num_elements)({\
     cn_map *m = map_create();\

--- a/runtime/libcn/src/cn-executable/utils.c
+++ b/runtime/libcn/src/cn-executable/utils.c
@@ -399,7 +399,13 @@ cn_bool *cn_map_equality(cn_map *m1, cn_map *m2, cn_bool *(value_equality_fun)(v
     return cn_bool_and(cn_map_subset(m1, m2, value_equality_fun), cn_map_subset(m2, m1, value_equality_fun));
 }
 
-
+// TODO (RB) does this need to be in here, or should it be auto-generated?
+// See https://github.com/rems-project/cerberus/pull/652 for details
+cn_bool *void_pointer_equality(void *p1, void *p2) {
+    cn_bool *res = alloc(sizeof(cn_bool));
+    res->val = (p1 == p2);
+    return res;
+}
 
 cn_pointer *convert_to_cn_pointer(void *ptr) {
     cn_pointer *res = (cn_pointer *) alloc(sizeof(cn_pointer));


### PR DESCRIPTION
For some reason, this doesn't work

```c
15:09 ➜  VST git:(VST) ✗ cat tmp.c
struct cell {
  char * key;
  unsigned int count;
  struct cell * next;
};
enum {Buckets=109};
struct hashtable {
    struct cell *buckets[Buckets]; // Array to pointer of structs
};

int main()
{
    struct hashtable h = { .buckets = 0 };
    struct hashtable h2 = { .buckets = 0 };
    /*@ assert (h == h2); @*/
}
```

```sh
15:09 ➜  VST git:(VST) ✗ /home/dhruv/.opam/4.14.1/lib/cn/runtime/libexec/cn-runtime-single-file.sh -o tmp.c
Generating C files from CN-annotated source.
cn.c: In function ‘struct_hashtable_cn_equality’:
cn.c:49:98: error: ‘void_pointer_equality’ undeclared (first use in this function); did you mean ‘cn_pointer_equality’?
   49 |   return cn_bool_and(convert_to_cn_bool(true), cn_map_equality(x_cast->buckets, y_cast->buckets, void_pointer_equality));
      |                                                                                                  ^~~~~~~~~~~~~~~~~~~~~
      |                                                                                                  cn_pointer_equality
cn.c:49:98: note: each undeclared identifier is reported only once for each function it appears in
Failed to compile C files in /tmp/cn-exec.QEkJ.
```

And so a very quick hack/work-around is included in this commit.