### PR TITLE
[CN-Test-Gen] Reset error message info between runs

### DIFF
--- a/runtime/libcn/include/cn-executable/utils.h
+++ b/runtime/libcn/include/cn-executable/utils.h
@@ -46,6 +46,7 @@ void initialise_error_msg_info_(const char *function_name, char *file_name, int 
 
 #define initialise_error_msg_info() initialise_error_msg_info_(__func__, __FILE__, __LINE__)
 
+void reset_error_msg_info();
 
 /* TODO: Implement */
 /*struct cn_error_messages {

--- a/runtime/libcn/include/cn-testing/test.h
+++ b/runtime/libcn/include/cn-testing/test.h
@@ -68,6 +68,7 @@ int cn_test_main(int argc, char* argv[]);
 
 #define CN_TEST_INIT()                                                                  \
     free_all();                                                                         \
+    reset_error_msg_info();                                                             \
     initialise_ownership_ghost_state();                                                 \
     initialise_ghost_stack_depth();                                                     \
     cn_gen_backtrack_reset();                                                           \

--- a/runtime/libcn/src/cn-executable/utils.c
+++ b/runtime/libcn/src/cn-executable/utils.c
@@ -431,6 +431,10 @@ void initialise_error_msg_info_(const char *function_name, char *file_name, int 
   error_msg_info = make_error_message_info_entry(function_name, file_name, line_number, 0, NULL);
 }
 
+void reset_error_msg_info() {
+  error_msg_info = NULL;
+}
+
 void cn_pop_msg_info ()
 {
   struct cn_error_message_info *old = error_msg_info;


### PR DESCRIPTION
Failing test cases' error reporting was broken by #651, this fixes it.