### PR TITLE
[CN-Test-Gen] Allow random splitting of generator sizes

### DIFF
--- a/.github/workflows/ci-cn-spec-testing.yml
+++ b/.github/workflows/ci-cn-spec-testing.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: System dependencies (ubuntu)
       run: |
-        sudo apt-get install build-essential libgmp-dev z3 opam cmake
+        sudo apt-get install build-essential libgmp-dev z3 opam cmake lcov
 
     - name: Restore cached opam
       id: cache-opam-restore

--- a/backend/cn/bin/main.ml
+++ b/backend/cn/bin/main.ml
@@ -450,6 +450,7 @@ let run_tests
   allowed_depth_failures
   max_generator_size
   random_size_splits
+  allowed_size_split_backtracks
   sized_null
   coverage
   disable_passes
@@ -520,6 +521,7 @@ let run_tests
               allowed_depth_failures;
               max_generator_size;
               random_size_splits;
+              allowed_size_split_backtracks;
               sized_null;
               coverage;
               disable_passes
@@ -1007,6 +1009,17 @@ module Testing_flags = struct
     Arg.(value & flag & info [ "random-size-splits" ] ~doc)
 
 
+  let allowed_size_split_backtracks =
+    let doc =
+      "Set the maximum attempts to split up a generator's size (between recursive calls) \
+       before backtracking further, during input generation"
+    in
+    Arg.(
+      value
+      & opt (some int) TestGeneration.default_cfg.allowed_size_split_backtracks
+      & info [ "allowed-size-split-backtracks" ] ~doc)
+
+
   let sized_null =
     let doc =
       "Scale the likelihood of [NULL] proportionally for a desired size (1/n for size n)"
@@ -1070,6 +1083,7 @@ let testing_cmd =
     $ Testing_flags.allowed_depth_failures
     $ Testing_flags.max_generator_size
     $ Testing_flags.random_size_splits
+    $ Testing_flags.allowed_size_split_backtracks
     $ Testing_flags.sized_null
     $ Testing_flags.coverage
     $ Testing_flags.disable_passes

--- a/backend/cn/bin/main.ml
+++ b/backend/cn/bin/main.ml
@@ -447,6 +447,7 @@ let run_tests
   until_timeout
   exit_fast
   max_stack_depth
+  allowed_depth_failures
   max_generator_size
   random_size_splits
   sized_null
@@ -516,6 +517,7 @@ let run_tests
               until_timeout;
               exit_fast;
               max_stack_depth;
+              allowed_depth_failures;
               max_generator_size;
               random_size_splits;
               sized_null;
@@ -984,6 +986,14 @@ module Testing_flags = struct
       & info [ "max-stack-depth" ] ~doc)
 
 
+  let allowed_depth_failures =
+    let doc = "Maximum stack depth failures before discarding an attempt" in
+    Arg.(
+      value
+      & opt (some int) TestGeneration.default_cfg.allowed_depth_failures
+      & info [ "allowed-depth-failures" ] ~doc)
+
+
   let max_generator_size =
     let doc = "Maximum size for generated values" in
     Arg.(
@@ -1057,6 +1067,7 @@ let testing_cmd =
     $ Testing_flags.until_timeout
     $ Testing_flags.exit_fast
     $ Testing_flags.max_stack_depth
+    $ Testing_flags.allowed_depth_failures
     $ Testing_flags.max_generator_size
     $ Testing_flags.random_size_splits
     $ Testing_flags.sized_null

--- a/backend/cn/bin/main.ml
+++ b/backend/cn/bin/main.ml
@@ -448,6 +448,7 @@ let run_tests
   exit_fast
   max_stack_depth
   max_generator_size
+  random_size_splits
   sized_null
   coverage
   disable_passes
@@ -516,6 +517,7 @@ let run_tests
               exit_fast;
               max_stack_depth;
               max_generator_size;
+              random_size_splits;
               sized_null;
               coverage;
               disable_passes
@@ -990,6 +992,11 @@ module Testing_flags = struct
       & info [ "max-generator-size" ] ~doc)
 
 
+  let random_size_splits =
+    let doc = "Randomly split sizes between recursive generator calls" in
+    Arg.(value & flag & info [ "random-size-splits" ] ~doc)
+
+
   let sized_null =
     let doc =
       "Scale the likelihood of [NULL] proportionally for a desired size (1/n for size n)"
