### PR TITLE
CN: Re-add label consistency check

### DIFF
--- a/backend/cn/lib/check.ml
+++ b/backend/cn/lib/check.ml
@@ -2669,6 +2669,11 @@ let time_check_c_functions (global_var_constraints, (checked : c_function list))
       global.fun_decls
       (return ())
   in
+  let@ () =
+    ListM.iterM
+      (fun (_, (loc, args_and_body)) -> WellTyped.WProc.consistent loc args_and_body)
+      checked
+  in
   let@ errors = check_c_functions checked in
   Cerb_debug.end_csv_timing "type checking functions";
   return errors

--- a/tests/cn/memcpy.c.verify
+++ b/tests/cn/memcpy.c.verify
@@ -17,12 +17,6 @@ tests/cn/memcpy.c:17:16: warning: 'each' expects a 'u64', but 'j' with type 'i32
 tests/cn/memcpy.c:19:16: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
           take srcInv = each (i32 j; 0i32 <= j && j < n)
                ^
-tests/cn/memcpy.c:17:16: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
-  /*@ inv take dstInv = each (i32 j; 0i32 <= j && j < n)
-               ^
-tests/cn/memcpy.c:19:16: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
-          take srcInv = each (i32 j; 0i32 <= j && j < n)
-               ^
 tests/cn/memcpy.c:28:30: warning: 'extract' expects a 'u64', but '(i32)read_&i0' with type 'i32' was provided. This will become an error in the future.
     /*@ extract Owned<char>, (i32)i; @*/
                              ^~~~~~ 


### PR DESCRIPTION
PR #797 split out the consistency and welltyped checks for a few constructs, but accidentally removed the consistency checks for labels. This commit adds them back.

This commit also deletes some code which was made redundant by aba34a0, but was not deleted in that commit.