### PR TITLE
Add missing bits for supporting `default` in executable specs.

### DIFF
--- a/backend/cn/lib/cn_internal_to_ail.ml
+++ b/backend/cn/lib/cn_internal_to_ail.ml
@@ -576,7 +576,8 @@ let cn_to_ail_default bt =
   let do_call f = A.AilEcall (mk_expr (A.AilEident (Sym.fresh_pretty f)), []) in
   match get_underscored_typedef_string_from_bt bt with
   | Some f -> do_call ("default_" ^ f)
-  | None   -> failwith ("[UNSUPPORTED] default<" ^ Pp.plain (BT.pp bt) ^ ">")
+  | None -> failwith ("[UNSUPPORTED] default<" ^ Pp.plain (BT.pp bt) ^ ">")
+
 
 let cn_to_ail_const_internal const basetype =
   let wrap x = wrap_with_convert_to x basetype in
@@ -588,12 +589,16 @@ let cn_to_ail_const_internal const basetype =
     | Q q -> wrap (A.AilEconst (ConstantFloating (Q.to_string q, None)))
     | Pointer z ->
       (* Printf.printf "In Pointer case; const\n"; *)
-      let ail_const' = A.AilEconst (ConstantInteger (IConstant (z.addr, Decimal, None))) in
+      let ail_const' =
+        A.AilEconst (ConstantInteger (IConstant (z.addr, Decimal, None)))
+      in
       wrap (A.AilEunary (Address, mk_expr ail_const'))
     | Alloc_id _ -> failwith "TODO Alloc_id"
     | Bool b ->
-      wrap (A.AilEconst (ConstantPredefined (if b then PConstantTrue else PConstantFalse)))
-    | Unit -> wrap (A.AilEconst ConstantNull) (* Gets overridden by dest_with_unit_check *)
+      wrap
+        (A.AilEconst (ConstantPredefined (if b then PConstantTrue else PConstantFalse)))
+    | Unit ->
+      wrap (A.AilEconst ConstantNull) (* Gets overridden by dest_with_unit_check *)
     | Null -> wrap (A.AilEconst ConstantNull)
     | CType_const _ -> failwith "TODO CType_const"
     | Default bt -> cn_to_ail_default bt
@@ -810,9 +815,7 @@ let rec cn_to_ail_expr_aux_internal
   match term_ with
   | Const const ->
     let ail_expr, is_unit = cn_to_ail_const_internal const basetype in
-    dest_with_unit_check
-      d
-      ([], [], mk_expr ail_expr, is_unit)
+    dest_with_unit_check d ([], [], mk_expr ail_expr, is_unit)
   | Sym sym ->
     let sym =
       if String.equal (Sym.pp_string sym) "return" then

--- a/backend/cn/lib/executable_spec_records.ml
+++ b/backend/cn/lib/executable_spec_records.ml
@@ -11,7 +11,11 @@ module AT = ArgumentTypes
 let rec add_records_to_map_from_it it =
   match IT.get_term it with
   | IT.Sym _s -> ()
-  | Const _c -> ()
+  | Const c -> begin
+    match c with
+    | Default bt -> Cn_internal_to_ail.augment_record_map bt
+    | _ -> ()
+  end
   | Unop (_uop, t1) -> add_records_to_map_from_it t1
   | Binop (_bop, t1, t2) -> List.iter add_records_to_map_from_it [ t1; t2 ]
   | ITE (t1, t2, t3) -> List.iter add_records_to_map_from_it [ t1; t2; t3 ]

--- a/backend/cn/lib/executable_spec_records.ml
+++ b/backend/cn/lib/executable_spec_records.ml
@@ -11,11 +11,8 @@ module AT = ArgumentTypes
 let rec add_records_to_map_from_it it =
   match IT.get_term it with
   | IT.Sym _s -> ()
-  | Const c -> begin
-    match c with
-    | Default bt -> Cn_internal_to_ail.augment_record_map bt
-    | _ -> ()
-  end
+  | Const c ->
+    (match c with Default bt -> Cn_internal_to_ail.augment_record_map bt | _ -> ())
   | Unop (_uop, t1) -> add_records_to_map_from_it t1
   | Binop (_bop, t1, t2) -> List.iter add_records_to_map_from_it [ t1; t2 ]
   | ITE (t1, t2, t3) -> List.iter add_records_to_map_from_it [ t1; t2; t3 ]

--- a/backend/cn/lib/source_injection.ml
+++ b/backend/cn/lib/source_injection.ml
@@ -349,7 +349,7 @@ let return_injs xs =
            | None ->
              Ok
                ({ footprint = { start_pos; end_pos };
-                  kind = InStmt (1, String.concat "" inj_strs ^ "goto __cn_epilogue;\n")
+                  kind = InStmt (1, String.concat "" ("{ " :: inj_strs) ^ "goto __cn_epilogue; }\n")
                 }
                 :: acc)
            | Some e ->

--- a/backend/cn/lib/source_injection.ml
+++ b/backend/cn/lib/source_injection.ml
@@ -349,7 +349,9 @@ let return_injs xs =
            | None ->
              Ok
                ({ footprint = { start_pos; end_pos };
-                  kind = InStmt (1, String.concat "" ("{ " :: inj_strs) ^ "goto __cn_epilogue; }\n")
+                  kind =
+                    InStmt
+                      (1, String.concat "" ("{ " :: inj_strs) ^ "goto __cn_epilogue; }\n")
                 }
                 :: acc)
            | Some e ->


### PR DESCRIPTION
Fixes #813.   The changes are:

* Replace the `todo` exception, with a call to the relevant `default` function.
* Remember to add the records from `default` to the record map.

Note: some future refactoring could be useful, but is not pressing, to factor out common stuff for calling `default` functions.

Fixes #714.  This also fixes an issue in #714 where we were missing some braces.   This should have been a separate PR but I accidentally pushed it here, and the change is sufficiently small that I felt it is not worth doing surgery on the repo to fix.