### PR TITLE
Alternative resource inference scheme

### DIFF
--- a/backend/cn/lib/check.ml
+++ b/backend/cn/lib/check.ml
@@ -1845,8 +1845,12 @@ let rec check_expr labels (e : BT.t Mu.expr) (k : IT.t -> unit m) : unit m =
        let aux loc stmt =
          (* copying bits of code from elsewhere in check.ml *)
          match stmt with
-         | Cnprog.Pack_unpack (_pack_unpack, _pt) ->
-           warn loc !^"Explicit pack/unpack unsupported.";
+         | Cnprog.Pack_unpack (Pack, pt) ->
+           let@ pt = WellTyped.WReq.welltyped loc (P pt) in
+           let pt = match pt with P pt -> pt | Q _ -> assert false in
+           add_packable_resource loc pt
+         | Cnprog.Pack_unpack (Unpack, _pt) ->
+           warn loc !^"Explicit unpack unsupported.";
            return ()
          | To_from_bytes ((To | From), { name = PName _; _ }) ->
            fail (fun _ -> { loc; msg = Byte_conv_needs_owned })

--- a/backend/cn/lib/resourceInference.ml
+++ b/backend/cn/lib/resourceInference.ml
@@ -227,7 +227,8 @@ module General = struct
       match needed with
       | false -> return (Some ((requested, oarg), changed_or_deleted))
       | true ->
-        (match Pack.packing_ft here global provable (P requested) with
+        let@ packable_resources = get_packable_resources () in
+        (match Pack.packing_ft here global provable packable_resources (P requested) with
          | Some packing_ft ->
            let ft_pp =
              lazy (LogicalArgumentTypes.pp (fun _ -> Pp.string "resource") packing_ft)

--- a/backend/cn/lib/typing.mli
+++ b/backend/cn/lib/typing.mli
@@ -166,11 +166,15 @@ val bind_logical_return
 
 val bind_return : Locations.t -> IndexTerms.t list -> ReturnTypes.t -> IndexTerms.t m
 
+val add_packable_resource : Locations.t -> Request.Predicate.t -> unit m
+
 val add_movable_index
   :  Locations.t ->
   (* verbose:bool -> *)
   Request.name * IndexTerms.t ->
   unit m
+
+val get_packable_resources : unit -> Request.Predicate.t list m
 
 val get_movable_indices : unit -> (Request.name * IndexTerms.t) list m
 


### PR DESCRIPTION
Not all predicates are automatically un/packed.

Instead, resources with multiple clauses (including recursive predicates) are only packed when instructed by the user.

This makes resource inference a bit more manual than before, but it should also be substantially faster, we will see.