### PR TITLE
CHERI CI dependency fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         opam pin --yes -n coq-struct-tact https://github.com/uwplse/StructTact.git
         opam repo add --yes --this-switch iris-dev https://gitlab.mpi-sws.org/iris/opam.git
         opam pin --yes -n coq-sail-stdpp https://github.com/rems-project/coq-sail.git#f319aad
-        opam pin --yes -n coq-cheri-capabilities https://github.com/rems-project/coq-cheri-capabilities.git
+        opam pin --yes -n coq-cheri-capabilities https://github.com/rems-project/coq-cheri-capabilities.git#2f02c44ad061d4da30136dc9dbc06c142c94fdaf
         opam install --deps-only --yes ./cerberus-lib.opam ./cerberus-cheri.opam
 
     - name: Save cached opam

--- a/Dockerfile.cheri
+++ b/Dockerfile.cheri
@@ -12,7 +12,7 @@ RUN opam repo add --yes --this-switch coq-released https://coq.inria.fr/opam/rel
     && opam repo add --yes --this-switch iris-dev https://gitlab.mpi-sws.org/iris/opam.git \
     && opam pin --yes -n coq-struct-tact https://github.com/uwplse/StructTact.git \
     && opam pin --yes -n coq-sail-stdpp https://github.com/rems-project/coq-sail.git#f319aad \
-    && opam pin --yes -n coq-cheri-capabilities https://github.com/rems-project/coq-cheri-capabilities.git \
+    && opam pin --yes -n coq-cheri-capabilities https://github.com/rems-project/coq-cheri-capabilities.git#2f02c44ad061d4da30136dc9dbc06c142c94fdaf \
     && opam pin add -n --yes cerberus-lib https://github.com/rems-project/cerberus.git \
     && opam pin add -n --yes cerberus https://github.com/rems-project/cerberus.git \
     && opam pin add -n --yes cerberus-cheri https://github.com/rems-project/cerberus.git

--- a/README-cheri.md
+++ b/README-cheri.md
@@ -31,7 +31,7 @@ opam repo add --this-switch coq-released https://coq.inria.fr/opam/released
 opam pin -ny coq-struct-tact https://github.com/uwplse/StructTact.git
 opam repo add --this-switch iris-dev https://gitlab.mpi-sws.org/iris/opam.git
 opam pin -ny coq-sail-stdpp https://github.com/rems-project/coq-sail.git#f319aad
-opam pin -ny coq-cheri-capabilities https://github.com/rems-project/coq-cheri-capabilities.git
+opam pin -ny coq-cheri-capabilities https://github.com/rems-project/coq-cheri-capabilities.git#2f02c44ad061d4da30136dc9dbc06c142c94fdaf
 ```
 
 Install the remaining dependencies using opam:


### PR DESCRIPTION
Pinned `coq-cheri-capabilities` dependency to last known good version.

Fixes #736