### PR TITLE
[CN-Test-Gen] Allow controlling progress output (`--progress-level`)

### DIFF
--- a/backend/cn/bin/main.ml
+++ b/backend/cn/bin/main.ml
@@ -462,6 +462,7 @@ let run_tests
   null_in_every
   seed
   logging_level
+  progress_level
   interactive
   until_timeout
   exit_fast
@@ -537,6 +538,7 @@ let run_tests
               null_in_every;
               seed;
               logging_level;
+              progress_level;
               interactive;
               until_timeout;
               exit_fast;
@@ -998,6 +1000,17 @@ module Testing_flags = struct
       & info [ "logging-level" ] ~doc)
 
 
+  let progress_level =
+    let doc =
+      "Set the level of detail for progress updates (0 = Quiet, 1 = Per function, 2 = \
+       Per test case)"
+    in
+    Arg.(
+      value
+      & opt (some int) TestGeneration.default_cfg.progress_level
+      & info [ "progress-level" ] ~doc)
+
+
   let interactive =
     let doc =
       "Enable interactive features for testing, such as requesting more detailed logs"
@@ -1117,6 +1130,7 @@ let testing_cmd =
     $ Testing_flags.null_in_every
     $ Testing_flags.seed
     $ Testing_flags.logging_level
+    $ Testing_flags.progress_level
     $ Testing_flags.interactive
     $ Testing_flags.until_timeout
     $ Testing_flags.exit_fast

--- a/backend/cn/lib/testGeneration/specTests.ml
+++ b/backend/cn/lib/testGeneration/specTests.ml
@@ -451,6 +451,10 @@ let compile_script ~(output_dir : string) ~(test_file : string) : Pp.document =
           |> Option.map (fun level -> [ "--logging-level"; string_of_int level ])
           |> Option.to_list
           |> List.flatten)
+       @ (Config.has_progress_level ()
+          |> Option.map (fun level -> [ "--progress-level"; string_of_int level ])
+          |> Option.to_list
+          |> List.flatten)
        @ (if Config.is_interactive () then
             [ "--interactive" ]
           else

--- a/backend/cn/lib/testGeneration/testGenConfig.ml
+++ b/backend/cn/lib/testGeneration/testGenConfig.ml
@@ -9,6 +9,7 @@ type t =
     null_in_every : int option;
     seed : string option;
     logging_level : int option;
+    progress_level : int option;
     interactive : bool;
     until_timeout : int option;
     exit_fast : bool;
@@ -31,6 +32,7 @@ let default =
     null_in_every = None;
     seed = None;
     logging_level = None;
+    progress_level = None;
     interactive = false;
     until_timeout = None;
     exit_fast = false;
@@ -64,6 +66,8 @@ let has_null_in_every () = !instance.null_in_every
 let has_seed () = !instance.seed
 
 let has_logging_level () = !instance.logging_level
+
+let has_progress_level () = !instance.progress_level
 
 let is_interactive () = !instance.interactive
 

--- a/backend/cn/lib/testGeneration/testGenConfig.mli
+++ b/backend/cn/lib/testGeneration/testGenConfig.mli
@@ -9,6 +9,7 @@ type t =
     null_in_every : int option;
     seed : string option;
     logging_level : int option;
+    progress_level : int option;
     interactive : bool;
     until_timeout : int option;
     exit_fast : bool;
@@ -41,6 +42,8 @@ val has_null_in_every : unit -> int option
 val has_seed : unit -> string option
 
 val has_logging_level : unit -> int option
+
+val has_progress_level : unit -> int option
 
 val is_interactive : unit -> bool
 

--- a/tests/run-cn-test-gen.sh
+++ b/tests/run-cn-test-gen.sh
@@ -30,12 +30,12 @@ function separator() {
 CONFIGS=("--coverage" "--sized-null" "--random-size-splits" "--random-size-splits --allowed-size-split-backtracks=10")
 
 # For each configuration
-for CONFIG in ${CONFIGS[@]}; do
+for CONFIG in "${CONFIGS[@]}"; do
   separator
   echo "Running CI with CLI config \"$CONFIG\""
   separator
 
-  CONFIG="$CONFIG --allowed-depth-failures=100 --input-timeout=1000"
+  FULL_CONFIG="$CONFIG --allowed-depth-failures=100 --input-timeout=1000 --progress-level=1"
 
   # Test each `*.c` file
   for TEST in $FILES; do
@@ -43,13 +43,13 @@ for CONFIG in ${CONFIGS[@]}; do
 
     # Run passing tests
     if [[ $TEST == *.pass.c ]]; then
-      $CN test "$TEST" --output-dir="test" $CONFIG
+      $CN test "$TEST" --output-dir="test" $FULL_CONFIG
       RET=$?
       if [[ "$RET" != 0 ]]; then
         echo
         echo "$TEST -- Tests failed unexpectedly"
         NUM_FAILED=$(($NUM_FAILED + 1))
-        FAILED="$FAILED $TEST"
+        FAILED="$FAILED $TEST($CONFIG)"
         eval "$CLEANUP"
         continue
       else
@@ -60,13 +60,13 @@ for CONFIG in ${CONFIGS[@]}; do
 
     # Run failing tests
     if [[ $TEST == *.fail.c ]]; then
-      $CN test "$TEST" --output-dir="test" $CONFIG
+      $CN test "$TEST" --output-dir="test" $FULL_CONFIG
       RET=$?
       if [[ "$RET" = 0 ]]; then
         echo
         echo "$TEST -- Tests passed unexpectedly"
         NUM_FAILED=$(($NUM_FAILED + 1))
-        FAILED="$FAILED $TEST"
+        FAILED="$FAILED $TEST($CONFIG)"
         eval "$CLEANUP"
         continue
       else


### PR DESCRIPTION
Make it quiet (`--progress-level 0`), only print the sample and discard count after testing a function (`--progress-level 1`), or update the count live (`--progress-level 2`).

Makes CI easier to read and simplifies processing the output in other tools (ex: Etna)

Closes #748 