### PR TITLE
[CN-Test-Gen] Add input discard timeout

### DIFF
--- a/backend/cn/bin/main.ml
+++ b/backend/cn/bin/main.ml
@@ -458,6 +458,7 @@ let run_tests
   max_backtracks
   max_unfolds
   max_array_length
+  input_timeout
   null_in_every
   seed
   logging_level
@@ -532,6 +533,7 @@ let run_tests
               max_backtracks;
               max_unfolds;
               max_array_length;
+              input_timeout;
               null_in_every;
               seed;
               logging_level;
@@ -967,6 +969,14 @@ module Testing_flags = struct
       & info [ "max-array-length" ] ~doc)
 
 
+  let input_timeout =
+    let doc = "Timeout for discarding a generation attempt (ms)" in
+    Arg.(
+      value
+      & opt (some int) TestGeneration.default_cfg.input_timeout
+      & info [ "input-timeout" ] ~doc)
+
+
   let null_in_every =
     let doc = "Set the likelihood of NULL being generated as 1 in every <n>" in
     Arg.(
@@ -1103,6 +1113,7 @@ let testing_cmd =
     $ Testing_flags.gen_backtrack_attempts
     $ Testing_flags.gen_max_unfolds
     $ Testing_flags.max_array_length
+    $ Testing_flags.input_timeout
     $ Testing_flags.null_in_every
     $ Testing_flags.seed
     $ Testing_flags.logging_level

--- a/backend/cn/lib/testGeneration/specTests.ml
+++ b/backend/cn/lib/testGeneration/specTests.ml
@@ -433,6 +433,11 @@ let compile_script ~(output_dir : string) ~(test_file : string) : Pp.document =
       space
       string
       ([ "./tests.out" ]
+       @ (Config.has_input_timeout ()
+          |> Option.map (fun input_timeout ->
+            [ "--input-timeout"; string_of_int input_timeout ])
+          |> Option.to_list
+          |> List.flatten)
        @ (Config.has_null_in_every ()
           |> Option.map (fun null_in_every ->
             [ "--null-in-every"; string_of_int null_in_every ])

--- a/backend/cn/lib/testGeneration/testGenConfig.ml
+++ b/backend/cn/lib/testGeneration/testGenConfig.ml
@@ -4,6 +4,7 @@ type t =
     max_backtracks : int;
     max_unfolds : int option;
     max_array_length : int;
+    input_timeout : int option;
     (* Run time *)
     null_in_every : int option;
     seed : string option;
@@ -26,6 +27,7 @@ let default =
     max_backtracks = 25;
     max_unfolds = None;
     max_array_length = 50;
+    input_timeout = None;
     null_in_every = None;
     seed = None;
     logging_level = None;
@@ -54,6 +56,8 @@ let get_max_backtracks () = !instance.max_backtracks
 let get_max_unfolds () = !instance.max_unfolds
 
 let get_max_array_length () = !instance.max_array_length
+
+let has_input_timeout () = !instance.input_timeout
 
 let has_null_in_every () = !instance.null_in_every
 

--- a/backend/cn/lib/testGeneration/testGenConfig.mli
+++ b/backend/cn/lib/testGeneration/testGenConfig.mli
@@ -5,6 +5,7 @@ type t =
     max_unfolds : int option;
     max_array_length : int;
     (* Run time *)
+    input_timeout : int option;
     null_in_every : int option;
     seed : string option;
     logging_level : int option;
@@ -32,6 +33,8 @@ val get_max_backtracks : unit -> int
 val get_max_unfolds : unit -> int option
 
 val get_max_array_length : unit -> int
+
+val has_input_timeout : unit -> int option
 
 val has_null_in_every : unit -> int option
 

--- a/runtime/libcn/include/cn-testing/dsl.h
+++ b/runtime/libcn/include/cn-testing/dsl.h
@@ -7,19 +7,15 @@
 #include "backtrack.h"
 
 
-#define CN_GEN_INIT()                                                                   \
-    if (0) {                                                                            \
-    cn_label_bennet_backtrack:                                                          \
-        cn_gen_decrement_depth();                                                       \
-        return NULL;                                                                    \
-    }                                                                                   \
-    cn_gen_increment_depth();                                                           \
-    if (cn_gen_depth() == cn_gen_max_depth()) {                                         \
-        cn_gen_backtrack_depth_exceeded();                                              \
-        goto cn_label_bennet_backtrack;                                                 \
-    }
+#define CN_GEN_INIT() CN_GEN_INIT_SIZED(cn_gen_get_max_size())
 
 #define CN_GEN_INIT_SIZED(size)                                                         \
+    if (cn_gen_get_input_timeout() != 0                                                 \
+        && cn_gen_get_milliseconds() - cn_gen_get_input_timer()                         \
+            > cn_gen_get_input_timeout()) {                                             \
+        cn_gen_backtrack_assert_failure();                                              \
+        goto cn_label_bennet_backtrack;                                                 \
+    }                                                                                   \
     if (0) {                                                                            \
     cn_label_bennet_backtrack:                                                          \
         cn_gen_decrement_depth();                                                       \

--- a/runtime/libcn/include/cn-testing/size.h
+++ b/runtime/libcn/include/cn-testing/size.h
@@ -18,3 +18,11 @@ uint16_t cn_gen_get_depth_failures_allowed();
 
 void cn_gen_set_size_split_backtracks_allowed(uint16_t allowed);
 uint16_t cn_gen_get_size_split_backtracks_allowed();
+
+void cn_gen_set_input_timeout(uint8_t seconds);
+uint8_t cn_gen_get_input_timeout(void);
+
+void cn_gen_set_input_timer(uint64_t time);
+uint64_t cn_gen_get_input_timer(void);
+
+uint64_t cn_gen_get_milliseconds(void);

--- a/runtime/libcn/src/cn-testing/size.c
+++ b/runtime/libcn/src/cn-testing/size.c
@@ -62,3 +62,58 @@ void cn_gen_set_size_split_backtracks_allowed(uint16_t allowed) {
 uint16_t cn_gen_get_size_split_backtracks_allowed() {
     return size_split_backtracks_allowed;
 }
+
+static uint8_t timeout = 0;
+
+void cn_gen_set_input_timeout(uint8_t seconds) {
+    timeout = seconds;
+}
+
+uint8_t cn_gen_get_input_timeout(void) {
+    return timeout;
+}
+
+static uint64_t timer = 0;
+
+void cn_gen_set_input_timer(uint64_t time) {
+    timer = time;
+}
+
+uint64_t cn_gen_get_input_timer(void) {
+    return timer;
+}
+
+#if defined (__unix__) || (defined (__APPLE__) && defined (__MACH__))
+#include <sys/time.h>
+#elif defined(_WIN32) || defined(_WIN64)
+#include <Windows.h>
+
+/// Taken from https://stackoverflow.com/questions/10905892/equivalent-of-gettimeofday-for-windows
+int gettimeofday(struct timeval* tp, struct timezone* tzp)
+{
+    // Note: some broken versions only have 8 trailing zero's, the correct epoch has 9 trailing zero's
+    // This magic number is the number of 100 nanosecond intervals since January 1, 1601 (UTC)
+    // until 00:00:00 January 1, 1970 
+    static const uint64_t EPOCH = ((uint64_t)116444736000000000ULL);
+
+    SYSTEMTIME  system_time;
+    FILETIME    file_time;
+    uint64_t    time;
+
+    GetSystemTime(&system_time);
+    SystemTimeToFileTime(&system_time, &file_time);
+    time = ((uint64_t)file_time.dwLowDateTime);
+    time += ((uint64_t)file_time.dwHighDateTime) << 32;
+
+    tp->tv_sec = (long)((time - EPOCH) / 10000000L);
+    tp->tv_usec = (long)(system_time.wMilliseconds * 1000);
+    return 0;
+}
+#endif
+
+uint64_t cn_gen_get_milliseconds(void) {
+    struct timeval tv;
+
+    gettimeofday(&tv, NULL);
+    return (((uint64_t)tv.tv_sec) * 1000) + (tv.tv_usec / 1000);
+}

--- a/tests/run-cn-test-gen.sh
+++ b/tests/run-cn-test-gen.sh
@@ -35,7 +35,7 @@ for CONFIG in ${CONFIGS[@]}; do
   echo "Running CI with CLI config \"$CONFIG\""
   separator
 
-  CONFIG="$CONFIG --max-generator-size=10 --allowed-depth-failures=100"
+  CONFIG="$CONFIG --allowed-depth-failures=100 --input-timeout=1000"
 
   # Test each `*.c` file
   for TEST in $FILES; do


### PR DESCRIPTION
Closes #745.

Allows us to use the default generator max size in CI, decreasing CI flakiness, without significantly increasing the time it takes to run.