### PR TITLE
Adjust caching in workflows

### DIFF
--- a/.github/workflows/ci-cheri.yml
+++ b/.github/workflows/ci-cheri.yml
@@ -30,7 +30,7 @@ jobs:
 
     - name: System dependencies (ubuntu)
       run: |
-        sudo apt install build-essential libgmp-dev opam
+        sudo apt-get install build-essential libgmp-dev opam
 
     - name: Restore cached opam
       id: cache-opam-restore
@@ -38,25 +38,7 @@ jobs:
       with:
         path: ~/.opam
         key: ${{ matrix.version }}
-
-    - name: Setup opam
-      if: steps.cache-opam-restore.outputs.cache-hit != 'true'
-      run: |
-        eval $(opam env --switch=with_coq)
-        opam repo add --yes --this-switch coq-released https://coq.inria.fr/opam/released
-        opam pin --yes -n coq-struct-tact https://github.com/uwplse/StructTact.git
-        opam repo add --yes --this-switch iris-dev https://gitlab.mpi-sws.org/iris/opam.git
-        opam pin --yes -n coq-sail-stdpp https://github.com/rems-project/coq-sail.git#f319aad
-        opam pin --yes -n coq-cheri-capabilities https://github.com/rems-project/coq-cheri-capabilities.git
-        opam install --deps-only --yes ./cerberus-lib.opam ./cerberus-cheri.opam
-
-    - name: Save cached opam
-      if: steps.cache-opam-restore.outputs.cache-hit != 'true'
-      id: cache-opam-save
-      uses: actions/cache/save@v4
-      with:
-        path: ~/.opam
-        key: ${{ steps.cache-opam-restore.outputs.cache-primary-key }}
+        fail-on-cache-miss: true
 
     - name: Install Cerberus-CHERI
       if: ${{ matrix.version == '4.14.1' }}

--- a/.github/workflows/ci-cn-bench.yml
+++ b/.github/workflows/ci-cn-bench.yml
@@ -35,7 +35,7 @@ jobs:
 
     - name: System dependencies (ubuntu)
       run: |
-        sudo apt install build-essential libgmp-dev z3 opam jq
+        sudo apt-get install build-essential libgmp-dev z3 opam jq
 
     - name: Restore cached opam
       id: cache-opam-restore
@@ -43,21 +43,7 @@ jobs:
       with:
         path: ~/.opam
         key: ${{ matrix.version }}
-
-    - name: Setup opam
-      if: steps.cache-opam-restore.outputs.cache-hit != 'true'
-      run: |
-        opam init --yes --no-setup --shell=sh --compiler=${{ matrix.version }}
-        opam install --deps-only --yes ./cerberus-lib.opam
-        opam switch create with_coq ${{ matrix.version }}
-
-    - name: Save cached opam
-      if: steps.cache-opam-restore.outputs.cache-hit != 'true'
-      id: cache-opam-save
-      uses: actions/cache/save@v4
-      with:
-        path: ~/.opam
-        key: ${{ steps.cache-opam-restore.outputs.cache-primary-key }}
+        fail-on-cache-miss: true
 
     - name: Install Cerberus
       run: |

--- a/.github/workflows/ci-cn-spec-testing.yml
+++ b/.github/workflows/ci-cn-spec-testing.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: System dependencies (ubuntu)
       run: |
-        sudo apt install build-essential libgmp-dev z3 opam cmake
+        sudo apt-get install build-essential libgmp-dev z3 opam cmake
 
     - name: Restore cached opam
       id: cache-opam-restore
@@ -39,20 +39,7 @@ jobs:
       with:
         path: ~/.opam
         key: ${{ matrix.version }}
-
-    - name: Setup opam
-      if: steps.cache-opam-restore.outputs.cache-hit != 'true'
-      run: |
-        opam init --yes --no-setup --shell=sh --compiler=${{ matrix.version }}
-        opam install --deps-only --yes ./cerberus-lib.opam
-
-    - name: Save cached opam
-      if: steps.cache-opam-restore.outputs.cache-hit != 'true'
-      id: cache-opam-save
-      uses: actions/cache/save@v4
-      with:
-        path: ~/.opam
-        key: ${{ steps.cache-opam-restore.outputs.cache-primary-key }}
+        fail-on-cache-miss: true
 
     - name: Install Cerberus
       run: |

--- a/.github/workflows/ci-cn.yml
+++ b/.github/workflows/ci-cn.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: System dependencies (ubuntu)
       run: |
