### PR TITLE
Makes cached model evaluator solver resettable

### DIFF
--- a/backend/cn/lib/solver.mli
+++ b/backend/cn/lib/solver.mli
@@ -35,6 +35,9 @@ val pop : solver -> int -> unit
     but may be unnecessary https://github.com/rems-project/cerberus/issues/752 *)
 val num_scopes : solver -> int
 
+(* Resets internal state for the model evaluator *)
+val reset_model_evaluator_state : unit -> unit
+
 (* Run the solver. Note that we pass the assumptions explicitly even though they are also
    available in the solver context, because CN is going some simplification on its own. *)
 val provable


### PR DESCRIPTION
The CN LSP Server uses CN as a library and makes repeated calls to `Cn.Check.check_decls_lemmata_fun_specs` to verify and type check multiple files. As each verification call is intended to be in a fresh context, this seems to cause a problem with the cached solver used by the model evaluator and causes an error to be raised leading to the following issue: https://github.com/GaloisInc/VERSE-Toolchain/issues/142

This PR exposes a function in the Solver interface that allows resetting this state.

(The VERSE-toolchain uses an older commit of Cerberus, but applying this patch to that commit also makes the above error go away so it seems to be the cause of the problem)