### PR TITLE
[CN-Test-Gen] Enum hints for `--with-static-hack`

### DIFF
--- a/tests/cn-test-gen/src/enum1.pass.c
+++ b/tests/cn-test-gen/src/enum1.pass.c
@@ -1,0 +1,7 @@
+enum color {
+    Red, Green, Blue
+};
+
+enum color identity(enum color x) {
+    return x;
+}

--- a/tests/cn-test-gen/src/enum2.pass.c
+++ b/tests/cn-test-gen/src/enum2.pass.c
@@ -1,0 +1,7 @@
+enum color {
+    Red, Green, Blue
+};
+
+enum color identity() {
+    return Red;
+}


### PR DESCRIPTION
The `--with-static-hack` flag also works around issues related to https://github.com/rems-project/cerberus/issues/765.

This PR adds warning messages directing the user to the flag, when testing functions with enums in their types.
