### PR TITLE
CN: serialize JSON-encoded state traces on error

### DIFF
--- a/backend/cn/lib/dune
+++ b/backend/cn/lib/dune
@@ -13,13 +13,16 @@
   menhirLib
   monomorphic
   ocamlgraph
+  ppx_deriving_yojson.runtime
   result
   str
-  unix)
+  unix
+  yojson)
  (preprocess
   (pps
    ppx_deriving.eq
    ppx_deriving.fold
    ppx_deriving.map
    ppx_deriving.ord
-   ppx_deriving.show)))
+   ppx_deriving.show
+   ppx_deriving_yojson)))

--- a/backend/cn/lib/pp.ml
+++ b/backend/cn/lib/pp.ml
@@ -335,3 +335,17 @@ let progress_simple title name =
 
 
 let of_total cur total = Printf.sprintf "[%d/%d]" cur total
+
+let document_to_yojson (doc : document) : Yojson.Safe.t =
+  let buf_size = 1024 (* chosen pretty arbitrarily *) in
+  let buf = Stdlib.Buffer.create buf_size in
+  PPrint.ToBuffer.compact buf doc;
+  let str = Stdlib.Buffer.contents buf in
+  `String str
+
+
+let document_of_yojson (json : Yojson.Safe.t) : (document, string) Result.t =
+  match json with
+  | `String str -> Ok (PPrint.arbitrary_string str)
+  | _ ->
+    Error ("document_of_yojson: expected `String, found " ^ Yojson.Safe.to_string json)

--- a/backend/cn/lib/pp.mli
+++ b/backend/cn/lib/pp.mli
@@ -347,3 +347,7 @@ val print_json : Yojson.Safe.t Lazy.t -> unit
 val progress_simple : string -> string -> unit
 
 val of_total : int -> int -> string
+
+val document_to_yojson : document -> Yojson.Safe.t
+
+val document_of_yojson : Yojson.Safe.t -> (document, string) Result.t

--- a/backend/cn/lib/report.mli
+++ b/backend/cn/lib/report.mli
@@ -77,3 +77,7 @@ type report =
 
     The third argument is information about the various things that need to be saved. *)
 val make : string -> string Option.m -> report -> string
+
+val report_of_yojson : Yojson.Safe.t -> (report, string) Result.t
+
+val report_to_yojson : report -> Yojson.Safe.t

--- a/cn.opam
+++ b/cn.opam
@@ -7,6 +7,7 @@ depends: [
   "monomorphic"
   "ocaml" {>= "4.14.0"}
   "ppx_deriving"
+  "ppx_deriving_yojson" {>= "3.8.0"}
   "cmdliner"
   "ocamlgraph"
 ]


### PR DESCRIPTION
This introduces a new flag, `--json-trace`, to cause CN to serialize state trace files encoded as JSON, in addition to serializing them as HTML. It also exposes an API for libraries that depend on CN to parse these files.