### PR TITLE
[CN-exec] Complete pattern matching translation

### DIFF
--- a/backend/cn/lib/cn_internal_to_ail.ml
+++ b/backend/cn/lib/cn_internal_to_ail.ml
@@ -1395,6 +1395,10 @@ let rec cn_to_ail_expr_aux_internal
       A.bindings * _ A.statement_ list
       =
       fun count vars cases ->
+      let result_sym = Sym.fresh () in
+      let _result_ident = A.(AilEident result_sym) in
+      let _result_binding = create_binding result_sym (bt_to_ail_ctype basetype) in
+      let _result_decl = A.(AilSdeclaration [ (result_sym, None) ]) in
       match vars with
       | [] ->
         (match cases with

--- a/backend/cn/lib/cn_internal_to_ail.ml
+++ b/backend/cn/lib/cn_internal_to_ail.ml
@@ -1472,7 +1472,8 @@ let rec cn_to_ail_expr_aux_internal
                  let stat_block =
                    A.AilSblock
                      ( constr_binding :: bindings,
-                       constructor_var_assign :: List.map mk_stmt member_stats )
+                       (constructor_var_assign :: List.map mk_stmt member_stats)
+                       @ [ mk_stmt AilSbreak ] )
                  in
                  let tag_sym =
                    generate_sym_with_suffix ~suffix:"" ~uppercase:true constr_sym


### PR DESCRIPTION
Fill in remaining parts of pattern matching translation in `Cn_internal_to_ail.ml` for all destinations. Unblocks @ZippeyKeys12 on test-gen work.