@@ -1051,6 +1058,7 @@ let testing_cmd =
     $ Testing_flags.exit_fast
     $ Testing_flags.max_stack_depth
     $ Testing_flags.max_generator_size
+    $ Testing_flags.random_size_splits
     $ Testing_flags.sized_null
     $ Testing_flags.coverage
     $ Testing_flags.disable_passes

--- a/backend/cn/bin/main.ml
+++ b/backend/cn/bin/main.ml
@@ -448,6 +448,7 @@ let run_tests
   exit_fast
   max_stack_depth
   max_generator_size
+  sized_null
   coverage
   disable_passes
   =
@@ -515,6 +516,7 @@ let run_tests
               exit_fast;
               max_stack_depth;
               max_generator_size;
+              sized_null;
               coverage;
               disable_passes
             }
@@ -882,16 +884,16 @@ module Testing_flags = struct
 
 
   let only =
-    let doc = "only test this function (or comma-separated names)" in
+    let doc = "Only test this function (or comma-separated names)" in
     Arg.(value & opt (some string) None & info [ "only" ] ~doc)
 
 
   let skip =
-    let doc = "skip testing of this function (or comma-separated names)" in
+    let doc = "Skip testing of this function (or comma-separated names)" in
     Arg.(value & opt (some string) None & info [ "skip" ] ~doc)
 
 
-  let dont_run_tests =
+  let dont_run =
     let doc = "Do not run tests, only generate them" in
     Arg.(value & flag & info [ "no-run" ] ~doc)
 
@@ -921,7 +923,7 @@ module Testing_flags = struct
       & info [ "max-unfolds" ] ~doc)
 
 
-  let test_max_array_length =
+  let max_array_length =
     let doc = "Set the maximum length for an array generated" in
     Arg.(
       value
@@ -929,7 +931,7 @@ module Testing_flags = struct
       & info [ "max-array-length" ] ~doc)
 
 
-  let test_null_in_every =
+  let null_in_every =
     let doc = "Set the likelihood of NULL being generated as 1 in every <n>" in
     Arg.(
       value
@@ -937,12 +939,12 @@ module Testing_flags = struct
       & info [ "null-in-every" ] ~doc)
 
 
-  let test_seed =
+  let seed =
     let doc = "Set the seed for random testing" in
     Arg.(value & opt (some string) TestGeneration.default_cfg.seed & info [ "seed" ] ~doc)
 
 
-  let test_logging_level =
+  let logging_level =
     let doc = "Set the logging level for failing inputs from tests" in
     Arg.(
       value
@@ -950,14 +952,14 @@ module Testing_flags = struct
       & info [ "logging-level" ] ~doc)
 
 
-  let interactive_testing =
+  let interactive =
     let doc =
       "Enable interactive features for testing, such as requesting more detailed logs"
     in
     Arg.(value & flag & info [ "interactive" ] ~doc)
 
 
-  let test_until_timeout =
+  let until_timeout =
     let doc =
       "Keep rerunning tests until the given timeout (in seconds) has been reached"
     in
@@ -967,12 +969,12 @@ module Testing_flags = struct
       & info [ "until-timeout" ] ~doc)
 
 
-  let test_exit_fast =
+  let exit_fast =
     let doc = "Stop testing upon finding the first failure" in
     Arg.(value & flag & info [ "exit-fast" ] ~doc)
 
 
-  let test_max_stack_depth =
+  let max_stack_depth =
     let doc = "Maximum stack depth for generators" in
     Arg.(
       value
@@ -980,7 +982,7 @@ module Testing_flags = struct
       & info [ "max-stack-depth" ] ~doc)
 
 
-  let test_max_generator_size =
+  let max_generator_size =
     let doc = "Maximum size for generated values" in
     Arg.(
       value
@@ -988,8 +990,15 @@ module Testing_flags = struct
       & info [ "max-generator-size" ] ~doc)
 
 
-  let test_coverage =
-    let doc = "Record coverage of tests" in
+  let sized_null =
+    let doc =
+      "Scale the likelihood of [NULL] proportionally for a desired size (1/n for size n)"
+    in
+    Arg.(value & flag & info [ "sized-null" ] ~doc)
+
+
+  let coverage =
+    let doc = "(Experimental) Record coverage of tests via [lcov]" in
     Arg.(value & flag & info [ "coverage" ] ~doc)
 
 
@@ -1029,27 +1038,29 @@ let testing_cmd =
     $ Testing_flags.output_test_dir
     $ Testing_flags.only
     $ Testing_flags.skip
