### PR TITLE
CN VIP: Correct/explain shifting assumptions

### DIFF
--- a/backend/cn/bin/main.ml
+++ b/backend/cn/bin/main.ml
@@ -59,6 +59,10 @@ let frontend ~macros ~incl_dirs ~incl_files astprints ~filename ~magic_comment_c
   Ocaml_implementation.set Ocaml_implementation.HafniumImpl.impl;
   Switches.set
     ([ "inner_arg_temps"; "at_magic_comments" ]
+     (* TODO (DCM, VIP) figure out how to support liveness checks for read-only
+        resources and then switch on "strict_pointer_arith" to elaborate array
+        shift to the effectful version. "strict_pointer_relationals" is also
+        assumed, but this does not affect elaboration. *)
      @ if magic_comment_char_dollar then [ "magic_comment_char_dollar" ] else []);
   let@ stdlib = load_core_stdlib () in
   let@ impl = load_core_impl stdlib impl_name in

--- a/backend/cn/lib/core_to_mucore.ml
+++ b/backend/cn/lib/core_to_mucore.ml
@@ -233,7 +233,7 @@ let rec n_pexpr ~inherit_loc loc (Pexpr (annots, bty, pe)) : unit Mucore.pexpr =
   | PEmemop (_mop, _pes) ->
     (* FIXME(CHERI merge) *)
     (* this construct is currently only used by the CHERI switch *)
-    assert_error loc !^"PEmemop"
+    assert_error loc !^"PEmemop (CHERI only)"
   | PEnot e' ->
     let e' = n_pexpr loc e' in
     annotate (PEnot e')
@@ -626,9 +626,12 @@ let n_memop ~inherit_loc loc memop pexprs =
     let pe1 = n_pexpr loc pe1 in
     let pe2 = n_pexpr loc pe2 in
     CopyAllocId (pe1, pe2)
+  | PtrMemberShift _, _ -> assert_error loc !^"PtrMemberShift (CHERI only)"
   | memop, pexprs1 ->
     let err =
-      !^(show_n_memop memop)
+      !^__FUNCTION__
+      ^^ colon
+      ^^^ !^(show_n_memop memop)
       ^^^ !^"applied to"
       ^^^ int (List.length pexprs1)
       ^^^ !^"arguments"

--- a/backend/cn/lib/resourceInference.ml
+++ b/backend/cn/lib/resourceInference.ml
@@ -481,6 +481,11 @@ module Special = struct
     match result with Some r -> return r | None -> fail_missing_resource loc uiinfo
 
 
+  let has_predicate loc situation (request, oinfo) =
+    let@ result = sandbox @@ predicate_request loc situation (request, oinfo) in
+    return (Result.is_ok result)
+
+
   (** This function checks whether [ptr1] belongs to a live allocation. It
       searches the context (without modification) for either an Alloc(p) or an
       Owned(p) such that (alloc_id) p == (alloc_id) ptr. *)
@@ -537,10 +542,6 @@ module Special = struct
             { reason; ptr; model_constr = Some (model, constr); ctxt }
         in
         { loc; msg })
-
-
-  let predicate_request loc situation (request, oinfo) =
-    predicate_request loc situation (request, oinfo)
 
 
   let qpredicate_request loc situation (request, oinfo) =

--- a/backend/cn/lib/resourceInference.ml
+++ b/backend/cn/lib/resourceInference.ml
@@ -484,7 +484,7 @@ module Special = struct
   (** This function checks whether [ptr1] belongs to a live allocation. It
       searches the context (without modification) for either an Alloc(p) or an
       Owned(p) such that (alloc_id) p == (alloc_id) ptr. *)
-  let get_live_alloc reason loc ptr =
+  let check_live_alloc reason loc ptr =
     let module Ans = struct
       type t =
         | Found
@@ -523,7 +523,7 @@ module Special = struct
     let@ found, _ = map_and_fold_resources loc f (return Ans.No_res) in
     let@ found in
     match found with
-    | Ans.Found -> return (Alloc.History.lookup_ptr ptr here)
+    | Ans.Found -> return ()
     | No_res ->
       fail (fun ctxt ->
         let msg =

--- a/backend/cn/lib/resourceInference.mli
+++ b/backend/cn/lib/resourceInference.mli
@@ -18,11 +18,11 @@ module General : sig
 end
 
 module Special : sig
-  val get_live_alloc
-    :  [ `Copy_alloc_id | `Ptr_cmp | `Ptr_diff | `ISO_array_shift ] ->
+  val check_live_alloc
+    :  [ `Copy_alloc_id | `Ptr_cmp | `Ptr_diff | `ISO_array_shift | `ISO_member_shift ] ->
     Locations.t ->
     IndexTerms.t ->
-    IndexTerms.t Typing.m
+    unit Typing.m
 
   val predicate_request
     :  Locations.t ->

--- a/backend/cn/lib/resourceInference.mli
+++ b/backend/cn/lib/resourceInference.mli
@@ -30,6 +30,12 @@ module Special : sig
     Request.Predicate.t * (Locations.t * string) option ->
     (Resource.predicate * int list) Typing.m
 
+  val has_predicate
+    :  Locations.t ->
+    TypeErrors.situation ->
+    Request.Predicate.t * (Locations.t * string) option ->
+    bool Typing.m
+
   val qpredicate_request
     :  Locations.t ->
     TypeErrors.situation ->

--- a/frontend/model/translation.lem
+++ b/frontend/model/translation.lem
@@ -2819,7 +2819,7 @@ end
             E.return begin
               C.Expr [Annot.Astd "§6.5.2.3#3, sentence 2"] (
                 C.Esseq e_wrp.E.sym_pat core_e (
-begin if Global.has_strict_pointer_arith () || Global.is_CHERI () (* || Global.is_PNVI () *) then
+begin if Global.is_CHERI () then
                   (Caux.mk_memop_e (Mem_common.PtrMemberShift tag_sym ident) [e_wrp.E.sym_pe])
 else
                   Caux.mk_pure_e (Caux.mk_member_shift_pe e_wrp.E.sym_pe tag_sym ident)


### PR DESCRIPTION
This is trickier than anticipated because of create_rdonly - it uses the effectful array shift for some reason.