### PR TITLE
[CN-Test-Gen] Better information and control

### DIFF
--- a/backend/cn/bin/main.ml
+++ b/backend/cn/bin/main.ml
@@ -445,6 +445,8 @@ let run_tests
   seed
   logging_level
   interactive
+  until_timeout
+  exit_fast
   =
   (* flags *)
   Cerb_debug.debug_level := debug_level;
@@ -493,7 +495,9 @@ let run_tests
               null_in_every;
               seed;
               logging_level;
-              interactive
+              interactive;
+              until_timeout;
+              exit_fast
             }
           in
           TestGeneration.run
@@ -914,6 +918,21 @@ module Testing_flags = struct
       "Enable interactive features for testing, such as requesting more detailed logs"
     in
     Arg.(value & flag & info [ "interactive" ] ~doc)
+
+
+  let test_until_timeout =
+    let doc =
+      "Keep rerunning tests until the given timeout (in seconds) has been reached"
+    in
+    Arg.(
+      value
+      & opt (some int) TestGeneration.default_cfg.until_timeout
+      & info [ "until-timeout" ] ~doc)
+
+
+  let test_exit_fast =
+    let doc = "Stop testing upon finding the first failure" in
+    Arg.(value & flag & info [ "exit-fast" ] ~doc)
 end
 
 let testing_cmd =
@@ -942,6 +961,8 @@ let testing_cmd =
     $ Testing_flags.test_seed
     $ Testing_flags.test_logging_level
     $ Testing_flags.interactive_testing
+    $ Testing_flags.test_until_timeout
+    $ Testing_flags.test_exit_fast
   in
   let doc =
     "Generates RapidCheck tests for all functions in [FILE] with CN specifications.\n\

--- a/backend/cn/lib/testGeneration/genOptimize.ml
+++ b/backend/cn/lib/testGeneration/genOptimize.ml
@@ -986,7 +986,8 @@ module BranchPruning = struct
       let aux (gt : GT.t) : GT.t =
         match gt with
         | GT (Pick [ (_, gt') ], _, _) -> gt'
-        | GT (Pick wgts, _, loc_pick) ->
+        (* TODO: Understand why this is so bad *)
+        (* | GT (Pick wgts, _, loc_pick) ->
           let rec aux'' (wgts : (Z.t * GT.t) list) : (Z.t * GT.t) list =
             match List.find_index (fun (_, gt') -> GT.is_pick gt') wgts with
             | Some i ->
@@ -1011,7 +1012,7 @@ module BranchPruning = struct
                | _ -> failwith ("unreachable @ " ^ __LOC__))
             | None -> wgts
           in
-          GT.pick_ (aux'' wgts) loc_pick
+          GT.pick_ (aux'' wgts) loc_pick *)
         | GT (ITE (it_cond, gt_then, gt_else), _, _) ->
           if IT.is_true it_cond then
             gt_then

--- a/backend/cn/lib/testGeneration/specTests.ml
+++ b/backend/cn/lib/testGeneration/specTests.ml
@@ -443,9 +443,16 @@ let compile_script ~(output_dir : string) ~(test_file : string) : Pp.document =
           |> Option.map (fun level -> [ "--logging-level"; string_of_int level ])
           |> Option.to_list
           |> List.flatten)
+       @ (if Config.is_interactive () then
+            [ "--interactive" ]
+          else
+            [])
+       @ (match Config.is_until_timeout () with
+          | Some timeout -> [ "--until-timeout"; string_of_int timeout ]
+          | None -> [])
        @
-       if Config.is_interactive () then
-         [ "--interactive" ]
+       if Config.is_exit_fast () then
+         [ "--exit-fast" ]
        else
          [])
   in

--- a/backend/cn/lib/testGeneration/specTests.ml
+++ b/backend/cn/lib/testGeneration/specTests.ml
@@ -160,7 +160,17 @@ let compile_random_test_case
   ^^ parens
        (separate
           (comma ^^ space)
-          [ Sym.pp inst.fn; int 100; separate_map (comma ^^ space) convert_from args ])
+          [ inst.fn_loc
+            |> Cerb_location.get_filename
+            |> Option.get
+            |> Filename.basename
+            |> String.split_on_char '.'
+            |> List.hd
+            |> string;
+            Sym.pp inst.fn;
+            int 100;
+            separate_map (comma ^^ space) convert_from args
+          ])
   ^^ twice hardline
 
 