-    $ Testing_flags.dont_run_tests
+    $ Testing_flags.dont_run
     $ Testing_flags.gen_num_samples
     $ Testing_flags.gen_backtrack_attempts
     $ Testing_flags.gen_max_unfolds
-    $ Testing_flags.test_max_array_length
-    $ Testing_flags.test_null_in_every
-    $ Testing_flags.test_seed
-    $ Testing_flags.test_logging_level
-    $ Testing_flags.interactive_testing
-    $ Testing_flags.test_until_timeout
-    $ Testing_flags.test_exit_fast
-    $ Testing_flags.test_max_stack_depth
-    $ Testing_flags.test_max_generator_size
-    $ Testing_flags.test_coverage
+    $ Testing_flags.max_array_length
+    $ Testing_flags.null_in_every
+    $ Testing_flags.seed
+    $ Testing_flags.logging_level
+    $ Testing_flags.interactive
+    $ Testing_flags.until_timeout
+    $ Testing_flags.exit_fast
+    $ Testing_flags.max_stack_depth
+    $ Testing_flags.max_generator_size
+    $ Testing_flags.sized_null
+    $ Testing_flags.coverage
     $ Testing_flags.disable_passes
   in
   let doc =
-    "Generates RapidCheck tests for all functions in [FILE] with CN specifications.\n\
+    "Generates tests for all functions in [FILE] with CN specifications.\n\
     \    The tests use randomized inputs, which are guaranteed to satisfy the CN \
      precondition.\n\
-    \    A [.cpp] file containing the test harnesses will be placed in [output-dir]."
+    \    A script [run_tests.sh] for building and running the tests will be placed in \
+     [output-dir]."
   in
   let info = Cmd.info "test" ~doc in
   Cmd.v info test_t

--- a/backend/cn/lib/testGeneration/genCodeGen.ml
+++ b/backend/cn/lib/testGeneration/genCodeGen.ml
@@ -144,33 +144,33 @@ let rec compile_term
   | Call { fsym; iargs; oarg_bt; path_vars; sized } ->
     let sym = GenUtils.get_mangled_name (fsym :: List.map fst iargs) in
     let es = iargs |> List.map snd |> List.map (fun x -> A.(AilEident x)) in
-    let es =
-      List.map
-        mk_expr
-        (es
-         @ A.(
-             match sized with
-             | Some 1 ->
-               [ AilEbinary
-                   ( mk_expr (AilEident (Sym.fresh_named "cn_gen_rec_size")),
-                     Arithmetic Sub,
-                     mk_expr
-                       (AilEconst (ConstantInteger (IConstant (Z.one, Decimal, None)))) )
-               ]
-             | Some n ->
-               [ AilEbinary
-                   ( mk_expr (AilEident (Sym.fresh_named "cn_gen_rec_size")),
-                     Arithmetic Div,
-                     mk_expr
-                       (AilEconst
-                          (ConstantInteger (IConstant (Z.of_int n, Decimal, None)))) )
-               ]
-             | None
-               when (not (GenBuiltins.is_builtin fsym))
-                    && (ctx |> List.assoc Sym.equal fsym |> List.hd |> snd).sized ->
-               [ AilEcall (mk_expr (AilEident (Sym.fresh_named "cn_gen_get_size")), []) ]
-             | None -> []))
+    let sized_call =
+      A.(
+        match sized with
+        | Some (n, _) when n <= 0 -> failwith "Invalid sized call"
+        | Some (1, _) ->
+          [ AilEbinary
+              ( mk_expr (AilEident (Sym.fresh_named "cn_gen_rec_size")),
+                Arithmetic Sub,
+                mk_expr (AilEconst (ConstantInteger (IConstant (Z.one, Decimal, None))))
+              )
+          ]
+        | Some (_, sym_size) when TestGenConfig.is_random_size_splits () ->
+          [ AilEident sym_size ]
+        | Some (n, _) ->
+          [ AilEbinary
+              ( mk_expr (AilEident (Sym.fresh_named "cn_gen_rec_size")),
+                Arithmetic Div,
+                mk_expr
+                  (AilEconst (ConstantInteger (IConstant (Z.of_int n, Decimal, None)))) )
+          ]
+        | None
+          when (not (GenBuiltins.is_builtin fsym))
+               && (ctx |> List.assoc Sym.equal fsym |> List.hd |> snd).sized ->
+          [ AilEcall (mk_expr (AilEident (Sym.fresh_named "cn_gen_get_size")), []) ]
+        | None -> [])
     in
