### PR TITLE
[CN-exec] Enable ownership checking by default

### DIFF
--- a/backend/cn/bin/main.ml
+++ b/backend/cn/bin/main.ml
@@ -384,7 +384,7 @@ let generate_executable_specs
   (* Executable spec *)
     output_decorated
   output_decorated_dir
-  with_ownership_checking
+  without_ownership_checking
   with_test_gen
   copy_source_dir
   =
@@ -421,7 +421,7 @@ let generate_executable_specs
       Cerb_colour.without_colour
         (fun () ->
           Executable_spec.main
-            ~with_ownership_checking
+            ~without_ownership_checking
             ~with_test_gen
             ~copy_source_dir
             filename
@@ -449,7 +449,7 @@ let run_tests
   no_inherit_loc
   magic_comment_char_dollar
   (* Executable spec *)
-    with_ownership_checking
+    without_ownership_checking
   (* Test Generation *)
     output_dir
   dont_run
@@ -494,7 +494,7 @@ let run_tests
               ("Created directory \"" ^ output_dir ^ "\" with full permissions."));
           let _, sigma = ail_prog in
           Executable_spec.main
-            ~with_ownership_checking
+            ~without_ownership_checking
             ~with_test_gen:true
             ~copy_source_dir:false
             filename
@@ -518,7 +518,7 @@ let run_tests
           TestGeneration.run
             ~output_dir
             ~filename
-            ~with_ownership_checking
+            ~without_ownership_checking
             config
             sigma
             prog5;
@@ -773,8 +773,8 @@ module Executable_spec_flags = struct
     Arg.(value & opt (some string) None & info [ "output-decorated" ] ~docv:"FILE" ~doc)
 
 
-  let with_ownership_checking =
-    let doc = "Enable ownership checking within CN runtime testing" in
+  let without_ownership_checking =
+    let doc = "Disable ownership checking within CN runtime testing" in
     Arg.(value & flag & info [ "with-ownership-checking" ] ~doc)
 
 
@@ -973,7 +973,7 @@ let testing_cmd =
     $ Common_flags.use_peval
     $ Common_flags.no_inherit_loc
     $ Common_flags.magic_comment_char_dollar
-    $ Executable_spec_flags.with_ownership_checking
+    $ Executable_spec_flags.without_ownership_checking
     $ Testing_flags.output_test_dir
     $ Testing_flags.dont_run_tests
     $ Testing_flags.gen_backtrack_attempts
@@ -1026,7 +1026,7 @@ let instrument_cmd =
     $ Common_flags.magic_comment_char_dollar
     $ Executable_spec_flags.output_decorated
     $ Executable_spec_flags.output_decorated_dir
-    $ Executable_spec_flags.with_ownership_checking
+    $ Executable_spec_flags.without_ownership_checking
     $ Executable_spec_flags.with_test_gen
     $ Executable_spec_flags.copy_source_dir
   in

--- a/backend/cn/bin/main.ml
+++ b/backend/cn/bin/main.ml
@@ -775,7 +775,7 @@ module Executable_spec_flags = struct
 
   let without_ownership_checking =
     let doc = "Disable ownership checking within CN runtime testing" in
-    Arg.(value & flag & info [ "with-ownership-checking" ] ~doc)
+    Arg.(value & flag & info [ "without-ownership-checking" ] ~doc)
 
 
   let with_test_gen =

--- a/backend/cn/lib/cn_internal_to_ail.mli
+++ b/backend/cn/lib/cn_internal_to_ail.mli
@@ -58,12 +58,12 @@ type ail_executable_spec =
   }
 
 val generate_get_or_put_ownership_function
-  :  with_ownership_checking:bool ->
+  :  without_ownership_checking:bool ->
   C.ctype ->
   A.sigma_declaration * CF.GenTypes.genTypeCategory A.sigma_function_definition
 
 val generate_assume_ownership_function
-  :  with_ownership_checking:bool ->
+  :  without_ownership_checking:bool ->
   C.ctype ->
   A.sigma_declaration * CF.GenTypes.genTypeCategory A.sigma_function_definition
 
@@ -167,7 +167,7 @@ val cn_to_ail_predicates_internal
   * A.sigma_tag_definition option list
 
 val cn_to_ail_pre_post_internal
