### PR TITLE
[CN-Exec/CN-Test-Gen] Add allocation checkpoints

### DIFF
--- a/runtime/libcn/include/cn-executable/alloc.h
+++ b/runtime/libcn/include/cn-executable/alloc.h
@@ -28,6 +28,12 @@ void *zalloc_(long nbytes, const char *, int);
 
 void free_all(void);
 
+typedef void* alloc_checkpoint;
+
+alloc_checkpoint alloc_save_checkpoint(void);
+
+void free_after(alloc_checkpoint ptr);
+
 // void *alloc_zeros(long nbytes);
 
 #ifdef __cplusplus

--- a/runtime/libcn/include/cn-testing/dsl.h
+++ b/runtime/libcn/include/cn-testing/dsl.h
@@ -66,6 +66,7 @@
     int var##_backtracks = backtracks;                                                  \
     cn_label_##var##_gen:                                                               \
         ;                                                                               \
+        alloc_checkpoint var##_checkpoint = alloc_save_checkpoint();                    \
         void *var##_alloc_checkpoint = cn_gen_alloc_save();                             \
         void *var##_ownership_checkpoint = cn_gen_ownership_save();
 
@@ -76,6 +77,7 @@
 #define CN_GEN_LET_END(backtracks, var, last_var, ...)                                  \
         if (cn_gen_backtrack_type() != CN_GEN_BACKTRACK_NONE) {                         \
         cn_label_##var##_backtrack:                                                     \
+            free_after(var##_checkpoint);                                               \
             cn_gen_alloc_restore(var##_alloc_checkpoint);                               \
             cn_gen_ownership_restore(var##_ownership_checkpoint);                       \
             if (cn_gen_backtrack_relevant_contains((char*)#var)) {                      \
@@ -144,11 +146,13 @@
     struct int_urn* tmp##_urn = urn_from_array(tmp##_choices, tmp##_num_choices);       \
     cn_label_##tmp##_gen:                                                               \
         ;                                                                               \
+    alloc_checkpoint tmp##_checkpoint = alloc_save_checkpoint();                        \
     void *tmp##_alloc_checkpoint = cn_gen_alloc_save();                                 \
     void *tmp##_ownership_checkpoint = cn_gen_ownership_save();                         \
     uint64_t tmp = urn_remove(tmp##_urn);                                               \
     if (0) {                                                                            \
     cn_label_##tmp##_backtrack:                                                         \
+        free_after(tmp##_checkpoint);                                                   \
         cn_gen_alloc_restore(tmp##_alloc_checkpoint);                                   \
         cn_gen_ownership_restore(tmp##_ownership_checkpoint);                           \
         if (cn_gen_backtrack_type() == CN_GEN_BACKTRACK_ASSERT                          \

--- a/runtime/libcn/src/cn-executable/alloc.c
+++ b/runtime/libcn/src/cn-executable/alloc.c
@@ -65,6 +65,14 @@ void free_all(void) {
     curr = buf;
 }
 
+alloc_checkpoint alloc_save_checkpoint(void) {
+    return curr;
+}
+
+void free_after(alloc_checkpoint ptr) {
+    curr = ptr;
+}
+
 // void *alloc_zeros(long nbytes) {
 //     void *res = alloc(nbytes);
 //     bzero(res, nbytes);


### PR DESCRIPTION
With a bump allocator, we can store what its `curr` pointer is at each backtrack point. Then, since after backtracking, all values that were calculated or generated later are discarded, we can reset the `curr` pointer to what we had stored.

This means that generators don't leak memory due to backtracking.