### PR TITLE
Build multiplatform docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        platform: [linux/amd64, linux/arm64]
+        platform: ["linux/amd64,linux/arm64"]
     permissions:
       packages: write
       contents: read


### PR DESCRIPTION
The current build builds two single-platform images and then overwrites one with the other by pushing both to the same name.