+    let es = List.map mk_expr (es @ sized_call) in
     let x = Sym.fresh () in
     let b = Utils.create_binding x (bt_to_ctype fsym oarg_bt) in
     let wrap_to_string (sym : Sym.t) =
@@ -451,6 +451,47 @@ let rec compile_term
     ( [ b_map; b_i ] @ b_min @ b_perm @ b_val,
       s_begin @ s_body @ s_end,
       mk_expr (AilEident sym_map) )
+  | SplitSize { rest; _ } when not (TestGenConfig.is_random_size_splits ()) ->
+    compile_term sigma ctx name rest
+  | SplitSize { marker_var; syms; path_vars; last_var; rest } ->
+    let e_ty = mk_expr (AilEident (Sym.fresh_named (name_of_bt name Memory.size_bt))) in
+    let e_tmp = mk_expr (AilEident marker_var) in
+    let e_size = mk_expr (AilEident (Sym.fresh_named "cn_gen_rec_size")) in
+    let syms_l = syms |> GR.SymSet.to_seq |> List.of_seq in
+    let b =
+      syms_l |> List.map (fun x -> Utils.create_binding x (C.mk_ctype_integer Size_t))
+    in
+    let e_syms =
+      syms_l |> List.map (fun x -> mk_expr (AilEunary (Address, mk_expr (AilEident x))))
+    in
+    let wrap_to_string (sym : Sym.t) =
+      let open A in
+      mk_expr
+        (AilEcast
+           ( C.no_qualifiers,
+             C.pointer_to_char,
+             mk_expr
+               (AilEstr (None, [ (Locations.other __LOC__, [ Sym.pp_string sym ]) ])) ))
+    in
+    let s =
+      let open A in
+      List.map (fun x -> AilSdeclaration [ (x, None) ]) syms_l
+      @ [ AilSexpr
+            (mk_expr
+               (AilEcall
+                  ( mk_expr (AilEident (Sym.fresh_named "CN_GEN_SPLIT_BEGIN")),
+                    [ e_tmp; e_size ] @ e_syms @ [ mk_expr (AilEconst ConstantNull) ] )));
+          AilSexpr
+            (mk_expr
+               (AilEcall
+                  ( mk_expr (AilEident (Sym.fresh_named "CN_GEN_SPLIT_END")),
+                    [ e_ty; e_tmp; e_size; mk_expr (AilEident last_var) ]
+                    @ List.map wrap_to_string (List.of_seq (GR.SymSet.to_seq path_vars))
+                    @ [ mk_expr (AilEconst ConstantNull) ] )))
+        ]
+    in
+    let b', s', e' = compile_term sigma ctx name rest in
+    (b @ b', s @ s', e')
 
 
 let compile_gen_def

--- a/backend/cn/lib/testGeneration/genRuntime.mli
+++ b/backend/cn/lib/testGeneration/genRuntime.mli
@@ -27,7 +27,7 @@ type term =
         iargs : (Sym.t * Sym.t) list;
         oarg_bt : BT.t;
         path_vars : SymSet.t;
-        sized : int option
+        sized : (int * Sym.t) option
       }
   | Asgn of
       { pointer : Sym.t;
@@ -65,6 +65,13 @@ type term =
         perm : IT.t;
         inner : term;
         last_var : Sym.t
+      }
+  | SplitSize of
+      { marker_var : Sym.t;
+        syms : SymSet.t;
+        path_vars : SymSet.t;
+        last_var : Sym.t;
+        rest : term
       }
 [@@deriving eq, ord]
 

--- a/backend/cn/lib/testGeneration/specTests.ml
+++ b/backend/cn/lib/testGeneration/specTests.ml
@@ -475,6 +475,13 @@ let compile_script ~(output_dir : string) ~(test_file : string) : Pp.document =
           |> Option.map (fun allowed_depth_failures ->
             [ "--allowed-depth-failures"; string_of_int allowed_depth_failures ])
           |> Option.to_list
+          |> List.flatten)
+       @ (Config.has_allowed_size_split_backtracks ()
+          |> Option.map (fun allowed_size_split_backtracks ->
+            [ "--allowed-size-split-backtracks";
+              string_of_int allowed_size_split_backtracks
+            ])
+          |> Option.to_list
           |> List.flatten))
   in
   cmd

