### PR TITLE
[CN-Test-Gen] Rewrite ownership and allocation checking

### DIFF
--- a/backend/cn/lib/testGeneration/genCodeGen.ml
+++ b/backend/cn/lib/testGeneration/genCodeGen.ml
@@ -198,7 +198,21 @@ let rec compile_term
                              mk_expr (AilEstr (None, [ (loc, [ Sym.pp_string name ]) ]))
                            ));
                       mk_expr (AilEident last_var)
-                    ] )))
+                    ]
+                    @ List.map
+                        (fun x ->
+                          mk_expr
+                            (AilEcast
+                               ( C.no_qualifiers,
+                                 C.pointer_to_char,
+                                 mk_expr
+                                   (AilEstr
+                                      ( None,
+                                        [ (Locations.other __LOC__, [ Sym.pp_string x ]) ]
+                                      )) )))
+                        (List.of_seq
+                           (SymSet.to_seq (SymSet.add pointer (IT.free_vars offset))))
+                    @ [ mk_expr (AilEconst ConstantNull) ] )))
         ]
     in
     let b4, s4, e4 = compile_term sigma name rest in

--- a/backend/cn/lib/testGeneration/specTests.ml
+++ b/backend/cn/lib/testGeneration/specTests.ml
@@ -393,6 +393,7 @@ let compile_script ~(output_dir : string) ~(test_file : string) : Pp.document =
        string
        [ "if";
          "cc";
+         "-g";
          "\"-I${RUNTIME_PREFIX}/include\"";
          "-o \"${TEST_DIR}/tests.out\"";
          "${TEST_DIR}/" ^ Filename.chop_extension test_file ^ ".o";

--- a/runtime/libcn/include/cn-testing/alloc.h
+++ b/runtime/libcn/include/cn-testing/alloc.h
@@ -13,11 +13,25 @@ extern "C" {
 
     void cn_gen_alloc_reset(void);
 
+    void* cn_gen_alloc_save(void);
+
+    void cn_gen_alloc_restore(void* ptr);
+
+    void cn_gen_ownership_reset(void);
+
+    void* cn_gen_ownership_save(void);
+
+    void cn_gen_ownership_restore(void* ptr);
+
     cn_pointer* cn_gen_alloc(cn_bits_u64* sz);
 
     cn_pointer* cn_gen_aligned_alloc(cn_bits_u64* alignment, cn_bits_u64* sz);
 
-    cn_bits_u64* cn_gen_alloc_size(cn_pointer* p);
+    int cn_gen_alloc_check(void* p, size_t sz);
+
+    void cn_gen_ownership_update(void* p, size_t sz);
+
+    int cn_gen_ownership_check(cn_pointer* p, size_t sz);
 
 #ifdef __cplusplus
 }

--- a/runtime/libcn/include/cn-testing/test.h
+++ b/runtime/libcn/include/cn-testing/test.h
@@ -73,7 +73,8 @@ int cn_test_main(int argc, char* argv[]);
     initialise_ownership_ghost_state();                                                 \
     initialise_ghost_stack_depth();                                                     \
     cn_gen_backtrack_reset();                                                           \
-    cn_gen_alloc_reset();
+    cn_gen_alloc_reset();                                                               \
+    cn_gen_ownership_reset();
 
 #define CN_TEST_GENERATE(name) ({                                                       \
     struct cn_gen_##name##_record* res = cn_gen_##name();                               \

--- a/runtime/libcn/src/cn-testing/gen_alloc.c
+++ b/runtime/libcn/src/cn-testing/gen_alloc.c
@@ -1,19 +1,66 @@
 #include "stdlib.h"
 
 #include <cn-executable/utils.h>
-
 #include <cn-testing/prelude.h>
+
+#define MEM_SIZE (1024 * 1024 * 256)
+static char alloc_buf[MEM_SIZE];
+static void* alloc_curr = alloc_buf;
+
+void cn_gen_alloc_reset(void) {
+    alloc_curr = alloc_buf;
+}
+
+void* cn_gen_alloc_save(void) {
+    return alloc_curr;
+}
+
+void cn_gen_alloc_restore(void* ptr) {
+    alloc_curr = ptr;
+}
+
+static char ownership_buf[MEM_SIZE];
+static void* ownership_curr = ownership_buf;
+
+void cn_gen_ownership_reset(void) {
+    ownership_curr = ownership_buf;
+}
+
+void* cn_gen_ownership_save(void) {
+    return ownership_curr;
+}
+
+void cn_gen_ownership_restore(void* ptr) {
+    ownership_curr = ptr;
+}
+
+struct pointer_data {
+    void* ptr;
+    size_t sz;
+};
+
+static void update_alloc(void* ptr, size_t sz) {
+    if ((uintptr_t)alloc_curr - (uintptr_t)alloc_buf + sizeof(struct pointer_data) > MEM_SIZE) {
+        printf("Out of space for allocation metadata!\n");
+        exit(1);
+    }
+    *(struct pointer_data*)alloc_curr = (struct pointer_data){ .ptr = ptr, .sz = sz };
+    alloc_curr = (char*)alloc_curr + sizeof(struct pointer_data);
+}
+
+static void update_ownership(void* ptr, size_t sz) {
+    if ((uintptr_t)ownership_curr - (uintptr_t)ownership_buf + sizeof(struct pointer_data) > MEM_SIZE) {
+        printf("Out of space for ownership metadata!\n");
+        exit(1);
+    }
+    *(struct pointer_data*)ownership_curr = (struct pointer_data){ .ptr = ptr, .sz = sz };
+    ownership_curr = (char*)ownership_curr + sizeof(struct pointer_data);
+}
 
 static uint8_t null_in_every = 4;
 
 void set_null_in_every(uint8_t n) {
     null_in_every = n;
-}
-
-static hash_table* pointer_size_map = 0;
-
-void cn_gen_alloc_reset(void) {
-    pointer_size_map = ht_create();
 }
 
 cn_pointer* cn_gen_alloc(cn_bits_u64* sz) {
@@ -31,17 +78,13 @@ cn_pointer* cn_gen_alloc(cn_bits_u64* sz) {
         }
         else {
             p = alloc(1);
-            uint64_t* size = alloc(sizeof(uint64_t));
-            *size = bytes + 1;
-            ht_set(pointer_size_map, (intptr_t*)&p, size);
+            update_alloc(p, 1);
         }
         return convert_to_cn_pointer(p);
     }
     else {
         void* p = alloc(bytes);
-        uint64_t* size = alloc(sizeof(uint64_t));
-        *size = bytes;
-        ht_set(pointer_size_map, (intptr_t*)&p, size);
+        update_alloc(p, bytes);
         return convert_to_cn_pointer(p);
     }
 }
