### PR TITLE
fixed Coq version (it does not compile with 8.19)

### DIFF
--- a/cerberus-cheri.opam
+++ b/cerberus-cheri.opam
@@ -35,7 +35,7 @@ depends: [
   "ounit2"
   "ppx_deriving"
   "zarith"
-  "coq" {>= "8.18.0"}
+  "coq" {= "8.18.0"}
   "coq-bbv" {>= "1.3" & <= "1.4"}
   "coq-sail-stdpp"
   "coq-ext-lib"


### PR DESCRIPTION
Because the Coq version was not constrained from above, the recent Opam update updated it to 8.19, which broke compilation.