--- a/backend/cn/lib/testGeneration/specTests.ml
+++ b/backend/cn/lib/testGeneration/specTests.ml
@@ -467,11 +467,15 @@ let compile_script ~(output_dir : string) ~(test_file : string) : Pp.document =
             [ "--max-generator-size"; string_of_int max_generator_size ])
           |> Option.to_list
           |> List.flatten)
-       @
-       if Config.is_sized_null () then
-         [ "--sized-null" ]
-       else
-         [])
+       @ (if Config.is_sized_null () then
+            [ "--sized-null" ]
+          else
+            [])
+       @ (Config.has_allowed_depth_failures ()
+          |> Option.map (fun allowed_depth_failures ->
+            [ "--allowed-depth-failures"; string_of_int allowed_depth_failures ])
+          |> Option.to_list
+          |> List.flatten))
   in
   cmd
   ^^ hardline

--- a/backend/cn/lib/testGeneration/specTests.ml
+++ b/backend/cn/lib/testGeneration/specTests.ml
@@ -466,7 +466,12 @@ let compile_script ~(output_dir : string) ~(test_file : string) : Pp.document =
           |> Option.map (fun max_generator_size ->
             [ "--max-generator-size"; string_of_int max_generator_size ])
           |> Option.to_list
-          |> List.flatten))
+          |> List.flatten)
+       @
+       if Config.is_sized_null () then
+         [ "--sized-null" ]
+       else
+         [])
   in
   cmd
   ^^ semi

--- a/backend/cn/lib/testGeneration/testGenConfig.ml
+++ b/backend/cn/lib/testGeneration/testGenConfig.ml
@@ -13,6 +13,7 @@ type t =
     exit_fast : bool;
     max_stack_depth : int option;
     max_generator_size : int option;
+    random_size_splits : bool;
     sized_null : bool;
     coverage : bool;
     disable_passes : string list
@@ -31,6 +32,7 @@ let default =
     exit_fast = false;
     max_stack_depth = None;
     max_generator_size = None;
+    random_size_splits = false;
     sized_null = false;
     coverage = false;
     disable_passes = []
@@ -64,6 +66,8 @@ let is_exit_fast () = !instance.exit_fast
 let has_max_stack_depth () = !instance.max_stack_depth
 
 let has_max_generator_size () = !instance.max_generator_size
+
+let is_random_size_splits () = !instance.random_size_splits
 
 let is_sized_null () = !instance.sized_null
 

--- a/backend/cn/lib/testGeneration/testGenConfig.ml
+++ b/backend/cn/lib/testGeneration/testGenConfig.ml
@@ -12,6 +12,7 @@ type t =
     until_timeout : int option;
     exit_fast : bool;
     max_stack_depth : int option;
+    allowed_depth_failures : int option;
     max_generator_size : int option;
     random_size_splits : bool;
     sized_null : bool;
@@ -31,6 +32,7 @@ let default =
     until_timeout = None;
     exit_fast = false;
     max_stack_depth = None;
+    allowed_depth_failures = None;
     max_generator_size = None;
     random_size_splits = false;
     sized_null = false;
@@ -64,6 +66,8 @@ let is_until_timeout () = !instance.until_timeout
 let is_exit_fast () = !instance.exit_fast
 
 let has_max_stack_depth () = !instance.max_stack_depth
+
+let has_allowed_depth_failures () = !instance.allowed_depth_failures
 
 let has_max_generator_size () = !instance.max_generator_size
 

--- a/backend/cn/lib/testGeneration/testGenConfig.ml
+++ b/backend/cn/lib/testGeneration/testGenConfig.ml
@@ -13,6 +13,7 @@ type t =
     exit_fast : bool;
     max_stack_depth : int option;
     max_generator_size : int option;
+    sized_null : bool;
     coverage : bool;
     disable_passes : string list
   }
@@ -30,6 +31,7 @@ let default =
     exit_fast = false;
     max_stack_depth = None;
     max_generator_size = None;
+    sized_null = false;
     coverage = false;
     disable_passes = []
   }
@@ -62,6 +64,8 @@ let is_exit_fast () = !instance.exit_fast
 let has_max_stack_depth () = !instance.max_stack_depth
 
 let has_max_generator_size () = !instance.max_generator_size
+
+let is_sized_null () = !instance.sized_null
 
 let is_coverage () = !instance.coverage
 