--- a/backend/cn/lib/testGeneration/testGenConfig.ml
+++ b/backend/cn/lib/testGeneration/testGenConfig.ml
@@ -7,7 +7,9 @@ type t =
     null_in_every : int option;
     seed : string option;
     logging_level : int option;
-    interactive : bool
+    interactive : bool;
+    until_timeout : int option;
+    exit_fast : bool
   }
 
 let default =
@@ -17,7 +19,9 @@ let default =
     null_in_every = None;
     seed = None;
     logging_level = None;
-    interactive = false
+    interactive = false;
+    until_timeout = None;
+    exit_fast = false
   }
 
 
@@ -38,3 +42,7 @@ let has_seed () = !instance.seed
 let has_logging_level () = !instance.logging_level
 
 let is_interactive () = !instance.interactive
+
+let is_until_timeout () = !instance.until_timeout
+
+let is_exit_fast () = !instance.exit_fast

--- a/backend/cn/lib/testGeneration/testGenConfig.mli
+++ b/backend/cn/lib/testGeneration/testGenConfig.mli
@@ -7,7 +7,9 @@ type t =
     null_in_every : int option;
     seed : string option;
     logging_level : int option;
-    interactive : bool
+    interactive : bool;
+    until_timeout : int option;
+    exit_fast : bool
   }
 
 val default : t
@@ -27,3 +29,7 @@ val has_seed : unit -> string option
 val has_logging_level : unit -> int option
 
 val is_interactive : unit -> bool
+
+val is_until_timeout : unit -> int option
+
+val is_exit_fast : unit -> bool

--- a/runtime/libcn/include/cn-testing/test.h
+++ b/runtime/libcn/include/cn-testing/test.h
@@ -5,7 +5,7 @@
 #include <cn-executable/utils.h>
 #include <cn-testing/result.h>
 
-typedef enum cn_test_result cn_test_case_fn(void);
+typedef enum cn_test_result cn_test_case_fn(int);
 
 void cn_register_test_case(char* suite, char* name, cn_test_case_fn* func);
 
@@ -37,7 +37,7 @@ void print_test_info(char* suite, char* name, int tests, int discards);
         longjmp(buf_##Name, 1);                                                         \
     }                                                                                   \
                                                                                         \
