### PR TITLE
[CN-Exec/CN-Test-Gen] Generalize failure handling

### DIFF
--- a/runtime/libcn/include/cn-executable/utils.h
+++ b/runtime/libcn/include/cn-executable/utils.h
@@ -138,9 +138,18 @@ void cn_free_sized(void*, size_t len);
 void cn_print_nr_u64(int i, unsigned long u) ;
 void cn_print_u64(const char *str, unsigned long u) ;
 
-/* cn_exit callbacks */
-void set_cn_exit_cb(void (*callback)(void));
-void reset_cn_exit_cb(void);
+/* cn_failure callbacks */
+enum cn_failure_mode {
+    CN_FAILURE_ASSERT = 1,
+    CN_FAILURE_CHECK_OWNERSHIP,
+    CN_FAILURE_OWNERSHIP_LEAK,
+    CN_FAILURE_ALLOC
+};
+
+typedef void (*cn_failure_callback)(enum cn_failure_mode);
+void set_cn_failure_cb(cn_failure_callback callback);
+void reset_cn_failure_cb(void);
+void cn_failure(enum cn_failure_mode mode);
 
 /* Conversion functions */
 

--- a/runtime/libcn/src/cn-executable/alloc.c
+++ b/runtime/libcn/src/cn-executable/alloc.c
@@ -3,6 +3,7 @@
 #include <string.h>
 
 #include <cn-executable/alloc.h>
+#include <cn-executable/utils.h>
 
 // #define foo(x)\
 //     [ x ] = #x
@@ -44,8 +45,8 @@ void *alloc_(long nbytes, const char *str, int line) {
     // printf("Alloc called: %s:%d\n", str, line);
     void *res = curr;
     if ((char *) curr + nbytes - buf > MEM_SIZE) {
-        printf("Out of memory! %lu\n", count);
-        exit(1);
+        cn_failure(CN_FAILURE_ALLOC);
+        return NULL;
     }
     count++;
     curr += nbytes;

--- a/runtime/libcn/src/cn-testing/test.c
+++ b/runtime/libcn/src/cn-testing/test.c
@@ -228,7 +228,7 @@ outside_loop:
 
         cn_gen_rand_restore(checkpoints[mapToCase[testcase - 1]]);
         set_cn_logging_level(CN_LOGGING_INFO);
-        reset_cn_exit_cb();
+        reset_cn_failure_cb();
         // raise(SIGTRAP); // Trigger breakpoint
         test_cases[mapToCase[testcase - 1]].func(0);
     }


### PR DESCRIPTION
Generalizes failure handling to provide the reason for the failure. Also cleans up connect allocation to the failure mechanism.

For test-gen, this allows closes #697 