--- a/backend/cn/lib/testGeneration/testGenConfig.ml
+++ b/backend/cn/lib/testGeneration/testGenConfig.ml
@@ -15,6 +15,7 @@ type t =
     allowed_depth_failures : int option;
     max_generator_size : int option;
     random_size_splits : bool;
+    allowed_size_split_backtracks : int option;
     sized_null : bool;
     coverage : bool;
     disable_passes : string list
@@ -35,6 +36,7 @@ let default =
     allowed_depth_failures = None;
     max_generator_size = None;
     random_size_splits = false;
+    allowed_size_split_backtracks = None;
     sized_null = false;
     coverage = false;
     disable_passes = []
@@ -72,6 +74,8 @@ let has_allowed_depth_failures () = !instance.allowed_depth_failures
 let has_max_generator_size () = !instance.max_generator_size
 
 let is_random_size_splits () = !instance.random_size_splits
+
+let has_allowed_size_split_backtracks () = !instance.allowed_size_split_backtracks
 
 let is_sized_null () = !instance.sized_null
 

--- a/backend/cn/lib/testGeneration/testGenConfig.mli
+++ b/backend/cn/lib/testGeneration/testGenConfig.mli
@@ -13,6 +13,7 @@ type t =
     exit_fast : bool;
     max_stack_depth : int option;
     max_generator_size : int option;
+    random_size_splits : bool;
     sized_null : bool;
     coverage : bool;
     disable_passes : string list
@@ -45,6 +46,8 @@ val is_exit_fast : unit -> bool
 val has_max_stack_depth : unit -> int option
 
 val has_max_generator_size : unit -> int option
+
+val is_random_size_splits : unit -> bool
 
 val is_sized_null : unit -> bool
 

--- a/backend/cn/lib/testGeneration/testGenConfig.mli
+++ b/backend/cn/lib/testGeneration/testGenConfig.mli
@@ -13,6 +13,7 @@ type t =
     exit_fast : bool;
     max_stack_depth : int option;
     max_generator_size : int option;
+    sized_null : bool;
     coverage : bool;
     disable_passes : string list
   }
@@ -44,6 +45,8 @@ val is_exit_fast : unit -> bool
 val has_max_stack_depth : unit -> int option
 
 val has_max_generator_size : unit -> int option
+
+val is_sized_null : unit -> bool
 
 val is_coverage : unit -> bool
 

--- a/backend/cn/lib/testGeneration/testGenConfig.mli
+++ b/backend/cn/lib/testGeneration/testGenConfig.mli
@@ -12,6 +12,7 @@ type t =
     until_timeout : int option;
     exit_fast : bool;
     max_stack_depth : int option;
+    allowed_depth_failures : int option;
     max_generator_size : int option;
     random_size_splits : bool;
     sized_null : bool;
@@ -44,6 +45,8 @@ val is_until_timeout : unit -> int option
 val is_exit_fast : unit -> bool
 
 val has_max_stack_depth : unit -> int option
+
+val has_allowed_depth_failures : unit -> int option
 
 val has_max_generator_size : unit -> int option
 

--- a/backend/cn/lib/testGeneration/testGenConfig.mli
+++ b/backend/cn/lib/testGeneration/testGenConfig.mli
@@ -15,6 +15,7 @@ type t =
     allowed_depth_failures : int option;
     max_generator_size : int option;
     random_size_splits : bool;
+    allowed_size_split_backtracks : int option;
     sized_null : bool;
     coverage : bool;
     disable_passes : string list
@@ -51,6 +52,8 @@ val has_allowed_depth_failures : unit -> int option
 val has_max_generator_size : unit -> int option
 
 val is_random_size_splits : unit -> bool
+
+val has_allowed_size_split_backtracks : unit -> int option
 
 val is_sized_null : unit -> bool
 