-    enum cn_test_result cn_test_##Name () {                                             \
+    enum cn_test_result cn_test_##Name (int printing) {                                 \
         if (setjmp(buf_##Name)) {                                                       \
             return CN_TEST_FAIL;                                                        \
         }                                                                               \
@@ -46,8 +46,10 @@ void print_test_info(char* suite, char* name, int tests, int discards);
         cn_gen_rand_checkpoint checkpoint = cn_gen_rand_save();                         \
         int i = 0, d = 0;                                                               \
         for (; i < Samples; i++) {                                                      \
-            printf("\r");                                                               \
-            print_test_info(#Suite, #Name, i, d);                                       \
+            if (printing) {                                                             \
+                printf("\r");                                                           \
+                print_test_info(#Suite, #Name, i, d);                                   \
+            }                                                                           \
             CN_TEST_INIT();                                                             \
             struct cn_gen_##Name##_record *res = cn_gen_##Name();                       \
             if (cn_gen_backtrack_type() != CN_GEN_BACKTRACK_NONE) {                     \
@@ -66,8 +68,10 @@ void print_test_info(char* suite, char* name, int tests, int discards);
             cn_gen_rand_replace(checkpoint);                                            \
         }                                                                               \
                                                                                         \
-        printf("\r");                                                                   \
-        print_test_info(#Suite, #Name, i, d);                                           \
+        if (printing) {                                                                 \
+            printf("\r");                                                               \
+            print_test_info(#Suite, #Name, i, d);                                       \
+        }                                                                               \
         return CN_TEST_PASS;                                                            \
     }
 

--- a/runtime/libcn/src/cn-testing/test.c
+++ b/runtime/libcn/src/cn-testing/test.c
@@ -38,6 +38,20 @@ void cn_register_test_case(char* suite, char* name, cn_test_case_fn* func) {
     };
 }
 
+void print_test_info(char* suite, char* name, int tests, int discards) {
+    if (tests == 0 && discards == 0) {
+        printf("Testing %s::%s:", suite, name);
+    }
+    else if (discards == 0) {
+        printf("Testing %s::%s: %d runs", suite, name, tests);
+    }
+    else {
+        printf("Testing %s::%s: %d runs; %d discarded", suite, name, tests, discards);
+    }
+
+    fflush(stdout);
+}
+
 int cn_test_main(int argc, char* argv[]) {
     set_cn_logging_level(CN_LOGGING_NONE);
 
@@ -82,9 +96,11 @@ int cn_test_main(int argc, char* argv[]) {
     enum cn_test_result results[CN_TEST_MAX_TEST_CASES];
     for (int i = 0; i < num_test_cases; i++) {
         struct cn_test_case* test_case = &test_cases[i];
-        printf("Testing %s::%s: ", test_case->suite, test_case->name);
+        print_test_info(test_case->suite, test_case->name, 0, 0);
+        fflush(stdout);
         checkpoints[i] = cn_gen_rand_save();
         results[i] = test_case->func();
+        printf("\n");
         switch (results[i]) {
         case CN_TEST_PASS:
             passed++;

--- a/runtime/libcn/src/cn-testing/test.c
+++ b/runtime/libcn/src/cn-testing/test.c
@@ -8,11 +8,10 @@
 
 #include <cn-executable/utils.h>
 
+#include <cn-testing/test.h>
 #include <cn-testing/result.h>
 #include <cn-testing/rand.h>
 #include <cn-testing/alloc.h>
-
-typedef enum cn_test_result cn_test_case_fn(void);
 
 struct cn_test_case {
     char* suite;
@@ -116,7 +115,7 @@ int cn_test_main(int argc, char* argv[]) {
             print_test_info(test_case->suite, test_case->name, 0, 0);
             fflush(stdout);
             checkpoints[i] = cn_gen_rand_save();
-            enum cn_test_result result = test_case->func();
+            enum cn_test_result result = test_case->func(1);
             if (!(results[i] == CN_TEST_PASS && result == CN_TEST_GEN_FAIL)) {
                 results[i] = result;
             }
@@ -129,8 +128,9 @@ int cn_test_main(int argc, char* argv[]) {
                 printf("FAILED\n");
                 set_cn_logging_level(logging_level);
                 cn_gen_rand_restore(checkpoints[i]);
-                test_case->func();
+                test_case->func(0);
                 set_cn_logging_level(CN_LOGGING_NONE);
+                printf("\n\n");
                 break;
             case CN_TEST_GEN_FAIL:
                 printf("FAILED TO GENERATE VALID INPUT\n");
@@ -225,7 +225,7 @@ outside_loop:
         set_cn_logging_level(CN_LOGGING_INFO);
         reset_cn_exit_cb();
         // raise(SIGTRAP); // Trigger breakpoint
-        test_cases[mapToCase[testcase - 1]].func();
+        test_cases[mapToCase[testcase - 1]].func(0);
     }
 
     return !(failed == 0 && errored == 0);


### PR DESCRIPTION
- Rather than erroring on the first time a generator fails to generate an input, try again until `10 * Samples` attempts have failed
  - Now prints out inputs ran and these failures (called discards)
- Allows rerunning passing tests until some timeout via `--until-timeout`
- Allows having testing exit after its first failure via `--exit-fast` 