@@ -60,37 +103,79 @@ cn_pointer* cn_gen_aligned_alloc(cn_bits_u64* alignment, cn_bits_u64* sz) {
 
     if (bytes == 0) {
         void* p;
-        uint64_t rnd = convert_from_cn_bits_u64(cn_gen_uniform_cn_bits_u64(0));
-        if ((rnd % 2) == 0) {
+        uint64_t rnd = convert_from_cn_bits_u8(cn_gen_uniform_cn_bits_u8(null_in_every));
+        if (rnd == 0) {
             p = NULL;
         }
         else {
             p = aligned_alloc(align, 1);
-            uint64_t* size = alloc(sizeof(uint64_t));
-            *size = bytes + 1;
-            ht_set(pointer_size_map, (intptr_t*)&p, size);
+            update_alloc(p, 1);
         }
         return convert_to_cn_pointer(p);
     }
     else {
         void* p = aligned_alloc(align, bytes);
-        uint64_t* size = alloc(sizeof(uint64_t));
-        *size = bytes;
-        ht_set(pointer_size_map, (intptr_t*)&p, size);
+        update_alloc(p, bytes);
         return convert_to_cn_pointer(p);
     }
 }
 
-cn_bits_u64* cn_gen_alloc_size(cn_pointer* p) {
-    void* ptr = convert_from_cn_pointer(p);
-    if (ptr == NULL) {
-        return convert_to_cn_bits_u64(0);
+int cn_gen_alloc_check(void* p, size_t sz) {
+    if (alloc_curr == alloc_buf) {
+        return 0;
     }
 
-    uint64_t* value = (uint64_t*)ht_get(pointer_size_map, (signed long*)&ptr);
-    if (value == NULL) {
-        return convert_to_cn_bits_u64(0);
+    int bytes = sz;
+
+    struct pointer_data* q = (struct pointer_data*)(
+        (uintptr_t)alloc_curr - sizeof(struct pointer_data));
+    for (; (uintptr_t)q >= (uintptr_t)alloc_buf; q--) {
+        uintptr_t lb = (uintptr_t)q->ptr;
+        uintptr_t ub = (uintptr_t)q->ptr + q->sz;
+        if (lb < (uintptr_t)p) {
+            lb = (uintptr_t)p;
+        }
+        if (ub > (uintptr_t)p + sz) {
+            ub = (uintptr_t)p + sz;
+        }
+        if (ub > lb) {
+            bytes -= (ub - lb);
+        }
+
+        if (bytes == 0) {
+            return 1;
+        }
+    }
+    assert(bytes >= 0);
+    return (bytes == 0);
+}
+
+void cn_gen_ownership_update(void* p, size_t sz) {
+    update_ownership(p, sz);
+}
+
+int cn_gen_ownership_check(cn_pointer* p, size_t sz) {
+    if (ownership_curr == ownership_buf) {
+        return 1;
     }
 
-    return convert_to_cn_bits_u64(*value);
+    int bytes = sz;
+
+    struct pointer_data* q = (struct pointer_data*)(
+        (uintptr_t)ownership_curr - sizeof(struct pointer_data));
+    for (; (uintptr_t)q >= (uintptr_t)ownership_buf; q--) {
+        uintptr_t lb = (uintptr_t)q->ptr;
+        uintptr_t ub = (uintptr_t)q->ptr + q->sz;
+        if (lb < (uintptr_t)p) {
+            lb = (uintptr_t)p;
+        }
+        if (ub > (uintptr_t)p + sz) {
+            ub = (uintptr_t)p + sz;
+        }
+        if (ub > lb) {
+            return 0;
+        }
+    }
+
+    return 1;
 }


### PR DESCRIPTION
Previously, we had a slightly unsound approach that piggy-backed off the executable spec work. Now there's a fully sound version that provides checkpoints, without sacrificing too much speed.

This means not using the CN-Exec allocator. With the CN allocator's only use during generation being for the values constructed, we can implement a similar checkpoint system in order to no longer leak memory when backtracking.