### PR TITLE
Add opam-versions because dune developer preview needs it

### DIFF
--- a/cerberus-absint.opam
+++ b/cerberus-absint.opam
@@ -1,0 +1,1 @@
+opam-version: "2.0"

--- a/cerberus-ocaml.opam
+++ b/cerberus-ocaml.opam
@@ -1,0 +1,1 @@
+opam-version: "2.0"

--- a/rustic.opam
+++ b/rustic.opam
@@ -1,0 +1,1 @@
+opam-version: "2.0"


### PR DESCRIPTION
I'm trying the [dune preview](https://preview.dune.build) for package management and it seems that it doesn't like empty dune files without an opam version... Feel free to ignore if you don't want that

See https://github.com/ocaml/dune/issues/11276