-  :  with_ownership_checking:bool ->
+  :  without_ownership_checking:bool ->
   A.sigma_cn_datatype list ->
   (Sym.t * ResourcePredicates.definition) list ->
   (Sym.t * C.ctype) list ->

--- a/backend/cn/lib/executable_spec.ml
+++ b/backend/cn/lib/executable_spec.ml
@@ -194,7 +194,7 @@ let output_to_oc oc str_list = List.iter (Stdlib.output_string oc) str_list
 open Executable_spec_internal
 
 let main
-  ?(with_ownership_checking = false)
+  ?(without_ownership_checking = false)
   ?(with_test_gen = false)
   ?(copy_source_dir = false)
   filename
@@ -217,7 +217,7 @@ let main
   Executable_spec_records.populate_record_map instrumentation prog5;
   let executable_spec =
     generate_c_specs_internal
-      with_ownership_checking
+      without_ownership_checking
       instrumentation
       symbol_table
       statement_locs
@@ -244,7 +244,7 @@ let main
   in
   let ownership_function_defs, ownership_function_decls =
     generate_ownership_functions
-      with_ownership_checking
+      without_ownership_checking
       Cn_internal_to_ail.ownership_ctypes
       sigm
   in
@@ -326,7 +326,7 @@ let main
     List.map (fun (loc, _) -> (loc, [ "" ])) toplevel_locs_and_defs
   in
   let accesses_stmt_injs =
-    if with_ownership_checking then memory_accesses_injections ail_prog else []
+    if without_ownership_checking then [] else memory_accesses_injections ail_prog
   in
   let struct_injs_with_filenames = Executable_spec_internal.generate_struct_injs sigm in
   let struct_injs_with_filenames =
@@ -372,12 +372,12 @@ let main
         failwith
           "Input file cannot have predefined main function when passing to CN test-gen \
            tooling"
