### PR TITLE
CN VIP: Add support for memcpy & proxy

### DIFF
--- a/backend/cn/lib/setup.ml
+++ b/backend/cn/lib/setup.ml
@@ -35,10 +35,3 @@ let conf macros incl_dirs incl_files astprints =
     cpp_cmd = cpp_str macros incl_dirs incl_files;
     cpp_stderr = true
   }
-
-
-let unfold_proxies =
-  StringSet.of_list [ "ffs_proxy"; "ffsl_proxy"; "ffsll_proxy"; "ctz_proxy" ]
-
-
-let unfold_stdlib_name s = StringSet.mem s unfold_proxies

--- a/backend/cn/lib/setup.mli
+++ b/backend/cn/lib/setup.mli
@@ -12,5 +12,3 @@ val conf
   string list ->
   Cerb_backend.Pipeline.language list ->
   Cerb_backend.Pipeline.configuration
-
-val unfold_stdlib_name : string -> bool

--- a/tests/cn_vip_testsuite/cn_lemmas.h
+++ b/tests/cn_vip_testsuite/cn_lemmas.h
@@ -32,23 +32,6 @@ ensures
     (return != 0i32 || Src == Dest) && (return == 0i32 || Src != Dest);
 @*/
 
-void _memcpy(unsigned char *dest, unsigned char *src, size_t n);
-/*@ spec _memcpy(pointer dest, pointer src, u64 n);
-
-requires
-    (u64) src + n <= (u64) dest || (u64) dest + n <= (u64) src;
-    (u64) src <= (u64) src + n;
-    (u64) dest <= (u64) dest + n;
-    take Src = each (u64 i; 0u64 <= i && i < n ) { Owned(array_shift(src, i)) };
-    take Dest = each (u64 i; 0u64 <= i && i < n ) { Block<unsigned char>(array_shift(dest, i)) };
-
-ensures
-    take SrcR = each (u64 i; 0u64 <= i && i < n ) { Owned(array_shift(src, i)) };
-    take DestR = each (u64 i; 0u64 <= i && i < n ) { Owned(array_shift(dest, i)) };
-    Src == SrcR;
-    SrcR == DestR;
-@*/
-
 /*@
 lemma assert_equal(u64 x, u64 y)
 requires

--- a/tests/cn_vip_testsuite/pointer_copy_memcpy.c
+++ b/tests/cn_vip_testsuite/pointer_copy_memcpy.c
@@ -10,7 +10,7 @@ int main()
   int *q;
   /*CN_VIP*//*@ to_bytes Owned<int*>(&p); @*/
   /*CN_VIP*//*@ to_bytes Block<int*>(&q); @*/
-  _memcpy ((unsigned char*)&q, (unsigned char*)&p, sizeof p);
+  memcpy((unsigned char*)&q, (unsigned char*)&p, sizeof p);
   /*CN_VIP*//*@ from_bytes Owned<int*>(&p); @*/
   /*CN_VIP*//*@ from_bytes Owned<int*>(&q); @*/
 #ifdef NO_ROUND_TRIP

--- a/tests/run-cn-vip.sh
+++ b/tests/run-cn-vip.sh
@@ -1,11 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail -o noclobber
 
-# copying from run-ci.sh
-# Z3=$(ocamlfind query z3)
-# export DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH:-}:${Z3}"
-# export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}:${Z3}"
-
 USAGE="USAGE: $0 [-h]"
 
 function echo_and_err() {


### PR DESCRIPTION
This commit hooks into an existing place for assigning function types to proxy functions. It assumes that memcpy's type is expressible in CN, which is true-ish for now, but may not remain so if we want to support round-trip for pointers without provenance in byte values, and thus need a "special type" or more arbitrary set of operations on the typing context to support.