### PR TITLE
CN VIP: Update the succ tests to use byte rep conv

### DIFF
--- a/backend/cn/lib/indexTerms.ml
+++ b/backend/cn/lib/indexTerms.ml
@@ -717,14 +717,18 @@ let gtPointer_ (it, it') loc = ltPointer_ (it', it) loc
 
 let gePointer_ (it, it') loc = lePointer_ (it', it) loc
 
-let cast_ bt it loc = IT (Cast (bt, it), bt, loc)
+let cast_ bt' it loc = if BT.equal bt' (bt it) then it else IT (Cast (bt', it), bt', loc)
 
 let uintptr_const_ n loc = num_lit_ n Memory.uintptr_bt loc
 
 let uintptr_int_ n loc = uintptr_const_ (Z.of_int n) loc
 (* for integer-mode: z_ n *)
 
-let addr_ it loc = cast_ Memory.uintptr_bt it loc
+let addr_ it loc =
+  assert (BT.equal (bt it) (Loc ()));
+  cast_ Memory.uintptr_bt it loc
+
+
 (* for integer-mode: cast_ Integer it *)
 
 let allocId_ it loc = cast_ Alloc_id it loc

--- a/backend/cn/lib/sctypes.ml
+++ b/backend/cn/lib/sctypes.ml
@@ -132,6 +132,8 @@ let struct_ct tag = Struct tag
 
 let char_ct = Integer Char
 
+let uchar_ct = Integer (Unsigned Ichar)
+
 let rec to_ctype (ct_ : ctype) =
   let ct_ =
     match ct_ with

--- a/tests/cn/to_from_bytes_block.c
+++ b/tests/cn/to_from_bytes_block.c
@@ -1,7 +1,7 @@
 void from_bytes(int *p)
 /*@ 
 requires 
-    take X = each (u64 i; i < sizeof<int>) { Block(array_shift<char>(p, i)) };
+    take X = each (u64 i; i < sizeof<int>) { Block(array_shift<unsigned char>(p, i)) };
 ensures
     take Y = Block(p);
 @*/
@@ -14,7 +14,7 @@ void to_bytes(int *p)
 requires 
     take Y = Block(p);
 ensures
-    take X = each (u64 i; i < sizeof<int>) { Block(array_shift<char>(p, i)) };
+    take X = each (u64 i; i < sizeof<int>) { Block(array_shift<unsigned char>(p, i)) };
 @*/
 {
     /*@ to_bytes Block(p); @*/

--- a/tests/cn/to_from_bytes_owned.c
+++ b/tests/cn/to_from_bytes_owned.c
@@ -3,8 +3,8 @@ int main()
     int x = 0;
     int *p = &x;
     /*@ to_bytes Owned(p); @*/
-    char *p_char = (char *)p;
-    /*@ extract Owned<char>, 2u64; @*/
+    unsigned char *p_char = (unsigned char *)p;
+    /*@ extract Owned<unsigned char>, 2u64; @*/
     p_char[2] = 0xff;
     /*@ from_bytes Owned<int>(p); @*/
     /*@ assert (x == 16711680i32); @*/

--- a/tests/cn_vip_testsuite/cn_lemmas.h
+++ b/tests/cn_vip_testsuite/cn_lemmas.h
@@ -108,6 +108,8 @@ ensures
     XR == YR;
 @*/
 
+#include <stddef.h>
+
 int _memcmp(unsigned char *dest, unsigned char *src, size_t n);
 /*@ spec _memcmp(pointer dest, pointer src, u64 n);
 
@@ -141,3 +143,12 @@ ensures
     Src == SrcR;
     SrcR == DestR;
 @*/
+
+/*@
+lemma assert_equal(u64 x, u64 y)
+requires
+    true;
+ensures
+    x == y;
+@*/
+

--- a/tests/cn_vip_testsuite/pointer_arith_algebraic_properties_2_global.annot.c
+++ b/tests/cn_vip_testsuite/pointer_arith_algebraic_properties_2_global.annot.c
@@ -6,6 +6,7 @@ int y[2], x[2];
 int main()
 /*@ accesses x; @*/
 {
+  /*CN_VIP*//*@ extract Owned<int>, 1u64; @*/
 #if defined(ANNOT)
   int *p= copy_alloc_id(
     (((uintptr_t)&(x[0])) +
@@ -16,7 +17,6 @@ int main()
   int *p=(int*)(((uintptr_t)&(x[0])) +
     (((uintptr_t)&(y[1]))-((uintptr_t)&(y[0]))));
 #endif
-  /*@ extract Owned<int>, 1u64; @*/
   *p = 11;  // is this free of undefined behaviour?
   /*CN_VIP*//*@ assert(x[1u64] == 11i32 && *p == 11i32); @*/
   //CN_VIP printf("x[1]=%d *p=%d\n",x[1],*p);

--- a/tests/cn_vip_testsuite/pointer_arith_algebraic_properties_3_global.annot.c
+++ b/tests/cn_vip_testsuite/pointer_arith_algebraic_properties_3_global.annot.c
@@ -6,6 +6,7 @@ int y[2], x[2];
 int main()
 /*CN_VIP*//*@ accesses x; @*/
 {
+  /*CN_VIP*//*@ extract Owned<int>, 1u64; @*/
 #if defined(ANNOT)
   int *p = copy_alloc_id(
     (((uintptr_t)&(x[0])) + ((uintptr_t)&(y[1])))
@@ -17,7 +18,6 @@ int main()
     (((uintptr_t)&(x[0])) + ((uintptr_t)&(y[1])))
     -((uintptr_t)&(y[0])) );
 #endif
-  /*@ extract Owned<int>, 1u64; @*/
   *p = 11;  // is this free of undefined behaviour?
   //(equivalent to the &x[0]+(&(y[1])-&(y[0])) version?)
   /*CN_VIP*//*@ assert(x[1u64] == 11i32 && *p == 11i32); @*/

--- a/tests/cn_vip_testsuite/pointer_copy_memcpy.c
+++ b/tests/cn_vip_testsuite/pointer_copy_memcpy.c
@@ -8,11 +8,15 @@ int main()
 {
   int *p = &x;
   int *q;
-  /*CN_VIP*/unsigned char *q_bytes = block_int_ptr_to_block_uchar_arr(&q);
-  /*CN_VIP*/unsigned char *p_bytes = owned_int_ptr_to_owned_uchar_arr(&p);
-  _memcpy (q_bytes, p_bytes, sizeof p);
-  /*CN_VIP*//*@ apply byte_ptr_to_int_ptr_ptr(q_bytes); @*/
-  /*CN_VIP*//*@ apply byte_ptr_to_int_ptr_ptr(p_bytes); @*/
+  /*CN_VIP*//*@ to_bytes Owned<int*>(&p); @*/
+  /*CN_VIP*//*@ to_bytes Block<int*>(&q); @*/
+  _memcpy ((unsigned char*)&q, (unsigned char*)&p, sizeof p);
+  /*CN_VIP*//*@ from_bytes Owned<int*>(&p); @*/
+  /*CN_VIP*//*@ from_bytes Owned<int*>(&q); @*/
+#ifdef NO_ROUND_TRIP
+  /*CN_VIP*/p = __cerbvar_copy_alloc_id((uintptr_t)p, &x); // only for *p in assertion
+  /*CN_VIP*/q = __cerbvar_copy_alloc_id((uintptr_t)q, &x);
+#endif
   *q = 11; // is this free of undefined behaviour?
   //CN_VIP printf("*p=%d  *q=%d\n",*p,*q);
   /*CN_VIP*//*@ assert(*p == 11i32 && *q == 11i32); @*/

--- a/tests/cn_vip_testsuite/pointer_copy_user_ctrlflow_bitwise.annot.c
+++ b/tests/cn_vip_testsuite/pointer_copy_user_ctrlflow_bitwise.annot.c
@@ -20,7 +20,7 @@ int main()
   /*CN_VIP*/bit=0;
   for (int k=0; k<uintptr_t_width; k++)
   /*@ inv i == (u64) p;
-          (u64) p == (u64) &x;
+          ptr_eq(p, &x);
           uintptr_t_width == 64u64;
           (0i32 <= k) && (k <= 64i32);
           let k_mask = shift_left(1u64, (u64) k) - 1u64;

--- a/tests/cn_vip_testsuite/pointer_copy_user_dataflow_direct_bytewise.unprovable.c
+++ b/tests/cn_vip_testsuite/pointer_copy_user_dataflow_direct_bytewise.unprovable.c
@@ -45,12 +45,16 @@ int main()
 {
   int *p = &x;
   int *q;
-  /*CN_VIP*/unsigned char *q_bytes = block_int_ptr_to_block_uchar_arr(&q);
-  /*CN_VIP*/unsigned char *p_bytes = owned_int_ptr_to_owned_uchar_arr(&p);
-  user_memcpy(q_bytes, p_bytes, sizeof(int *));
-  /*CN_VIP*//*@ apply byte_arrays_equal(q_bytes, p_bytes, sizeof<int*>); @*/
-  /*CN_VIP*//*@ apply byte_ptr_to_int_ptr_ptr(q_bytes); @*/
-  /*CN_VIP*//*@ apply byte_ptr_to_int_ptr_ptr(p_bytes); @*/
+  /*CN_VIP*//*@ to_bytes Owned<int*>(&p); @*/
+  /*CN_VIP*//*@ to_bytes Block<int*>(&q); @*/
+  user_memcpy((unsigned char*)&q, (unsigned char*)&p, sizeof(int *));
+  /*CN_VIP*//*@ apply byte_arrays_equal(&q, &p, sizeof<int*>); @*/
+  /*CN_VIP*//*@ from_bytes Owned<int*>(&q); @*/
+  /*CN_VIP*//*@ from_bytes Owned<int*>(&p); @*/
+#ifdef NO_ROUND_TRIP
+  /*CN_VIP*/q = __cerbvar_copy_alloc_id((uintptr_t)q, &x);
+  /*CN_VIP*/p = __cerbvar_copy_alloc_id((uintptr_t)p, &x);
+#endif
   *q = 11; // is this free of undefined behaviour?
   //CN_VIP printf("*p=%d  *q=%d\n",*p,*q);
   /*CN_VIP*//*@ assert(*q == 11i32 && *p == 11i32); @*/

--- a/tests/cn_vip_testsuite/pointer_from_int_disambiguation_2.c
+++ b/tests/cn_vip_testsuite/pointer_from_int_disambiguation_2.c
@@ -7,21 +7,27 @@
 
 int y=2, x=1;
 int main()
-/*CN_VIP*//*@ accesses x; accesses y; @*/
+/*CN_VIP*//*@ accesses x; accesses y; requires y == 2i32; @*/
 {
   int *p = &x+1;
   int *q = &y;
   uintptr_t i = (uintptr_t)p;
   uintptr_t j = (uintptr_t)q;
-  /*CN_VIP*/ unsigned char *p_bytes = owned_int_ptr_to_owned_uchar_arr(&p);
-  /*CN_VIP*/ unsigned char *q_bytes = owned_int_ptr_to_owned_uchar_arr(&q);
-  if (_memcmp(p_bytes, q_bytes, sizeof(p)) == 0) {
+  /*CN_VIP*//*@ to_bytes Owned<int*>(&p); @*/
+  /*CN_VIP*//*@ to_bytes Owned<int*>(&q); @*/
+  /*CN_VIP*/int result = _memcmp((unsigned char*)&p, (unsigned char*)&q, sizeof(p));
+  /*CN_VIP*//*@ from_bytes Owned<int*>(&p); @*/
+  /*CN_VIP*//*@ from_bytes Owned<int*>(&q); @*/
+  if (result == 0) {
+#ifdef NO_ROUND_TRIP
+    /*CN_VIP*/int *r = __cerbvar_copy_alloc_id(i, &x);
+    /*CN_VIP*/q = __cerbvar_copy_alloc_id((uintptr_t)q, &y); // for *q in assertion
+#else
     int *r = (int *)i;
+#endif
     r=r-1;  // is this free of UB?
     *r=11;  // and this?
     //CN_VIP printf("x=%d y=%d *q=%d *r=%d\n",x,y,*q,*r);
     /*CN_VIP*//*@ assert (x == 11i32 && y == 2i32 && *q == 2i32 && *r == 11i32); @*/
   }
-  /*CN_VIP*//*@ apply byte_ptr_to_int_ptr_ptr(p_bytes); @*/
-  /*CN_VIP*//*@ apply byte_ptr_to_int_ptr_ptr(q_bytes); @*/
 }

--- a/tests/cn_vip_testsuite/pointer_from_integer_1ig.annot.c
+++ b/tests/cn_vip_testsuite/pointer_from_integer_1ig.annot.c
@@ -3,14 +3,16 @@
 //CN_VIP #include <stdio.h>
 #include <stdint.h>
 #include "charon_address_guesses.h"
+#include "cn_lemmas.h"
 void f(uintptr_t i) {
   int j=5;
+  /*CN_VIP*//*@ apply assert_equal(i, (u64)&j); @*/
 #if defined(ANNOT)
   int *p = copy_alloc_id(i, &j);
 #else
   int *p = (int*)i;
 #endif
-  /*CN_VIP*/ /*@ assert ((alloc_id) p == (alloc_id) &j);@*/
+  /*CN_VIP*//*@ assert ((alloc_id) p == (alloc_id) &j);@*/
   if (p==&j) {
     *p=7;
     /*CN_VIP*//*@ assert (j == 7i32); @*/

--- a/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_xy.annot.c
+++ b/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_xy.annot.c
@@ -12,19 +12,24 @@ int main() {
   uintptr_t offset = uy - ux;
   //CN_VIP printf("Addresses: &x=%"PRIuPTR" &y=%"PRIuPTR\
          " offset=%"PRIuPTR" \n",(unsigned long)ux,(unsigned long)uy,(unsigned long)offset);
-#if defined(ANNOT)
+#ifdef ANNOT
   int *p = copy_alloc_id(ux + offset, &y);
 #else
   int *p = (int *)(ux + offset);
 #endif
   int *q = &y;
-  /*CN_VIP*/unsigned char *p_bytes = owned_int_ptr_to_owned_uchar_arr(&p);
-  /*CN_VIP*/unsigned char *q_bytes = owned_int_ptr_to_owned_uchar_arr(&q);
-  int result = _memcmp(p_bytes, q_bytes, sizeof(p));
-  /*CN_VIP*//*@ apply byte_ptr_to_int_ptr_ptr(p_bytes); @*/
-  /*CN_VIP*//*@ apply byte_ptr_to_int_ptr_ptr(q_bytes); @*/
+  /*CN_VIP*//*@ to_bytes Owned<int*>(&p); @*/
+  /*CN_VIP*//*@ to_bytes Owned<int*>(&q); @*/
+  /*CN_VIP*/int result = _memcmp((unsigned char *)&p, (unsigned char *)&q, sizeof(p));
+  /*CN_VIP*//*@ from_bytes Owned<int*>(&p); @*/
+  /*CN_VIP*//*@ from_bytes Owned<int*>(&q); @*/
+#ifdef NO_ROUND_TRIP
+  /*CN_VIP*/p = copy_alloc_id((uintptr_t)p, &y);
+  /*CN_VIP*/q = copy_alloc_id((uintptr_t)q, &y); // for *q in assertion
+#endif
   if (result == 0) {
     *p = 11; // is this free of UB?
+    /*CN_VIP*//*@ assert (x == 1i32 && y == 11i32 && *p == 11i32 && *q == 11i32); @*/
     //CN_VIP printf("x=%d y=%d *p=%d *q=%d\n",x,y,*p,*q);
   }
 }

--- a/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_yx.annot.c
+++ b/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_yx.annot.c
@@ -12,17 +12,21 @@ int main() {
   uintptr_t offset = uy - ux;
   //CN_VIP printf("Addresses: &x=%"PRIuPTR" &y=%"PRIuPTR\
          " offset=%"PRIuPTR" \n",(unsigned long)ux,(unsigned long)uy,(unsigned long)offset);
-#if defined(ANNOT)
+#ifdef ANNOT
   int *p = copy_alloc_id(ux + offset, &y);
 #else
   int *p = (int *)(ux + offset);
 #endif
   int *q = &y;
-  /*CN_VIP*/unsigned char *p_bytes = owned_int_ptr_to_owned_uchar_arr(&p);
-  /*CN_VIP*/unsigned char *q_bytes = owned_int_ptr_to_owned_uchar_arr(&q);
-  int result = _memcmp(p_bytes, q_bytes, sizeof(p));
-  /*CN_VIP*//*@ apply byte_ptr_to_int_ptr_ptr(p_bytes); @*/
-  /*CN_VIP*//*@ apply byte_ptr_to_int_ptr_ptr(q_bytes); @*/
+  /*CN_VIP*//*@ to_bytes Owned<int*>(&p); @*/
+  /*CN_VIP*//*@ to_bytes Owned<int*>(&q); @*/
+  int result = _memcmp((unsigned char*)&p, (unsigned char*)&q, sizeof(p));
+  /*CN_VIP*//*@ from_bytes Owned<int*>(&p); @*/
+  /*CN_VIP*//*@ from_bytes Owned<int*>(&q); @*/
+#ifdef NO_ROUND_TRIP
+  /*CN_VIP*/p = copy_alloc_id((uintptr_t)p, &y);
+  /*CN_VIP*/q = copy_alloc_id((uintptr_t)q, &y); // for *q in assertion
+#endif
   if (result == 0) {
     *p = 11; // is this free of UB?
     //CN_VIP printf("x=%d y=%d *p=%d *q=%d\n",x,y,*p,*q);

--- a/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_xy.annot.c
+++ b/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_xy.annot.c
@@ -20,11 +20,15 @@ int main()
   int *p = (int *)(ux + offset);
 #endif
   int *q = &y;
-  /*CN_VIP*/unsigned char *p_bytes = owned_int_ptr_to_owned_uchar_arr(&p);
-  /*CN_VIP*/unsigned char *q_bytes = owned_int_ptr_to_owned_uchar_arr(&q);
-  /*CN_VIP*/int result = _memcmp(p_bytes, q_bytes, sizeof(p));
-  /*CN_VIP*//*@ apply byte_ptr_to_int_ptr_ptr(p_bytes); @*/
-  /*CN_VIP*//*@ apply byte_ptr_to_int_ptr_ptr(q_bytes); @*/
+  /*CN_VIP*//*@ to_bytes Owned<int*>(&p); @*/
+  /*CN_VIP*//*@ to_bytes Owned<int*>(&q); @*/
+  /*CN_VIP*/int result = _memcmp((unsigned char*)&p, (unsigned char*)&q, sizeof(p));
+  /*CN_VIP*//*@ from_bytes Owned<int*>(&p); @*/
+  /*CN_VIP*//*@ from_bytes Owned<int*>(&q); @*/
+#ifdef NO_ROUND_TRIP
+  /*CN_VIP*/p = copy_alloc_id((uintptr_t)p, &y);
+  /*CN_VIP*/q = copy_alloc_id((uintptr_t)q, &y); // for *q in assertion
+#endif
   if (result == 0) {
     *p = 11; // is this free of UB?
     //CN_VIP printf("x=%d y=%d *p=%d *q=%d\n",x,y,*p,*q);

--- a/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_yx.annot.c
+++ b/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_yx.annot.c
@@ -21,12 +21,15 @@ int main()
 #endif
   int *q = &y;
 
-  /*CN_VIP*/unsigned char *p_bytes = owned_int_ptr_to_owned_uchar_arr(&p);
-  /*CN_VIP*/unsigned char *q_bytes = owned_int_ptr_to_owned_uchar_arr(&q);
-
-  /*CN_VIP*/int result = _memcmp(p_bytes, q_bytes, sizeof(p));
-  /*CN_VIP*//*@ apply byte_ptr_to_int_ptr_ptr(p_bytes); @*/
-  /*CN_VIP*//*@ apply byte_ptr_to_int_ptr_ptr(q_bytes); @*/
+  /*CN_VIP*//*@ to_bytes Owned<int*>(&p); @*/
+  /*CN_VIP*//*@ to_bytes Owned<int*>(&q); @*/
+  /*CN_VIP*/int result = _memcmp((unsigned char*)&p, (unsigned char*)&q, sizeof(p));
+  /*CN_VIP*//*@ from_bytes Owned<int*>(&p); @*/
+  /*CN_VIP*//*@ from_bytes Owned<int*>(&q); @*/
+#ifdef NO_ROUND_TRIP
+  /*CN_VIP*/p = copy_alloc_id((uintptr_t)p, &y);
+  /*CN_VIP*/q = copy_alloc_id((uintptr_t)q, &y); // for *q in assertion
+#endif
   if (result == 0) {
     *p = 11; // is this free of UB?
     //CN_VIP printf("x=%d y=%d *p=%d *q=%d\n",x,y,*p,*q);

--- a/tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_auto_yx.annot.c
+++ b/tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_auto_yx.annot.c
@@ -11,7 +11,8 @@ int main() {
   uintptr_t uy = (uintptr_t)&y;
   uintptr_t offset = 4;
   ux = ux + offset;
-#if defined(ANNOT)
+  /*@ apply assert_equal((u64) ux, uy); @*/
+#ifdef ANNOT
   int *p = copy_alloc_id(ux, &y);
 #else
   int *p = (int *)ux; // does this have undefined behaviour?
@@ -19,11 +20,15 @@ int main() {
   int *q = &y;
   //CN_VIP printf("Addresses: &x=%p p=%p &y=%"PRIxPTR\
          "\n",(void*)&x,(void*)p,(unsigned long)uy);
-  /*CN_VIP*/unsigned char* p_bytes = owned_int_ptr_to_owned_uchar_arr(&p);
-  /*CN_VIP*/unsigned char* q_bytes = owned_int_ptr_to_owned_uchar_arr(&q);
-  /*CN_VIP*/int result = _memcmp(p_bytes, q_bytes, sizeof(p));
-  /*CN_VIP*//*@ apply byte_ptr_to_int_ptr_ptr(p_bytes); @*/
-  /*CN_VIP*//*@ apply byte_ptr_to_int_ptr_ptr(q_bytes); @*/
+  /*CN_VIP*//*@ to_bytes Owned<int*>(&p); @*/
+  /*CN_VIP*//*@ to_bytes Owned<int*>(&q); @*/
+  /*CN_VIP*/int result = _memcmp((unsigned char*)&p, (unsigned char*)&q, sizeof(p));
+  /*CN_VIP*//*@ from_bytes Owned<int*>(&p); @*/
+  /*CN_VIP*//*@ from_bytes Owned<int*>(&q); @*/
+#ifdef NO_ROUND_TRIP
+  /*CN_VIP*/p = copy_alloc_id((uintptr_t)p, &y);
+  /*CN_VIP*/q = copy_alloc_id((uintptr_t)q, &y); // for *q in assertion
+#endif
   if (result == 0) {
     *p = 11; // does this have undefined behaviour?
     /*CN_VIP*//*@ assert(x == 1i32 && y == 11i32 && *p == 11i32 && *q == 11i32); @*/

--- a/tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_global_yx.annot.c
+++ b/tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_global_yx.annot.c
@@ -13,6 +13,7 @@ int main()
   uintptr_t uy = (uintptr_t)&y;
   uintptr_t offset = 4;
   ux = ux + offset;
+  /*@ apply assert_equal((u64) ux, uy); @*/
 #if defined(ANNOT)
   int *p = copy_alloc_id(ux, &y);
 #else
@@ -21,11 +22,15 @@ int main()
   int *q = &y;
   //CN_VIP printf("Addresses: &x=%p p=%p &y=%"PRIxPTR\
          "\n",(void*)&x,(void*)p,(unsigned long)uy);
-  /*CN_VIP*/unsigned char* p_bytes = owned_int_ptr_to_owned_uchar_arr(&p);
-  /*CN_VIP*/unsigned char* q_bytes = owned_int_ptr_to_owned_uchar_arr(&q);
-  /*CN_VIP*/int result = _memcmp(p_bytes, q_bytes, sizeof(p));
-  /*CN_VIP*//*@ apply byte_ptr_to_int_ptr_ptr(p_bytes); @*/
-  /*CN_VIP*//*@ apply byte_ptr_to_int_ptr_ptr(q_bytes); @*/
+  /*CN_VIP*//*@ to_bytes Owned<int*>(&p); @*/
+  /*CN_VIP*//*@ to_bytes Owned<int*>(&q); @*/
+  /*CN_VIP*/int result = _memcmp((unsigned char*)&p, (unsigned char*)&q, sizeof(p));
+  /*CN_VIP*//*@ from_bytes Owned<int*>(&p); @*/
+  /*CN_VIP*//*@ from_bytes Owned<int*>(&q); @*/
+#ifdef NO_ROUND_TRIP
+  /*CN_VIP*/p = copy_alloc_id((uintptr_t)p, &y);
+  /*CN_VIP*/q = copy_alloc_id((uintptr_t)q, &y); // for *q in assertion
+#endif
   if (result == 0) {
     *p = 11; // does this have undefined behaviour?
     /*CN_VIP*//*@ assert(x == 1i32 && y == 11i32 && *p == 11i32 && *q == 11i32); @*/

--- a/tests/cn_vip_testsuite/provenance_equality_uintptr_t_auto_yx.c
+++ b/tests/cn_vip_testsuite/provenance_equality_uintptr_t_auto_yx.c
@@ -1,7 +1,9 @@
 //CN_VIP #include <stdio.h>
 #include <inttypes.h>
+#include "cn_lemmas.h"
 int main() {
   int y=2, x=1;
+  /*@ apply assert_equal((u64)&x + 4u64, (u64)&y); @*/
   uintptr_t p = (uintptr_t)(&x + 1);
   uintptr_t q = (uintptr_t)&y;
   //CN_VIP printf("Addresses: p=%" PRIxPTR " q=%" PRIxPTR "\n", (unsigned long)p,(unsigned long)q);

--- a/tests/cn_vip_testsuite/provenance_equality_uintptr_t_global_yx.c
+++ b/tests/cn_vip_testsuite/provenance_equality_uintptr_t_global_yx.c
@@ -1,7 +1,9 @@
 //CN_VIP #include <stdio.h>
 #include <inttypes.h>
+#include "cn_lemmas.h"
 int y=2, x=1;
 int main() {
+  /*@ apply assert_equal((u64)&x + 4u64, (u64)&y); @*/
   uintptr_t p = (uintptr_t)(&x + 1);
   uintptr_t q = (uintptr_t)&y;
   //CN_VIP printf("Addresses: p=%" PRIxPTR " q=%" PRIxPTR "\n", (unsigned long)p,(unsigned long)q);

--- a/tests/cn_vip_testsuite/provenance_lost_escape_1.annot.c
+++ b/tests/cn_vip_testsuite/provenance_lost_escape_1.annot.c
@@ -14,17 +14,18 @@ int main()
   uintptr_t i2 = i1 & 0x00000000FFFFFFFF;//
   uintptr_t i3 = i2 & 0xFFFFFFFF00000000;// (@1,0x0)
   uintptr_t i4 = i3 + ADDR_PLE_1;        // (@1,ADDR_PLE_1)
-#if defined(ANNOT)
+  /*@ apply assert_equal(i4, (u64)&x); @*/
+#ifdef ANNOT
   int *q = copy_alloc_id(i4, p);
 #else
   int *q = (int *)i4;
 #endif
   //CN_VIP printf("Addresses: p=%p\n",(void*)p);
-  /*CN_VIP*/unsigned char* i1_bytes = owned_uintptr_t_to_owned_uchar_arr(&i1);
-  /*CN_VIP*/unsigned char* i4_bytes = owned_uintptr_t_to_owned_uchar_arr(&i4);
-  /*CN_VIP*/int result = _memcmp(i1_bytes, i4_bytes, sizeof(i1));
-  /*CN_VIP*//*@ apply byte_ptr_to_uintptr_t(i1_bytes); @*/
-  /*CN_VIP*//*@ apply byte_ptr_to_uintptr_t(i4_bytes); @*/
+  /*CN_VIP*//*@ to_bytes Owned<uintptr_t>(&i1); @*/
+  /*CN_VIP*//*@ to_bytes Owned<uintptr_t>(&i4); @*/
+  /*CN_VIP*/int result = _memcmp((unsigned char*)&i1, (unsigned char*)&i4, sizeof(i1));
+  /*CN_VIP*//*@ from_bytes Owned<uintptr_t>(&i1); @*/
+  /*CN_VIP*//*@ from_bytes Owned<uintptr_t>(&i4); @*/
   if (result == 0) {
     *q = 11;  // does this have defined behaviour?
     /*CN_VIP*//*@ assert(x == 11i32 && *p == 11i32 && *q == 11i32); @*/

--- a/tests/cn_vip_testsuite/provenance_roundtrip_via_intptr_t.c
+++ b/tests/cn_vip_testsuite/provenance_roundtrip_via_intptr_t.c
@@ -1,10 +1,15 @@
 //CN_VIP #include <stdio.h>
 #include <inttypes.h>
 int x=1;
-int main() {
+int main()
+/*CN_VIP*//*@ accesses x; @*/
+{
   int *p = &x;
   intptr_t i = (intptr_t)p;
-  int *q = (int *)i;
+  /*CN_VIP*/int *q = (int *)i;
+#ifdef NO_ROUND_TRIP
+  /*CN_VIP*/q = __cerbvar_copy_alloc_id((uintptr_t)q, &x);
+#endif
   *q = 11; // is this free of undefined behaviour?
   //CN_VIP printf("*p=%d  *q=%d\n",*p,*q);
   /*CN_VIP*//*@ assert(*p == 11i32 && *q == 11i32); @*/

--- a/tests/cn_vip_testsuite/provenance_roundtrip_via_intptr_t_onepast.c
+++ b/tests/cn_vip_testsuite/provenance_roundtrip_via_intptr_t_onepast.c
@@ -13,7 +13,10 @@ requires
   int *p = &x;
   p=p+1;
   intptr_t i = (intptr_t)p;
-  int *q = (int *)i;
+  /*CN_VIP*/int *q = (int *)i;
+#ifdef NO_ROUND_TRIP
+  /*CN_VIP*/q = __cerbvar_copy_alloc_id((uintptr_t)q, &x);
+#endif
   q=q-1;
   *q = 11; // is this free of undefined behaviour?
   //CN_VIP printf("*q=%d\n",*q);

--- a/tests/cn_vip_testsuite/provenance_tag_bits_via_uintptr_t_1.annot.c
+++ b/tests/cn_vip_testsuite/provenance_tag_bits_via_uintptr_t_1.annot.c
@@ -1,3 +1,4 @@
+// NOTE: terminates with cvc5 but not Z3
 #include "refinedc.h"
 
 #include <assert.h>

--- a/tests/cn_vip_testsuite/refinedc.h
+++ b/tests/cn_vip_testsuite/refinedc.h
@@ -1,12 +1,7 @@
 #include <stdint.h>
 
-static inline void *copy_alloc_id(uintptr_t to, void *from)
-/*@ ensures (alloc_id) return == (alloc_id) from;
-            (u64) return == (u64) to; @*/
-{
 #if defined(__cerb__) && defined(VIP)
-    return __cerbvar_copy_alloc_id(to, from);
+#define copy_alloc_id(to, from) __cerbvar_copy_alloc_id(to, from)
 #else
-  return ((uintptr_t) (from), (void*) (to));
+#define copy_alloc_id(to, from) ((uintptr_t) (from), (void*) (to))
 #endif
-}

--- a/tests/run-cn-vip.sh
+++ b/tests/run-cn-vip.sh
@@ -1,13 +1,53 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail -o noclobber
 
-# set -xv
+# copying from run-ci.sh
+# Z3=$(ocamlfind query z3)
+# export DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH:-}:${Z3}"
+# export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}:${Z3}"
 
-export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:`ocamlfind query z3`
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`ocamlfind query z3`
-CN=$OPAM_SWITCH_PREFIX/bin/cn
+USAGE="USAGE: $0 [-h]"
 
+function echo_and_err() {
+    printf "%s\n" "$1"
+    exit 1
+}
 
-DIRNAME=$(dirname $0)
+LEMMATA=0
+
+while getopts "h" flag; do
+ case "$flag" in
+   h)
+   printf "%s\n" "${USAGE}"
+   exit 0
+   ;;
+   \?)
+   echo_and_err "${USAGE}"
+   ;;
+ esac
+done
+
+function exits_with_code() {
+  local action=$1
+  local file=$2
+  local -a expected_exit_codes=$3
+
+  printf "[$file]...\n"
+  timeout 15 ${action} "$file"
+  local result=$?
+
+  for code in "${expected_exit_codes[@]}"; do
+    if [ $result -eq $code ]; then
+      printf "\033[32mPASS\033[0m\n"
+      return 0
+    fi
+  done
+
+  printf "\033[31mFAIL\033[0m (Unexpected return code: %d)\n" "$result"
+  return 1
+}
+
+DIRNAME=$(dirname "$0")
 
 SUCC=$(
     find $DIRNAME/cn_vip_testsuite -name '*.c' \
@@ -15,30 +55,19 @@ SUCC=$(
         \! -name '*.error.c' \
         \! -name '*.unprovable.c' \
 )
-FAIL=$(find $DIRNAME/cn -name '*.error.c')
-ANNOT=$(find $DIRNAME/cn -name '*.annot.c')
+FAIL=$(find $DIRNAME/cn_vip_testsuite -name '*.error.c')
+ANNOT=$(find $DIRNAME/cn_vip_testsuite -name '*.annot.c')
 UNPROV=$(
-    find $DIRNAME/cn -name '*.unprovable.c' \
+    find $DIRNAME/cn_vip_testsuite -name '*.unprovable.c' \
         \! -name 'pointer_copy_user_ctrlflow_bytewise.unprovable.c'
 )
 
-NUM_FAILED=0
 FAILED=''
 
-
-for TEST in $SUCC $ANNOT
-do
-  $CN verify -DVIP -DANNOT $TEST
-  RET=$?
-  if [[ "$RET" = 0 ]]
-  then
-    echo "$TEST -- OK"
-  else
-    echo "$TEST -- Unexpected"
-    NUM_FAILED=$(( $NUM_FAILED + 1 ))
-    FAILED="$FAILED $TEST"
+for TEST in ${SUCC} ${ANNOT}; do
+  if ! exits_with_code "cn verify -DVIP -DANNOT -DNO_ROUND_TRIP --solver-type=cvc5" "${TEST}" 0; then
+      FAILED+=" ${TEST}"
   fi
-  echo
 done
 
 # TODO add below with both -DNON_DET_TRUE and -DNON_DET_FALSE
@@ -46,29 +75,27 @@ done
 # provenance_equality_global_fn_yx.c
 # provenance_equality_global_yx.c
 
-for TEST in $FAIL $ANNOT $UNPROV
-do
-  $CN verify $TEST
-  RET=$?
-  if [[ "$RET" = 1 || "$RET" = 2 ]]
-  then
-    echo "$TEST -- OK"
-  else
-    echo "$TEST -- Unexpected"
-    NUM_FAILED=$(( $NUM_FAILED + 1 ))
-    FAILED="$FAILED $TEST"
-  fi
-  echo
-done
+# for TEST in $FAIL $ANNOT $UNPROV
+# do
+#   echo $CN verify $TEST
+#   RET=$?
+#   if [[ "$RET" = 1 || "$RET" = 2 ]]
+#   then
+#     echo "$TEST -- OK"
+#   else
+#     echo "$TEST -- Unexpected"
+#     NUM_FAILED=$(( $NUM_FAILED + 1 ))
+#     FAILED="$FAILED $TEST"
+#   fi
+#   echo
+# done
 
-if [ -z "$FAILED" ]
-then
-  echo "All tests passed."
+if [ -z "${FAILED}" ]; then
   exit 0
 else
-  echo "$NUM_FAILED tests failed:"
-  echo "  $FAILED"
+  printf "\033[31mFAILED: %s\033[0m\n" "${FAILED}"
   exit 1
 fi
+
 
 


### PR DESCRIPTION
Because of the lack of roundtrip support (not just via u/intptr_t, but also via byte representations) this commit adds a `#ifdef NO_ROUND_TRIP` line to many tests to compensate by using a copy_alloc_id (though this is possible in these tests, it won't always be possible in general).

All the added lines are of the form `p = copy_alloc_id((uintptr_t)p, q)` which means that the prior code must get the address correct for only the allocation ID to be fixed up.