### PR TITLE
CN VIP: Clarify pointer equality tests

### DIFF
--- a/backend/cn/lib/check.ml
+++ b/backend/cn/lib/check.ml
@@ -1337,13 +1337,13 @@ let rec check_expr labels (e : BT.t Mu.expr) (k : IT.t -> unit m) : unit m =
              in
              let@ provable = provable loc in
              let@ () =
-               match provable @@ LC.T ambiguous with
-               | `False -> return ()
-               | `True ->
+               match provable @@ LC.T (not_ ambiguous here) with
+               | `True -> return ()
+               | `False ->
                  let msg =
                    Printf.sprintf
-                     "ambiguous pointer %sequality case: addresses equal, but \
-                      provenances differ"
+                     "Cannot rule out ambiguous pointer %sequality case (addresses \
+                      equal, but provenances differ)"
                      case
                  in
                  warn loc !^msg;

--- a/tests/cn_vip_testsuite/pointer_copy_user_dataflow_direct_bytewise.pass.c.no_annot
+++ b/tests/cn_vip_testsuite/pointer_copy_user_dataflow_direct_bytewise.pass.c.no_annot
@@ -1,1 +1,18 @@
-TIMEOUT
+return code: 0
+tests/cn_vip_testsuite/pointer_copy_user_dataflow_direct_bytewise.pass.c:28:5: warning: CN pointer equality is not the same as C's (will not warn again). Please use `ptr_eq` or `is_null` (maybe `addr_eq`).
+    src == array_shift<unsigned char>(src_start, n_start - n);
+    ~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
+tests/cn_vip_testsuite/pointer_copy_user_dataflow_direct_bytewise.pass.c:48:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
+  /*CN_VIP*//*@ to_bytes Owned<int*>(&p); @*/
+                ^~~~~~~~ 
+tests/cn_vip_testsuite/pointer_copy_user_dataflow_direct_bytewise.pass.c:49:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
+  /*CN_VIP*//*@ to_bytes Block<int*>(&q); @*/
+                ^~~~~~~~ 
+tests/cn_vip_testsuite/pointer_copy_user_dataflow_direct_bytewise.pass.c:52:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
+  /*CN_VIP*//*@ from_bytes Owned<int*>(&q); @*/
+                ^~~~~~~~~~ 
+tests/cn_vip_testsuite/pointer_copy_user_dataflow_direct_bytewise.pass.c:53:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
+  /*CN_VIP*//*@ from_bytes Owned<int*>(&p); @*/
+                ^~~~~~~~~~ 
+[1/2]: user_memcpy -- pass
+[2/2]: main -- pass

--- a/tests/cn_vip_testsuite/pointer_from_integer_1ig.annot.c.no_annot
+++ b/tests/cn_vip_testsuite/pointer_from_integer_1ig.annot.c.no_annot
@@ -1,4 +1,7 @@
 return code: 1