-    else if with_ownership_checking then (
+    else if without_ownership_checking then
+      executable_spec.pre_post
+    else (
       (* Inject ownership init function calls and mapping and unmapping of globals into provided main function *)
       let global_ownership_init_pair = generate_ownership_global_assignments sigm prog5 in
       global_ownership_init_pair @ executable_spec.pre_post)
-    else
-      executable_spec.pre_post
   in
   (match
      Source_injection.(

--- a/backend/cn/lib/executable_spec_internal.ml
+++ b/backend/cn/lib/executable_spec_internal.ml
@@ -55,7 +55,7 @@ let rec extract_global_variables = function
 
 
 let generate_c_pres_and_posts_internal
-  with_ownership_checking
+  without_ownership_checking
   (instrumentation : Core_to_mucore.instrumentation)
   _
   (sigm : _ CF.AilSyntax.sigma)
@@ -71,7 +71,7 @@ let generate_c_pres_and_posts_internal
   let globals = extract_global_variables prog5.globs in
   let ail_executable_spec =
     Cn_internal_to_ail.cn_to_ail_pre_post_internal
-      ~with_ownership_checking
+      ~without_ownership_checking
       dts
       preds
       globals
@@ -82,7 +82,9 @@ let generate_c_pres_and_posts_internal
   let post_str = generate_ail_stat_strs ail_executable_spec.post in
   (* C ownership checking *)
   let (pre_str, post_str), block_ownership_injs =
-    if with_ownership_checking then (
+    if without_ownership_checking then
+      ((pre_str, post_str), [])
+    else (
       let fn_ownership_stats_opt, block_ownership_injs =
         Ownership_exec.get_c_fn_local_ownership_checking_injs instrumentation.fn sigm
       in
@@ -97,8 +99,6 @@ let generate_c_pres_and_posts_internal
         in
         (pre_post_pair, block_ownership_injs)
       | None -> ((pre_str, post_str), []))
-    else
-      ((pre_str, post_str), [])
   in
   (* Needed for extracting correct location for CN statement injection *)
   let modify_magic_comment_loc loc =
@@ -183,7 +183,7 @@ let generate_c_assume_pres_internal
 
 (* Core_to_mucore.instrumentation list -> executable_spec *)
 let generate_c_specs_internal
-  with_ownership_checking
+  without_ownership_checking
   instrumentation_list
   type_map
   (_ : Cerb_location.t CStatements.LocMap.t)
@@ -192,7 +192,7 @@ let generate_c_specs_internal
   =
   let generate_c_spec (instrumentation : Core_to_mucore.instrumentation) =
     generate_c_pres_and_posts_internal
-      with_ownership_checking
+      without_ownership_checking
       instrumentation
       type_map
       sigm
@@ -482,7 +482,7 @@ let generate_c_predicates_internal
 
 
 let generate_ownership_functions
-  with_ownership_checking
+  without_ownership_checking
   ownership_ctypes
   (sigm : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma)
   =
@@ -501,7 +501,7 @@ let generate_ownership_functions
     List.map
       (fun ctype ->
         Cn_internal_to_ail.generate_get_or_put_ownership_function
-          ~with_ownership_checking
+          ~without_ownership_checking
           ctype)
       ctypes
   in

--- a/backend/cn/lib/testGeneration/specTests.ml
+++ b/backend/cn/lib/testGeneration/specTests.ml
@@ -219,7 +219,7 @@ let compile_random_tests
 
 
 let compile_assumes
-  ~(with_ownership_checking : bool)
+  ~(without_ownership_checking : bool)
   (sigma : CF.GenTypes.genTypeCategory A.sigma)
   (prog5 : unit Mucore.file)
   (insts : Core_to_mucore.instrumentation list)
@@ -230,7 +230,7 @@ let compile_assumes
       (List.map
          (fun ctype ->
            Cn_internal_to_ail.generate_assume_ownership_function
-             ~with_ownership_checking
+             ~without_ownership_checking
              ctype)
          (let module CtypeSet =
             Set.Make (struct
@@ -261,7 +261,7 @@ let compile_assumes
 
 
 let compile_tests
-  ~(with_ownership_checking : bool)
+  ~(without_ownership_checking : bool)
   (filename_base : string)
   (sigma : CF.GenTypes.genTypeCategory A.sigma)
   (prog5 : unit Mucore.file)
@@ -295,7 +295,7 @@ let compile_tests
   ^^ twice hardline
   ^^ pp_label "Assume Ownership Functions"
   ^^ twice hardline
-  ^^ compile_assumes ~with_ownership_checking sigma prog5 insts
+  ^^ compile_assumes ~without_ownership_checking sigma prog5 insts
   ^^ pp_label "Unit tests"
   ^^ twice hardline
   ^^ unit_tests_doc
@@ -487,7 +487,7 @@ let save ?(perm = 0o666) (output_dir : string) (filename : string) (doc : Pp.doc
 let generate
   ~(output_dir : string)
   ~(filename : string)
-  ~(with_ownership_checking : bool)
+  ~(without_ownership_checking : bool)
   (sigma : CF.GenTypes.genTypeCategory A.sigma)
   (prog5 : unit Mucore.file)
   : unit
@@ -510,7 +510,7 @@ let generate
   let generators_fn = filename_base ^ "_gen.h" in
   save output_dir generators_fn generators_doc;
   let tests_doc =
-    compile_tests ~with_ownership_checking filename_base sigma prog5 insts
+    compile_tests ~without_ownership_checking filename_base sigma prog5 insts
   in
   let test_file = filename_base ^ "_test.c" in
   save output_dir test_file tests_doc;

--- a/backend/cn/lib/testGeneration/specTests.mli
+++ b/backend/cn/lib/testGeneration/specTests.mli
@@ -4,7 +4,7 @@ module A = CF.AilSyntax
 val generate
   :  output_dir:string ->
   filename:string ->
-  with_ownership_checking:bool ->
+  without_ownership_checking:bool ->
   CF.GenTypes.genTypeCategory A.sigma ->
   unit Mucore.file ->
   unit

--- a/backend/cn/lib/testGeneration/testGeneration.ml
+++ b/backend/cn/lib/testGeneration/testGeneration.ml
@@ -7,7 +7,7 @@ let default_cfg : config = Config.default
 let run
   ~output_dir
   ~filename
-  ~with_ownership_checking
+  ~without_ownership_checking
   (cfg : config)
   (sigma : Cerb_frontend.GenTypes.genTypeCategory Cerb_frontend.AilSyntax.sigma)
   (prog5 : unit Mucore.file)
@@ -17,5 +17,5 @@ let run
   if Option.is_some prog5.main then
     failwith "Cannot test a file with a `main` function";
   Cerb_debug.begin_csv_timing ();
-  SpecTests.generate ~output_dir ~filename ~with_ownership_checking sigma prog5;
+  SpecTests.generate ~output_dir ~filename ~without_ownership_checking sigma prog5;
   Cerb_debug.end_csv_timing "specification test generation"

--- a/backend/cn/lib/testGeneration/testGeneration.mli
+++ b/backend/cn/lib/testGeneration/testGeneration.mli
@@ -5,7 +5,7 @@ val default_cfg : config
 val run
   :  output_dir:string ->
   filename:string ->
-  with_ownership_checking:bool ->
+  without_ownership_checking:bool ->
   config ->
   Cerb_frontend.GenTypes.genTypeCategory Cerb_frontend.AilSyntax.sigma ->
   unit Mucore.file ->

--- a/runtime/libcn/libexec/cn-runtime-single-file.sh
+++ b/runtime/libcn/libexec/cn-runtime-single-file.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail -o noclobber
 
-USAGE="USAGE: $0 -h\n       $0 [-ovq] FILE.c"
+USAGE="USAGE: $0 -h\n       $0 [-nvq] FILE.c"
 
 function echo_and_err() {
     printf "$1\n"
@@ -9,16 +9,16 @@ function echo_and_err() {
 }
 
 QUIET=""
-CHECK_OWNERSHIP=""
+NO_CHECK_OWNERSHIP=""
 
-while getopts "hoq" flag; do
+while getopts "hnq" flag; do
  case "$flag" in
    h)
    printf "${USAGE}"
    exit 0
    ;;
-   o)
-   CHECK_OWNERSHIP="--with-ownership-checking"
+   n)
+   NO_CHECK_OWNERSHIP="--without-ownership-checking"
    ;;
    q)
    QUIET=1
@@ -57,7 +57,7 @@ EXEC_DIR=$(mktemp -d -t 'cn-exec.XXXX')
 if cn instrument "${INPUT_FN}" \
     --output-decorated="${INPUT_BASENAME}-exec.c" \
     --output-decorated-dir="${EXEC_DIR}" \
-    ${CHECK_OWNERSHIP}; then
+    ${NO_CHECK_OWNERSHIP}; then
   [ "${QUIET}" ] || echo "Generating C files from CN-annotated source."
 else
   echo_and_err "Failed to generate C files from CN-annotatated source."

--- a/tests/cn-exec-performance-stats.py
+++ b/tests/cn-exec-performance-stats.py
@@ -85,7 +85,6 @@ def gen_instr_cmd(f, input_basename):
     instr_cmd_prefix = "cn instrument"
     instr_cmd = time_cmd_str + instr_cmd_prefix + " " + tests_path + "/" + f
     instr_cmd += " --output-decorated=" + input_basename + "-exec.c"
-    instr_cmd += " --with-ownership-checking"
     return instr_cmd
 
 def gen_compile_cmd(input_basename, instrumented):

--- a/tests/run-cn-exec.sh
+++ b/tests/run-cn-exec.sh
@@ -17,7 +17,7 @@ CHECK_SCRIPT="${RUNTIME_PREFIX}/libexec/cn-runtime-single-file.sh"
 
 [ -f "${CHECK_SCRIPT}" ] || echo_and_err "Could not find single file helper script: ${CHECK_SCRIPT}"
 
-SCRIPT_OPT="-oq"
+SCRIPT_OPT="-q"
 
 function exits_with_code() {
   local file=$1

--- a/tests/run-cn-test-gen.sh
+++ b/tests/run-cn-test-gen.sh
@@ -33,7 +33,7 @@ for TEST in $FILES; do
 
   # Run passing tests
   if [[ $TEST == *.pass.c ]]; then
-    $CN test "$TEST" --output-dir="test" --with-ownership-checking
+    $CN test "$TEST" --output-dir="test"
     RET=$?
     if [[ "$RET" != 0 ]]; then
       echo
@@ -50,7 +50,7 @@ for TEST in $FILES; do
 
   # Run failing tests
   if [[ $TEST == *.fail.c ]]; then
-    $CN test "$TEST" --output-dir="test" --with-ownership-checking
+    $CN test "$TEST" --output-dir="test"
     RET=$?
     if [[ "$RET" = 0 ]]; then
       echo


### PR DESCRIPTION
Remove `--with-ownership-checking` and add `--without-ownership-checking`, so user has to explicitly switch off dynamic ownership checking.