### PR TITLE
[CN-exec] Change naming convention for `Owned` functions

### DIFF
--- a/backend/cn/lib/cn_internal_to_ail.ml
+++ b/backend/cn/lib/cn_internal_to_ail.ml
@@ -742,13 +742,13 @@ let empty_for_dest : type a. a dest -> a =
   | PassBack -> ([], [], mk_expr empty_ail_expr)
 
 
-let generate_check_ownership_function ~with_ownership_checking ctype
+let generate_get_or_put_ownership_function ~with_ownership_checking ctype
   : A.sigma_declaration * CF.GenTypes.genTypeCategory A.sigma_function_definition
   =
   let ctype_str = str_of_ctype ctype in
   (* Printf.printf ("ctype_str: %s\n") ctype_str; *)
   let ctype_str = String.concat "_" (String.split_on_char ' ' ctype_str) in
-  let fn_sym = Sym.fresh_pretty ("check_owned_" ^ ctype_str) in
+  let fn_sym = Sym.fresh_pretty ("owned_" ^ ctype_str) in
   let param1_sym = Sym.fresh_pretty "cn_ptr" in
   let cast_expr =
     mk_expr
@@ -782,7 +782,7 @@ let generate_check_ownership_function ~with_ownership_checking ctype
   let param_types = List.map (fun t -> (empty_qualifiers, t, false)) param_types in
   let ownership_fcall_maybe =
     if with_ownership_checking then (
-      let ownership_fn_sym = Sym.fresh_pretty "cn_check_ownership" in
+      let ownership_fn_sym = Sym.fresh_pretty "cn_get_or_put_ownership" in
       let ownership_fn_args =
         A.
           [ AilEident param2_sym;
@@ -2601,7 +2601,7 @@ let cn_to_ail_resource_internal
         ownership_ctypes := Sctypes.to_ctype sct :: !ownership_ctypes;
         let ct_str = str_of_ctype (Sctypes.to_ctype sct) in
         let ct_str = String.concat "_" (String.split_on_char ' ' ct_str) in
-        let owned_fn_name = "check_owned_" ^ ct_str in
+        let owned_fn_name = "owned_" ^ ct_str in
         (* Hack with enum as sym *)
         let enum_val_get = IT.(IT (Sym enum_sym, BT.Integer, Cerb_location.unknown)) in
         let fn_call_it =
@@ -2708,7 +2708,7 @@ let cn_to_ail_resource_internal
         ownership_ctypes := Sctypes.to_ctype sct :: !ownership_ctypes;
         let sct_str = str_of_ctype (Sctypes.to_ctype sct) in
         let sct_str = String.concat "_" (String.split_on_char ' ' sct_str) in
-        let owned_fn_name = "check_owned_" ^ sct_str in
+        let owned_fn_name = "owned_" ^ sct_str in
         let ptr_add_it = IT.(IT (Sym ptr_add_sym, BT.(Loc ()), Cerb_location.unknown)) in
         (* Hack with enum as sym *)
         let enum_val_get = IT.(IT (Sym enum_sym, BT.Integer, Cerb_location.unknown)) in

--- a/backend/cn/lib/cn_internal_to_ail.mli
+++ b/backend/cn/lib/cn_internal_to_ail.mli
@@ -57,7 +57,7 @@ type ail_executable_spec =
     in_stmt : (Locations.t * ail_bindings_and_statements) list
   }
 
-val generate_check_ownership_function
+val generate_get_or_put_ownership_function
   :  with_ownership_checking:bool ->
   C.ctype ->
   A.sigma_declaration * CF.GenTypes.genTypeCategory A.sigma_function_definition

--- a/backend/cn/lib/executable_spec_internal.ml
+++ b/backend/cn/lib/executable_spec_internal.ml
@@ -500,7 +500,7 @@ let generate_ownership_functions
   let ail_funs =
     List.map
       (fun ctype ->
-        Cn_internal_to_ail.generate_check_ownership_function
+        Cn_internal_to_ail.generate_get_or_put_ownership_function
           ~with_ownership_checking
           ctype)
       ctypes

--- a/runtime/libcn/include/cn-executable/utils.h
+++ b/runtime/libcn/include/cn-executable/utils.h
@@ -524,7 +524,7 @@ void ownership_ghost_state_remove(signed long* address_key);
 void cn_get_ownership(uintptr_t generic_c_ptr, size_t size);
 void cn_put_ownership(uintptr_t generic_c_ptr, size_t size);
 void cn_assume_ownership(void *generic_c_ptr, unsigned long size, char *fun);
-void cn_check_ownership(enum OWNERSHIP owned_enum, uintptr_t generic_c_ptr, size_t size);
+void cn_get_or_put_ownership(enum OWNERSHIP owned_enum, uintptr_t generic_c_ptr, size_t size);
 
 /* C ownership checking */
 void c_add_to_ghost_state(uintptr_t ptr_to_local, size_t size, signed long stack_depth);

--- a/runtime/libcn/src/cn-executable/utils.c
+++ b/runtime/libcn/src/cn-executable/utils.c
@@ -223,7 +223,7 @@ void cn_assume_ownership(void *generic_c_ptr, unsigned long size, char *fun) {
 }
 
 
-void cn_check_ownership(enum OWNERSHIP owned_enum, uintptr_t generic_c_ptr, size_t size) {
+void cn_get_or_put_ownership(enum OWNERSHIP owned_enum, uintptr_t generic_c_ptr, size_t size) {
   nr_owned_predicates++;
   switch (owned_enum)
     {


### PR DESCRIPTION
Change `cn_check_ownership` function to be called `cn_get_or_put_ownership` in runtime library to be more accurate, since this function is both checking an ownership property _and_ mapping into/unmapping from the ownership ghost state. Similarly for generated translation of `Owned` - changed back to be `owned_<ctype>` to mirror the CN source, rather than `check_owned`.