+tests/cn_vip_testsuite/pointer_from_integer_1ig.annot.c:15:7: warning: Cannot rule out ambiguous pointer equality case (addresses equal, but provenances differ)
+  if (p==&j) {
+      ~^~~~ 
 [1/2]: f -- fail
 [2/2]: main -- pass
 tests/cn_vip_testsuite/pointer_from_integer_1ig.annot.c:16:5: error: Missing resource for writing

--- a/tests/cn_vip_testsuite/pointer_from_integer_1pg.unprovable.c.no_annot
+++ b/tests/cn_vip_testsuite/pointer_from_integer_1pg.unprovable.c.no_annot
@@ -1,4 +1,7 @@
 return code: 1
+tests/cn_vip_testsuite/pointer_from_integer_1pg.unprovable.c:6:7: warning: Cannot rule out ambiguous pointer equality case (addresses equal, but provenances differ)
+  if (p==&j)
+      ~^~~~ 
 [1/2]: f -- fail
 [2/2]: main -- pass
 tests/cn_vip_testsuite/pointer_from_integer_1pg.unprovable.c:7:5: error: Missing resource for writing

--- a/tests/cn_vip_testsuite/provenance_equality_auto_yx.nondet.c
+++ b/tests/cn_vip_testsuite/provenance_equality_auto_yx.nondet.c
@@ -1,7 +1,9 @@
 //CN_VIP #include <stdio.h>
 //CN_VIP #include <string.h>
+#include "cn_lemmas.h"
 int main() {
   int y=2, x=1;
+  /*CN_VIP*//*@ apply assert_equal((u64)&y, (u64)&x + sizeof<int>); @*/
   int *p = &x + 1;
   int *q = &y;
   //CN_VIP printf("Addresses: p=%p q=%p\n",(void*)p,(void*)q);

--- a/tests/cn_vip_testsuite/provenance_equality_auto_yx.nondet.c.no_annot
+++ b/tests/cn_vip_testsuite/provenance_equality_auto_yx.nondet.c.no_annot
@@ -1,2 +1,5 @@
 return code: 0
+tests/cn_vip_testsuite/provenance_equality_auto_yx.nondet.c:10:13: warning: Cannot rule out ambiguous pointer equality case (addresses equal, but provenances differ)
+  _Bool b = (p==q);
+            ^~~~~~ 
 [1/1]: main -- pass

--- a/tests/cn_vip_testsuite/provenance_equality_auto_yx.nondet.c.non_det_false
+++ b/tests/cn_vip_testsuite/provenance_equality_auto_yx.nondet.c.non_det_false
@@ -1,9 +1,12 @@
 return code: 1
+tests/cn_vip_testsuite/provenance_equality_auto_yx.nondet.c:10:13: warning: Cannot rule out ambiguous pointer equality case (addresses equal, but provenances differ)
+  _Bool b = (p==q);
+            ^~~~~~ 
 [1/1]: main -- fail
-tests/cn_vip_testsuite/provenance_equality_auto_yx.nondet.c:13:17: error: Unprovable constraint
+tests/cn_vip_testsuite/provenance_equality_auto_yx.nondet.c:15:17: error: Unprovable constraint
   /*CN_VIP*//*@ assert (b == 0u8); @*/ // non-det in PNVI-ae-udi; true in VIP
                 ^~~~~~~~~~~~~~~~~~ 
-Constraint from tests/cn_vip_testsuite/provenance_equality_auto_yx.nondet.c:13:17:
+Constraint from tests/cn_vip_testsuite/provenance_equality_auto_yx.nondet.c:15:17:
   /*CN_VIP*//*@ assert (b == 0u8); @*/ // non-det in PNVI-ae-udi; true in VIP
                 ^~~~~~~~~~~~~~~~~~ 
 State file: file:///tmp/state__provenance_equality_auto_yx.nondet.c__main.html

--- a/tests/cn_vip_testsuite/provenance_equality_auto_yx.nondet.c.non_det_true
+++ b/tests/cn_vip_testsuite/provenance_equality_auto_yx.nondet.c.non_det_true
@@ -1,9 +1,12 @@
 return code: 1
+tests/cn_vip_testsuite/provenance_equality_auto_yx.nondet.c:10:13: warning: Cannot rule out ambiguous pointer equality case (addresses equal, but provenances differ)
+  _Bool b = (p==q);
+            ^~~~~~ 
 [1/1]: main -- fail
-tests/cn_vip_testsuite/provenance_equality_auto_yx.nondet.c:11:17: error: Unprovable constraint
+tests/cn_vip_testsuite/provenance_equality_auto_yx.nondet.c:13:17: error: Unprovable constraint
   /*CN_VIP*//*@ assert (b == 1u8); @*/ // non-det in PNVI-ae-udi; true in VIP
                 ^~~~~~~~~~~~~~~~~~ 
-Constraint from tests/cn_vip_testsuite/provenance_equality_auto_yx.nondet.c:11:17:
+Constraint from tests/cn_vip_testsuite/provenance_equality_auto_yx.nondet.c:13:17:
   /*CN_VIP*//*@ assert (b == 1u8); @*/ // non-det in PNVI-ae-udi; true in VIP
                 ^~~~~~~~~~~~~~~~~~ 
 State file: file:///tmp/state__provenance_equality_auto_yx.nondet.c__main.html

--- a/tests/cn_vip_testsuite/provenance_equality_global_fn_yx.nondet.c
+++ b/tests/cn_vip_testsuite/provenance_equality_global_fn_yx.nondet.c
@@ -1,7 +1,9 @@
 //CN_VIP #include <stdio.h>
 #include <string.h>
 int y=2, x=1;
-void f(int* p, int* q) {
+void f(int* p, int* q)
+/*CN_VIP*//*@ requires (u64)p == (u64)q; @*/
+{
   _Bool b = (p==q);
   // can this be false even with identical addresses?
   //CN_VIP printf("(p==q) = %s\n", b?"true":"false");
@@ -14,7 +16,9 @@ void f(int* p, int* q) {
 #endif
   return;
 }
-int main() {
+int main()
+/*CN_VIP*//*@ accesses x; requires (u64)&y == (u64)&x + sizeof<int>; @*/
+{
   int *p = &x + 1;
   int *q = &y;
   //CN_VIP printf("Addresses: p=%p q=%p\n",(void*)p,(void*)q);

--- a/tests/cn_vip_testsuite/provenance_equality_global_fn_yx.nondet.c.no_annot
+++ b/tests/cn_vip_testsuite/provenance_equality_global_fn_yx.nondet.c.no_annot
@@ -1,3 +1,6 @@
 return code: 0
+tests/cn_vip_testsuite/provenance_equality_global_fn_yx.nondet.c:7:13: warning: Cannot rule out ambiguous pointer equality case (addresses equal, but provenances differ)
+  _Bool b = (p==q);
+            ^~~~~~ 
 [1/2]: f -- pass
 [2/2]: main -- pass

--- a/tests/cn_vip_testsuite/provenance_equality_global_fn_yx.nondet.c.non_det_false
+++ b/tests/cn_vip_testsuite/provenance_equality_global_fn_yx.nondet.c.non_det_false
@@ -1,10 +1,13 @@
 return code: 1
+tests/cn_vip_testsuite/provenance_equality_global_fn_yx.nondet.c:7:13: warning: Cannot rule out ambiguous pointer equality case (addresses equal, but provenances differ)
+  _Bool b = (p==q);
+            ^~~~~~ 
 [1/2]: f -- fail
 [2/2]: main -- pass
-tests/cn_vip_testsuite/provenance_equality_global_fn_yx.nondet.c:11:17: error: Unprovable constraint
+tests/cn_vip_testsuite/provenance_equality_global_fn_yx.nondet.c:13:17: error: Unprovable constraint
   /*CN_VIP*//*@ assert (b == 0u8); @*/ // non-det in PNVI-ae-udi; true in VIP
                 ^~~~~~~~~~~~~~~~~~ 
-Constraint from tests/cn_vip_testsuite/provenance_equality_global_fn_yx.nondet.c:11:17:
+Constraint from tests/cn_vip_testsuite/provenance_equality_global_fn_yx.nondet.c:13:17:
   /*CN_VIP*//*@ assert (b == 0u8); @*/ // non-det in PNVI-ae-udi; true in VIP
                 ^~~~~~~~~~~~~~~~~~ 
 State file: file:///tmp/state__provenance_equality_global_fn_yx.nondet.c__f.html

--- a/tests/cn_vip_testsuite/provenance_equality_global_fn_yx.nondet.c.non_det_true
+++ b/tests/cn_vip_testsuite/provenance_equality_global_fn_yx.nondet.c.non_det_true
@@ -1,10 +1,13 @@
 return code: 1
+tests/cn_vip_testsuite/provenance_equality_global_fn_yx.nondet.c:7:13: warning: Cannot rule out ambiguous pointer equality case (addresses equal, but provenances differ)
+  _Bool b = (p==q);
+            ^~~~~~ 
 [1/2]: f -- fail
 [2/2]: main -- pass
-tests/cn_vip_testsuite/provenance_equality_global_fn_yx.nondet.c:9:17: error: Unprovable constraint
+tests/cn_vip_testsuite/provenance_equality_global_fn_yx.nondet.c:11:17: error: Unprovable constraint
   /*CN_VIP*//*@ assert (b == 1u8); @*/ // non-det in PNVI-ae-udi; true in VIP
                 ^~~~~~~~~~~~~~~~~~ 
-Constraint from tests/cn_vip_testsuite/provenance_equality_global_fn_yx.nondet.c:9:17:
+Constraint from tests/cn_vip_testsuite/provenance_equality_global_fn_yx.nondet.c:11:17:
   /*CN_VIP*//*@ assert (b == 1u8); @*/ // non-det in PNVI-ae-udi; true in VIP
                 ^~~~~~~~~~~~~~~~~~ 
 State file: file:///tmp/state__provenance_equality_global_fn_yx.nondet.c__f.html

--- a/tests/cn_vip_testsuite/provenance_equality_global_yx.nondet.c
+++ b/tests/cn_vip_testsuite/provenance_equality_global_yx.nondet.c
@@ -1,7 +1,9 @@
 //CN_VIP #include <stdio.h>
 #include <string.h>
 int y=2, x=1;
-int main() {
+int main()
+/*CN_VIP*//*@ accesses x; requires (u64)&y == (u64)&x + sizeof<int>; @*/
+{
   int *p = &x + 1;
   int *q = &y;
   //CN_VIP printf("Addresses: p=%p q=%p\n",(void*)p,(void*)q);

--- a/tests/cn_vip_testsuite/provenance_equality_global_yx.nondet.c.no_annot
+++ b/tests/cn_vip_testsuite/provenance_equality_global_yx.nondet.c.no_annot
@@ -1,2 +1,5 @@
 return code: 0
+tests/cn_vip_testsuite/provenance_equality_global_yx.nondet.c:10:13: warning: Cannot rule out ambiguous pointer equality case (addresses equal, but provenances differ)
+  _Bool b = (p==q);
+            ^~~~~~ 
 [1/1]: main -- pass

--- a/tests/cn_vip_testsuite/provenance_equality_global_yx.nondet.c.non_det_false
+++ b/tests/cn_vip_testsuite/provenance_equality_global_yx.nondet.c.non_det_false
@@ -1,9 +1,12 @@
 return code: 1
+tests/cn_vip_testsuite/provenance_equality_global_yx.nondet.c:10:13: warning: Cannot rule out ambiguous pointer equality case (addresses equal, but provenances differ)
+  _Bool b = (p==q);
+            ^~~~~~ 
 [1/1]: main -- fail
-tests/cn_vip_testsuite/provenance_equality_global_yx.nondet.c:14:17: error: Unprovable constraint
+tests/cn_vip_testsuite/provenance_equality_global_yx.nondet.c:16:17: error: Unprovable constraint
   /*CN_VIP*//*@ assert (b == 0u8); @*/ // non-det in PNVI-ae-udi; true in VIP
                 ^~~~~~~~~~~~~~~~~~ 
-Constraint from tests/cn_vip_testsuite/provenance_equality_global_yx.nondet.c:14:17:
+Constraint from tests/cn_vip_testsuite/provenance_equality_global_yx.nondet.c:16:17:
   /*CN_VIP*//*@ assert (b == 0u8); @*/ // non-det in PNVI-ae-udi; true in VIP
                 ^~~~~~~~~~~~~~~~~~ 
 State file: file:///tmp/state__provenance_equality_global_yx.nondet.c__main.html

--- a/tests/cn_vip_testsuite/provenance_equality_global_yx.nondet.c.non_det_true
+++ b/tests/cn_vip_testsuite/provenance_equality_global_yx.nondet.c.non_det_true
@@ -1,9 +1,12 @@
 return code: 1
+tests/cn_vip_testsuite/provenance_equality_global_yx.nondet.c:10:13: warning: Cannot rule out ambiguous pointer equality case (addresses equal, but provenances differ)
+  _Bool b = (p==q);
+            ^~~~~~ 
 [1/1]: main -- fail
-tests/cn_vip_testsuite/provenance_equality_global_yx.nondet.c:12:17: error: Unprovable constraint
+tests/cn_vip_testsuite/provenance_equality_global_yx.nondet.c:14:17: error: Unprovable constraint
   /*CN_VIP*//*@ assert (b == 1u8); @*/ // non-det in PNVI-ae-udi; true in VIP
                 ^~~~~~~~~~~~~~~~~~ 
-Constraint from tests/cn_vip_testsuite/provenance_equality_global_yx.nondet.c:12:17:
+Constraint from tests/cn_vip_testsuite/provenance_equality_global_yx.nondet.c:14:17:
   /*CN_VIP*//*@ assert (b == 1u8); @*/ // non-det in PNVI-ae-udi; true in VIP
                 ^~~~~~~~~~~~~~~~~~ 
 State file: file:///tmp/state__provenance_equality_global_yx.nondet.c__main.html


### PR DESCRIPTION
The rule should warn when it cannot rule out ambiguity, rather than when it can prove it.