--- a/runtime/libcn/include/cn-testing/dsl.h
+++ b/runtime/libcn/include/cn-testing/dsl.h
@@ -27,11 +27,13 @@
     }                                                                                   \
     cn_gen_increment_depth();                                                           \
     if (size <= 0 || cn_gen_depth() == cn_gen_max_depth()) {                            \
-        static int backtracks;                                                          \
-        backtracks++;                                                                   \
-        if (backtracks >= 100) {                                                        \
-            cn_gen_backtrack_assert_failure();                                          \
-            goto cn_label_bennet_backtrack;                                             \
+        if (cn_gen_get_depth_failures_allowed() != UINT16_MAX) {                        \
+            static int backtracks;                                                      \
+            backtracks++;                                                               \
+            if (backtracks >= cn_gen_get_depth_failures_allowed()) {                    \
+                cn_gen_backtrack_assert_failure();                                      \
+                goto cn_label_bennet_backtrack;                                         \
+            }                                                                           \
         }                                                                               \
         cn_gen_backtrack_depth_exceeded();                                              \
         goto cn_label_bennet_backtrack;                                                 \

--- a/runtime/libcn/include/cn-testing/size.h
+++ b/runtime/libcn/include/cn-testing/size.h
@@ -12,3 +12,6 @@ uint16_t cn_gen_max_depth();
 void cn_gen_set_max_depth(uint16_t msd);
 void cn_gen_increment_depth();
 void cn_gen_decrement_depth();
+
+void cn_gen_set_depth_failures_allowed(uint16_t allowed);
+uint16_t cn_gen_get_depth_failures_allowed();

--- a/runtime/libcn/include/cn-testing/size.h
+++ b/runtime/libcn/include/cn-testing/size.h
@@ -15,3 +15,6 @@ void cn_gen_decrement_depth();
 
 void cn_gen_set_depth_failures_allowed(uint16_t allowed);
 uint16_t cn_gen_get_depth_failures_allowed();
+
+void cn_gen_set_size_split_backtracks_allowed(uint16_t allowed);
+uint16_t cn_gen_get_size_split_backtracks_allowed();

--- a/runtime/libcn/src/cn-testing/size.c
+++ b/runtime/libcn/src/cn-testing/size.c
@@ -42,3 +42,13 @@ void cn_gen_increment_depth() {
 void cn_gen_decrement_depth() {
     stack_depth--;
 }
+
+static uint16_t depth_failures_allowed = UINT16_MAX;
+
+void cn_gen_set_depth_failures_allowed(uint16_t allowed) {
+    depth_failures_allowed = allowed;
+}
+
+uint16_t cn_gen_get_depth_failures_allowed() {
+    return depth_failures_allowed;
+}

--- a/runtime/libcn/src/cn-testing/size.c
+++ b/runtime/libcn/src/cn-testing/size.c
@@ -52,3 +52,13 @@ void cn_gen_set_depth_failures_allowed(uint16_t allowed) {
 uint16_t cn_gen_get_depth_failures_allowed() {
     return depth_failures_allowed;
 }
+
+static uint16_t size_split_backtracks_allowed = 0;
+
+void cn_gen_set_size_split_backtracks_allowed(uint16_t allowed) {
+    size_split_backtracks_allowed = allowed;
+}
+
+uint16_t cn_gen_get_size_split_backtracks_allowed() {
+    return size_split_backtracks_allowed;
+}

--- a/runtime/libcn/src/cn-testing/test.c
+++ b/runtime/libcn/src/cn-testing/test.c
@@ -100,6 +100,9 @@ int cn_test_main(int argc, char* argv[]) {
         }
         else if (strcmp("--sized-null", arg) == 0) {
             set_sized_null();
+        }
+        else if (strcmp("--allowed-depth-failures", arg) == 0) {
+            cn_gen_set_depth_failures_allowed(strtoul(argv[i + 1], NULL, 10));
             i++;
         }
     }

--- a/runtime/libcn/src/cn-testing/test.c
+++ b/runtime/libcn/src/cn-testing/test.c
@@ -105,6 +105,10 @@ int cn_test_main(int argc, char* argv[]) {
             cn_gen_set_depth_failures_allowed(strtoul(argv[i + 1], NULL, 10));
             i++;
         }
+        else if (strcmp("--allowed-size-split-backtracks", arg) == 0) {
+            cn_gen_set_size_split_backtracks_allowed(strtoul(argv[i + 1], NULL, 10));
+            i++;
+        }
     }
 
     if (interactive) {

--- a/tests/run-cn-test-gen.sh
+++ b/tests/run-cn-test-gen.sh
@@ -27,45 +27,54 @@ function separator() {
   printf '\n\n'
 }
 
-# Test each `*.c` file
-for TEST in $FILES; do
-  CLEANUP="rm -rf test/* run_tests.sh;separator"
+CONFIGS=("--coverage" "--sized-null")
 
-  # Run passing tests
-  if [[ $TEST == *.pass.c ]]; then
-    $CN test "$TEST" --output-dir="test"
-    RET=$?
-    if [[ "$RET" != 0 ]]; then
-      echo
-      echo "$TEST -- Tests failed unexpectedly"
-      NUM_FAILED=$(($NUM_FAILED + 1))
-      FAILED="$FAILED $TEST"
-      eval "$CLEANUP"
-      continue
-    else
-      echo
-      echo "$TEST -- Tests passed successfully"
+# For each configuration
+for CONFIG in ${CONFIGS[@]}; do
+  separator
+  echo "Running CI with CLI config \"$CONFIG\""
+  separator
+
+  # Test each `*.c` file
+  for TEST in $FILES; do
+    CLEANUP="rm -rf test/* run_tests.sh;separator"
+
+    # Run passing tests
+    if [[ $TEST == *.pass.c ]]; then
+      $CN test "$TEST" --output-dir="test" $CONFIG
+      RET=$?
+      if [[ "$RET" != 0 ]]; then
+        echo
+        echo "$TEST -- Tests failed unexpectedly"
+        NUM_FAILED=$(($NUM_FAILED + 1))
+        FAILED="$FAILED $TEST"
+        eval "$CLEANUP"
+        continue
+      else
+        echo
+        echo "$TEST -- Tests passed successfully"
+      fi
     fi
-  fi
 
-  # Run failing tests
-  if [[ $TEST == *.fail.c ]]; then
-    $CN test "$TEST" --output-dir="test"
-    RET=$?
-    if [[ "$RET" = 0 ]]; then
-      echo
-      echo "$TEST -- Tests passed unexpectedly"
-      NUM_FAILED=$(($NUM_FAILED + 1))
-      FAILED="$FAILED $TEST"
-      eval "$CLEANUP"
-      continue
-    else
-      echo
-      echo "$TEST -- Tests failed successfully"
+    # Run failing tests
+    if [[ $TEST == *.fail.c ]]; then
+      $CN test "$TEST" --output-dir="test" $CONFIG
+      RET=$?
+      if [[ "$RET" = 0 ]]; then
+        echo
+        echo "$TEST -- Tests passed unexpectedly"
+        NUM_FAILED=$(($NUM_FAILED + 1))
+        FAILED="$FAILED $TEST"
+        eval "$CLEANUP"
+        continue
+      else
+        echo
+        echo "$TEST -- Tests failed successfully"
+      fi
     fi
-  fi
 
-  eval "$CLEANUP"
+    eval "$CLEANUP"
+  done
 done
 
 echo 'Done running tests.'

--- a/tests/run-cn-test-gen.sh
+++ b/tests/run-cn-test-gen.sh
@@ -27,13 +27,15 @@ function separator() {
   printf '\n\n'
 }
 
-CONFIGS=("--coverage" "--sized-null")
+CONFIGS=("--coverage" "--sized-null" "--random-size-splits")
 
 # For each configuration
 for CONFIG in ${CONFIGS[@]}; do
   separator
   echo "Running CI with CLI config \"$CONFIG\""
   separator
+
+  CONFIG="$CONFIG --max-generator-size=10"
 
   # Test each `*.c` file
   for TEST in $FILES; do

--- a/tests/run-cn-test-gen.sh
+++ b/tests/run-cn-test-gen.sh
@@ -35,7 +35,7 @@ for CONFIG in ${CONFIGS[@]}; do
   echo "Running CI with CLI config \"$CONFIG\""
   separator
 
-  CONFIG="$CONFIG --max-generator-size=10"
+  CONFIG="$CONFIG --max-generator-size=10 --allowed-depth-failures=100"
 
   # Test each `*.c` file
   for TEST in $FILES; do

--- a/tests/run-cn-test-gen.sh
+++ b/tests/run-cn-test-gen.sh
@@ -27,7 +27,7 @@ function separator() {
   printf '\n\n'
 }
 
-CONFIGS=("--coverage" "--sized-null" "--random-size-splits")
+CONFIGS=("--coverage" "--sized-null" "--random-size-splits" "--random-size-splits --allowed-size-split-backtracks=10")
 
 # For each configuration
 for CONFIG in ${CONFIGS[@]}; do


### PR DESCRIPTION
Generators are sized, which restricts the stack depth.

Currently, if there are `n` recursive calls, where `n` is greater than one, each one gets a size of `size / n`.
This change adds a CLI flag `--random-size-splits`, which will randomly generate `n` values, such that their sum is `n - 1`.

It also expands CI to check multiple configurations for testing, rather than just the default. Ideally, you might want to do some kind of combinatorial testing of the flags...