-        sudo apt install build-essential libgmp-dev z3 opam
+        sudo apt-get install build-essential libgmp-dev z3 opam
 
     - name: Restore cached opam
       id: cache-opam-restore
@@ -37,20 +37,7 @@ jobs:
       with:
         path: ~/.opam
         key: ${{ matrix.version }}
-
-    - name: Setup opam
-      if: steps.cache-opam-restore.outputs.cache-hit != 'true'
-      run: |
-        opam init --yes --no-setup --shell=sh --compiler=${{ matrix.version }}
-        opam install --deps-only --yes ./cerberus-lib.opam
-
-    - name: Save cached opam
-      if: steps.cache-opam-restore.outputs.cache-hit != 'true'
-      id: cache-opam-save
-      uses: actions/cache/save@v4
-      with:
-        path: ~/.opam
-        key: ${{ steps.cache-opam-restore.outputs.cache-primary-key }}
+        fail-on-cache-miss: true
 
     - name: Install Cerberus
       run: |

--- a/.github/workflows/ci-pr-bench.yml.disabled
+++ b/.github/workflows/ci-pr-bench.yml.disabled
@@ -45,28 +45,7 @@ jobs:
       with:
         path: ~/.opam
         key: ${{ matrix.version }}
-
-    - name: Setup opam
-      if: steps.cache-opam-restore.outputs.cache-hit != 'true'
-      run: |
-        opam init --yes --no-setup --shell=sh --compiler=${{ matrix.version }}
-        opam install --deps-only --yes ./cerberus-lib.opam
-        opam switch create with_coq ${{ matrix.version }}
-        eval $(opam env --switch=with_coq)
-        opam repo add --yes --this-switch coq-released https://coq.inria.fr/opam/released
-        opam pin --yes -n coq-struct-tact https://github.com/uwplse/StructTact.git
-        opam repo add --yes --this-switch iris-dev https://gitlab.mpi-sws.org/iris/opam.git
-        opam pin --yes -n coq-sail-stdpp https://github.com/rems-project/coq-sail.git#f319aad
-        opam pin --yes -n coq-cheri-capabilities https://github.com/rems-project/coq-cheri-capabilities.git
-        opam install --deps-only --yes ./cerberus-lib.opam ./cerberus-cheri.opam
-
-    - name: Save cached opam
-      if: steps.cache-opam-restore.outputs.cache-hit != 'true'
-      id: cache-opam-save
-      uses: actions/cache/save@v4
-      with:
-        path: ~/.opam
-        key: ${{ steps.cache-opam-restore.outputs.cache-primary-key }}
+        fail-on-cache-miss: true
 
     - name: Install python dependencies
       run: pip install tabulate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
 
     - name: System dependencies (ubuntu)
       run: |
-        sudo apt install build-essential libgmp-dev z3 opam cmake
+        sudo apt-get install build-essential libgmp-dev z3 opam cmake
 
     - name: Restore cached opam
       id: cache-opam-restore
@@ -44,6 +44,14 @@ jobs:
       run: |
         opam init --yes --no-setup --shell=sh --compiler=${{ matrix.version }}
         opam install --deps-only --yes ./cerberus-lib.opam
+        opam switch create with_coq ${{ matrix.version }}
+        eval $(opam env --switch=with_coq)
+        opam repo add --yes --this-switch coq-released https://coq.inria.fr/opam/released
+        opam pin --yes -n coq-struct-tact https://github.com/uwplse/StructTact.git
+        opam repo add --yes --this-switch iris-dev https://gitlab.mpi-sws.org/iris/opam.git
+        opam pin --yes -n coq-sail-stdpp https://github.com/rems-project/coq-sail.git#f319aad
+        opam pin --yes -n coq-cheri-capabilities https://github.com/rems-project/coq-cheri-capabilities.git
+        opam install --deps-only --yes ./cerberus-lib.opam ./cerberus-cheri.opam
 
     - name: Save cached opam
       if: steps.cache-opam-restore.outputs.cache-hit != 'true'


### PR DESCRIPTION
It looks like the cache is shared across workflows, https://github.com/rems-project/cerberus/actions/caches and is specific to a branch (but accessible for the branches descendants). 

I think that means the cache invalidation logic should really only be in one place, and the rest of the workflow files should just fail if the cache is empty (those jobs can be re-run after the cache is re-populated).