### PR TITLE
[CN-Exec] More general allocation

### DIFF
--- a/backend/cn/lib/cn_internal_to_ail.ml
+++ b/backend/cn/lib/cn_internal_to_ail.ml
@@ -782,7 +782,7 @@ let generate_get_or_put_ownership_function ~without_ownership_checking ctype
   (decl, def)
 
 
-let alloc_sym = Sym.fresh_pretty "cn_alloc"
+let alloc_sym = Sym.fresh_pretty "cn_bump_malloc"
 
 let mk_alloc_expr (ct_ : C.ctype_) : CF.GenTypes.genTypeCategory A.expression =
   A.(
@@ -1898,9 +1898,9 @@ let generate_datatype_default_function (cn_datatype : cn_datatype) =
       ->
 
       struct tree * default_struct_tree(void) {
-        struct tree *res = cn_alloc(sizeof(struct tree));
+        struct tree *res = cn_bump_malloc(sizeof(struct tree));
         res->tag = TREE_EMPTY;
-        res->u.tree_empty = cn_alloc(sizeof(struct tree_empty));
+        res->u.tree_empty = cn_bump_malloc(sizeof(struct tree_empty));
         res->u.tree_empty->k = default_cn_bits_i32();
         return res;
       }

--- a/runtime/libcn/include/cn-executable/alloc.h
+++ b/runtime/libcn/include/cn-executable/alloc.h
@@ -8,19 +8,43 @@
 extern "C" {
 #endif
 
+    ////////////////////
+    // Bump Allocator //
+    ////////////////////
 
+    void* cn_bump_aligned_alloc(size_t alignment, size_t nbytes);
 
-void* cn_alloc(size_t nbytes);
+    void* cn_bump_malloc(size_t nbytes);
 
-void* cn_zalloc(size_t nbytes);
+    void* cn_bump_calloc(size_t count, size_t size);
 
-void cn_free_all();
+    void cn_bump_free_all();
 
-typedef uintptr_t cn_alloc_checkpoint;
+    typedef uintptr_t cn_bump_frame_id;
 
-cn_alloc_checkpoint cn_alloc_save_checkpoint(void);
+    cn_bump_frame_id cn_bump_get_frame_id(void);
 
-void cn_free_after(cn_alloc_checkpoint ptr);
+    void cn_bump_free_after(cn_bump_frame_id frame_id);
+
+    void cn_bump_print();
+
+    //////////////////////////////////
+    // Implicit Free List Allocator //
+    //////////////////////////////////
+
+    void* cn_fl_aligned_alloc(size_t alignment, size_t size);
+
+    void* cn_fl_malloc(size_t size);
+
+    void* cn_fl_calloc(size_t count, size_t size);
+
+    void* cn_fl_realloc(void* p, size_t size);
+
+    void cn_fl_free(void* p);
+
+    void cn_fl_free_all();
+
+    void cn_fl_print();
 
 #ifdef __cplusplus
 }

--- a/runtime/libcn/include/cn-executable/alloc.h
+++ b/runtime/libcn/include/cn-executable/alloc.h
@@ -29,7 +29,7 @@ extern "C" {
     void cn_bump_print();
 
     //////////////////////////////////
-    // Implicit Free List Allocator //
+    // Explicit Free List Allocator //
     //////////////////////////////////
 
     void* cn_fl_aligned_alloc(size_t alignment, size_t size);

--- a/runtime/libcn/include/cn-executable/alloc.h
+++ b/runtime/libcn/include/cn-executable/alloc.h
@@ -20,7 +20,10 @@ extern "C" {
 
     void cn_bump_free_all();
 
-    typedef uintptr_t cn_bump_frame_id;
+    typedef struct {
+        uint16_t block;
+        char* pointer;
+    } cn_bump_frame_id;
 
     cn_bump_frame_id cn_bump_get_frame_id(void);
 

--- a/runtime/libcn/include/cn-executable/hash_table.h
+++ b/runtime/libcn/include/cn-executable/hash_table.h
@@ -51,7 +51,7 @@ typedef struct hash_table hash_table;
 
 hash_table *ht_create(void);
 
-// void destroy_hash_table(hash_table *table);
+void ht_destroy(hash_table* table);
 
 void *ht_get(hash_table *table, signed long *key);
 

--- a/runtime/libcn/include/cn-executable/utils.h
+++ b/runtime/libcn/include/cn-executable/utils.h
@@ -17,6 +17,8 @@
 extern "C" {
 #endif
 
+void reset_fulminate(void);
+
 enum cn_logging_level {
     CN_LOGGING_NONE = 0,
     CN_LOGGING_ERROR = 1,

--- a/runtime/libcn/include/cn-executable/utils.h
+++ b/runtime/libcn/include/cn-executable/utils.h
@@ -8,6 +8,7 @@
 // #include <assert.h>
 // #include "stdint.h"
 #include <stdint.h>
+#include <stdalign.h>
 
 #include <cn-executable/alloc.h>
 #include <cn-executable/hash_table.h>
@@ -208,7 +209,7 @@ cn_bool *cn_pointer_gt(cn_pointer *i1, cn_pointer *i2);
 
 #define CN_GEN_CONVERT(CTYPE, CNTYPE)\
     static inline CNTYPE *convert_to_##CNTYPE(CTYPE i) {\
-        CNTYPE *ret = (CNTYPE *) cn_bump_malloc(sizeof(CNTYPE));\
+        CNTYPE *ret = (CNTYPE *) cn_bump_aligned_alloc(alignof(CNTYPE), sizeof(CNTYPE));\
         ret->val = i;\
         return ret;\
     }
@@ -248,42 +249,42 @@ cn_bool *cn_pointer_gt(cn_pointer *i1, cn_pointer *i2);
 
 #define CN_GEN_ADD(CTYPE, CNTYPE)\
     static inline CNTYPE *CNTYPE##_add(CNTYPE *i1, CNTYPE *i2) {\
-        CNTYPE *res = (CNTYPE *) cn_bump_malloc(sizeof(CNTYPE));\
+        CNTYPE *res = (CNTYPE *) cn_bump_aligned_alloc(alignof(CNTYPE), sizeof(CNTYPE));\
         res->val = i1->val + i2->val;\
         return res;\
     }
 
 #define CN_GEN_SUB(CTYPE, CNTYPE)\
     static inline CNTYPE *CNTYPE##_sub(CNTYPE *i1, CNTYPE *i2) {\
-        CNTYPE *res = (CNTYPE *) cn_bump_malloc(sizeof(CNTYPE));\
+        CNTYPE *res = (CNTYPE *) cn_bump_aligned_alloc(alignof(CNTYPE), sizeof(CNTYPE));\
         res->val = i1->val - i2->val;\
         return res;\
     }
 
 #define CN_GEN_MUL(CTYPE, CNTYPE)\
     static inline CNTYPE *CNTYPE##_multiply(CNTYPE *i1, CNTYPE *i2) {\
-        CNTYPE *res = (CNTYPE *) cn_bump_malloc(sizeof(CNTYPE));\
+        CNTYPE *res = (CNTYPE *) cn_bump_aligned_alloc(alignof(CNTYPE), sizeof(CNTYPE));\
         res->val = i1->val * i2->val;\
         return res;\
     }
 
 #define CN_GEN_DIV(CTYPE, CNTYPE)\
     static inline CNTYPE *CNTYPE##_divide(CNTYPE *i1, CNTYPE *i2) {\
-        CNTYPE *res = (CNTYPE *) cn_bump_malloc(sizeof(CNTYPE));\
+        CNTYPE *res = (CNTYPE *) cn_bump_aligned_alloc(alignof(CNTYPE), sizeof(CNTYPE));\
         res->val = i1->val / i2->val;\
         return res;\
     }
 
 #define CN_GEN_SHIFT_LEFT(CTYPE, CNTYPE)\
     static inline CNTYPE *CNTYPE##_shift_left(CNTYPE *i1, CNTYPE *i2) {\
-        CNTYPE *res = (CNTYPE *) cn_bump_malloc(sizeof(CNTYPE));\
+        CNTYPE *res = (CNTYPE *) cn_bump_aligned_alloc(alignof(CNTYPE), sizeof(CNTYPE));\
         res->val = i1->val << i2->val;\
         return res;\
     }
 
 #define CN_GEN_SHIFT_RIGHT(CTYPE, CNTYPE)\
     static inline CNTYPE *CNTYPE##_shift_right(CNTYPE *i1, CNTYPE *i2) {\
-        CNTYPE *res = (CNTYPE *) cn_bump_malloc(sizeof(CNTYPE));\
+        CNTYPE *res = (CNTYPE *) cn_bump_aligned_alloc(alignof(CNTYPE), sizeof(CNTYPE));\
         res->val = i1->val >> i2->val;\
         return res;\
     }
@@ -301,7 +302,7 @@ cn_bool *cn_pointer_gt(cn_pointer *i1, cn_pointer *i2);
 /* TODO: Account for UB: https://stackoverflow.com/a/20638659 */
 #define CN_GEN_MOD(CTYPE, CNTYPE)\
     static inline CNTYPE *CNTYPE##_mod(CNTYPE *i1, CNTYPE *i2) {\
-        CNTYPE *res = (CNTYPE *) cn_bump_malloc(sizeof(CNTYPE));\
+        CNTYPE *res = (CNTYPE *) cn_bump_aligned_alloc(alignof(CNTYPE), sizeof(CNTYPE));\
         res->val = i1->val % i2->val;\
         if (res->val < 0) {\
             res->val = (i2->val < 0) ? res->val - i2->val : res->val + i2->val;\
@@ -312,28 +313,28 @@ cn_bool *cn_pointer_gt(cn_pointer *i1, cn_pointer *i2);
 
 #define CN_GEN_REM(CTYPE, CNTYPE)\
     static inline CNTYPE *CNTYPE##_rem(CNTYPE *i1, CNTYPE *i2) {\
-        CNTYPE *res = (CNTYPE *) cn_bump_malloc(sizeof(CNTYPE));\
+        CNTYPE *res = (CNTYPE *) cn_bump_aligned_alloc(alignof(CNTYPE), sizeof(CNTYPE));\
         res->val = i1->val % i2->val;\
         return res;\
     }
 
 #define CN_GEN_XOR(CTYPE, CNTYPE)\
     static inline CNTYPE *CNTYPE##_xor(CNTYPE *i1, CNTYPE *i2) {\
-        CNTYPE *res = (CNTYPE *) cn_bump_malloc(sizeof(CNTYPE));\
+        CNTYPE *res = (CNTYPE *) cn_bump_aligned_alloc(alignof(CNTYPE), sizeof(CNTYPE));\
         res->val = i1->val ^ i2->val;\
         return res;\
     }
 
 #define CN_GEN_BWAND(CTYPE, CNTYPE)\
     static inline CNTYPE *CNTYPE##_bwand(CNTYPE *i1, CNTYPE *i2) {\
-        CNTYPE *res = (CNTYPE *) cn_bump_malloc(sizeof(CNTYPE));\
+        CNTYPE *res = (CNTYPE *) cn_bump_aligned_alloc(alignof(CNTYPE), sizeof(CNTYPE));\
         res->val = i1->val & i2->val;\
         return res;\
     }
 
 #define CN_GEN_BWOR(CTYPE, CNTYPE)\
     static inline CNTYPE *CNTYPE##_bwor(CNTYPE *i1, CNTYPE *i2) {\
-        CNTYPE *res = (CNTYPE *) cn_bump_malloc(sizeof(CNTYPE));\
+        CNTYPE *res = (CNTYPE *) cn_bump_aligned_alloc(alignof(CNTYPE), sizeof(CNTYPE));\
         res->val = i1->val | i2->val;\
         return res;\
     }
@@ -359,7 +360,7 @@ static inline int ipow(int base, int exp)
 
 #define CN_GEN_POW(CTYPE, CNTYPE)\
     static inline CNTYPE *CNTYPE##_pow(CNTYPE *i1, CNTYPE *i2) {\
-        CNTYPE *res = (CNTYPE *) cn_bump_malloc(sizeof(CNTYPE));\
+        CNTYPE *res = (CNTYPE *) cn_bump_aligned_alloc(alignof(CNTYPE), sizeof(CNTYPE));\
         res->val = ipow(i1->val, i2->val);\
         return res;\
     }
@@ -407,7 +408,7 @@ static inline int ipow(int base, int exp)
 
 #define CN_GEN_CAST_INT_TYPES(CNTYPE1, CTYPE2, CNTYPE2)\
     static inline CNTYPE2 *cast_##CNTYPE1##_to_##CNTYPE2(CNTYPE1 *i) {\
-        CNTYPE2 *res = (CNTYPE2 *) cn_bump_malloc(sizeof(CNTYPE2));\
+        CNTYPE2 *res = (CNTYPE2 *) cn_bump_aligned_alloc(alignof(CNTYPE2), sizeof(CNTYPE2));\
         res->val = (CTYPE2) i->val;\
         return res;\
     }

--- a/runtime/libcn/include/cn-executable/utils.h
+++ b/runtime/libcn/include/cn-executable/utils.h
@@ -48,6 +48,7 @@ void initialise_error_msg_info_(const char *function_name, char *file_name, int 
 #define initialise_error_msg_info() initialise_error_msg_info_(__func__, __FILE__, __LINE__)
 
 void reset_error_msg_info();
+void free_error_msg_info();
 
 /* TODO: Implement */
 /*struct cn_error_messages {
@@ -124,6 +125,7 @@ typedef struct cn_alloc_id {
 typedef hash_table cn_map;
 
 void initialise_ownership_ghost_state(void);
+void free_ownership_ghost_state(void);
 void initialise_ghost_stack_depth(void);
 signed long get_cn_stack_depth(void);
 void ghost_stack_depth_incr(void);

--- a/runtime/libcn/include/cn-executable/utils.h
+++ b/runtime/libcn/include/cn-executable/utils.h
@@ -208,7 +208,7 @@ cn_bool *cn_pointer_gt(cn_pointer *i1, cn_pointer *i2);
 
 #define CN_GEN_CONVERT(CTYPE, CNTYPE)\
     static inline CNTYPE *convert_to_##CNTYPE(CTYPE i) {\
-        CNTYPE *ret = (CNTYPE *) cn_alloc(sizeof(CNTYPE));\
+        CNTYPE *ret = (CNTYPE *) cn_bump_malloc(sizeof(CNTYPE));\
         ret->val = i;\
         return ret;\
     }
@@ -248,42 +248,42 @@ cn_bool *cn_pointer_gt(cn_pointer *i1, cn_pointer *i2);
 
 #define CN_GEN_ADD(CTYPE, CNTYPE)\
     static inline CNTYPE *CNTYPE##_add(CNTYPE *i1, CNTYPE *i2) {\
-        CNTYPE *res = (CNTYPE *) cn_alloc(sizeof(CNTYPE));\
+        CNTYPE *res = (CNTYPE *) cn_bump_malloc(sizeof(CNTYPE));\
         res->val = i1->val + i2->val;\
         return res;\
     }
 
 #define CN_GEN_SUB(CTYPE, CNTYPE)\
     static inline CNTYPE *CNTYPE##_sub(CNTYPE *i1, CNTYPE *i2) {\
-        CNTYPE *res = (CNTYPE *) cn_alloc(sizeof(CNTYPE));\
+        CNTYPE *res = (CNTYPE *) cn_bump_malloc(sizeof(CNTYPE));\
         res->val = i1->val - i2->val;\
         return res;\
     }
 
 #define CN_GEN_MUL(CTYPE, CNTYPE)\
     static inline CNTYPE *CNTYPE##_multiply(CNTYPE *i1, CNTYPE *i2) {\
-        CNTYPE *res = (CNTYPE *) cn_alloc(sizeof(CNTYPE));\
+        CNTYPE *res = (CNTYPE *) cn_bump_malloc(sizeof(CNTYPE));\
         res->val = i1->val * i2->val;\
         return res;\
     }
 
 #define CN_GEN_DIV(CTYPE, CNTYPE)\
     static inline CNTYPE *CNTYPE##_divide(CNTYPE *i1, CNTYPE *i2) {\
-        CNTYPE *res = (CNTYPE *) cn_alloc(sizeof(CNTYPE));\
+        CNTYPE *res = (CNTYPE *) cn_bump_malloc(sizeof(CNTYPE));\
         res->val = i1->val / i2->val;\
         return res;\
     }
 
 #define CN_GEN_SHIFT_LEFT(CTYPE, CNTYPE)\
     static inline CNTYPE *CNTYPE##_shift_left(CNTYPE *i1, CNTYPE *i2) {\
-        CNTYPE *res = (CNTYPE *) cn_alloc(sizeof(CNTYPE));\
+        CNTYPE *res = (CNTYPE *) cn_bump_malloc(sizeof(CNTYPE));\
         res->val = i1->val << i2->val;\
         return res;\
     }
 
 #define CN_GEN_SHIFT_RIGHT(CTYPE, CNTYPE)\
     static inline CNTYPE *CNTYPE##_shift_right(CNTYPE *i1, CNTYPE *i2) {\
-        CNTYPE *res = (CNTYPE *) cn_alloc(sizeof(CNTYPE));\
+        CNTYPE *res = (CNTYPE *) cn_bump_malloc(sizeof(CNTYPE));\
         res->val = i1->val >> i2->val;\
         return res;\
     }
@@ -301,7 +301,7 @@ cn_bool *cn_pointer_gt(cn_pointer *i1, cn_pointer *i2);
 /* TODO: Account for UB: https://stackoverflow.com/a/20638659 */
 #define CN_GEN_MOD(CTYPE, CNTYPE)\
     static inline CNTYPE *CNTYPE##_mod(CNTYPE *i1, CNTYPE *i2) {\
-        CNTYPE *res = (CNTYPE *) cn_alloc(sizeof(CNTYPE));\
+        CNTYPE *res = (CNTYPE *) cn_bump_malloc(sizeof(CNTYPE));\
         res->val = i1->val % i2->val;\
         if (res->val < 0) {\
             res->val = (i2->val < 0) ? res->val - i2->val : res->val + i2->val;\
@@ -312,28 +312,28 @@ cn_bool *cn_pointer_gt(cn_pointer *i1, cn_pointer *i2);
 
 #define CN_GEN_REM(CTYPE, CNTYPE)\
     static inline CNTYPE *CNTYPE##_rem(CNTYPE *i1, CNTYPE *i2) {\
-        CNTYPE *res = (CNTYPE *) cn_alloc(sizeof(CNTYPE));\
+        CNTYPE *res = (CNTYPE *) cn_bump_malloc(sizeof(CNTYPE));\
         res->val = i1->val % i2->val;\
         return res;\
     }
 
 #define CN_GEN_XOR(CTYPE, CNTYPE)\
     static inline CNTYPE *CNTYPE##_xor(CNTYPE *i1, CNTYPE *i2) {\
-        CNTYPE *res = (CNTYPE *) cn_alloc(sizeof(CNTYPE));\
+        CNTYPE *res = (CNTYPE *) cn_bump_malloc(sizeof(CNTYPE));\
         res->val = i1->val ^ i2->val;\
         return res;\
     }
 
 #define CN_GEN_BWAND(CTYPE, CNTYPE)\
     static inline CNTYPE *CNTYPE##_bwand(CNTYPE *i1, CNTYPE *i2) {\
-        CNTYPE *res = (CNTYPE *) cn_alloc(sizeof(CNTYPE));\
+        CNTYPE *res = (CNTYPE *) cn_bump_malloc(sizeof(CNTYPE));\
         res->val = i1->val & i2->val;\
         return res;\
     }
 
 #define CN_GEN_BWOR(CTYPE, CNTYPE)\
     static inline CNTYPE *CNTYPE##_bwor(CNTYPE *i1, CNTYPE *i2) {\
-        CNTYPE *res = (CNTYPE *) cn_alloc(sizeof(CNTYPE));\
+        CNTYPE *res = (CNTYPE *) cn_bump_malloc(sizeof(CNTYPE));\
         res->val = i1->val | i2->val;\
         return res;\
     }
@@ -359,7 +359,7 @@ static inline int ipow(int base, int exp)
 
 #define CN_GEN_POW(CTYPE, CNTYPE)\
     static inline CNTYPE *CNTYPE##_pow(CNTYPE *i1, CNTYPE *i2) {\
-        CNTYPE *res = (CNTYPE *) cn_alloc(sizeof(CNTYPE));\
+        CNTYPE *res = (CNTYPE *) cn_bump_malloc(sizeof(CNTYPE));\
         res->val = ipow(i1->val, i2->val);\
         return res;\
     }
@@ -382,7 +382,7 @@ static inline int ipow(int base, int exp)
 
 #define CN_GEN_PTR_ADD(CNTYPE)\
     static inline cn_pointer *cn_pointer_add_##CNTYPE(cn_pointer *ptr, CNTYPE *i) {\
-        cn_pointer *res = (cn_pointer *) cn_alloc(sizeof(cn_pointer));\
+        cn_pointer *res = (cn_pointer *) cn_bump_malloc(sizeof(cn_pointer));\
         res->ptr = (char *) ptr->ptr + i->val;\
         return res;\
     }
@@ -392,14 +392,14 @@ static inline int ipow(int base, int exp)
 
 #define CN_GEN_CAST_TO_PTR(CNTYPE, INTPTR_TYPE)\
     static inline cn_pointer *cast_##CNTYPE##_to_cn_pointer(CNTYPE *i) {\
-        cn_pointer *res = (cn_pointer *) cn_alloc(sizeof(cn_pointer));\
+        cn_pointer *res = (cn_pointer *) cn_bump_malloc(sizeof(cn_pointer));\
         res->ptr = (void *) (INTPTR_TYPE) i->val;\
         return res;\
     }
 
 #define CN_GEN_CAST_FROM_PTR(CTYPE, CNTYPE, INTPTR_TYPE)\
     static inline CNTYPE *cast_cn_pointer_to_##CNTYPE(cn_pointer *ptr) {\
-        CNTYPE *res = (CNTYPE *) cn_alloc(sizeof(CNTYPE));\
+        CNTYPE *res = (CNTYPE *) cn_bump_malloc(sizeof(CNTYPE));\
         res->val = (CTYPE) (INTPTR_TYPE) (ptr->ptr);\
         return res;\
     }
@@ -407,7 +407,7 @@ static inline int ipow(int base, int exp)
 
 #define CN_GEN_CAST_INT_TYPES(CNTYPE1, CTYPE2, CNTYPE2)\
     static inline CNTYPE2 *cast_##CNTYPE1##_to_##CNTYPE2(CNTYPE1 *i) {\
-        CNTYPE2 *res = (CNTYPE2 *) cn_alloc(sizeof(CNTYPE2));\
+        CNTYPE2 *res = (CNTYPE2 *) cn_bump_malloc(sizeof(CNTYPE2));\
         res->val = (CTYPE2) i->val;\
         return res;\
     }
@@ -422,7 +422,7 @@ cn_bool *default_cn_bool(void);
 
 #define CN_GEN_MAP_GET(CNTYPE)\
     static inline void *cn_map_get_##CNTYPE(cn_map *m, cn_integer *key) {   \
-        signed long *key_ptr = cn_alloc(sizeof(signed long));               \
+        signed long *key_ptr = cn_bump_malloc(sizeof(signed long));         \
         *key_ptr = key->val;                                                \
         void *res = ht_get(m, key_ptr);                                     \
         if (!res) { return (void *) default_##CNTYPE(); }                   \

--- a/runtime/libcn/include/cn-testing/dsl.h
+++ b/runtime/libcn/include/cn-testing/dsl.h
@@ -10,16 +10,16 @@
 #define CN_GEN_INIT() CN_GEN_INIT_SIZED(cn_gen_get_max_size())
 
 #define CN_GEN_INIT_SIZED(size)                                                         \
+    if (0) {                                                                            \
+    cn_label_bennet_backtrack:                                                          \
+        cn_gen_decrement_depth();                                                       \
+        return NULL;                                                                    \
+    }                                                                                   \
     if (cn_gen_get_input_timeout() != 0                                                 \
         && cn_gen_get_milliseconds() - cn_gen_get_input_timer()                         \
             > cn_gen_get_input_timeout()) {                                             \
         cn_gen_backtrack_assert_failure();                                              \
         goto cn_label_bennet_backtrack;                                                 \
-    }                                                                                   \
-    if (0) {                                                                            \
-    cn_label_bennet_backtrack:                                                          \
-        cn_gen_decrement_depth();                                                       \
-        return NULL;                                                                    \
     }                                                                                   \
     cn_gen_increment_depth();                                                           \
     if (size <= 0 || cn_gen_depth() == cn_gen_max_depth()) {                            \

--- a/runtime/libcn/include/cn-testing/dsl.h
+++ b/runtime/libcn/include/cn-testing/dsl.h
@@ -113,7 +113,7 @@
 
 #define CN_GEN_LET_BEGIN(backtracks, var)                                               \
     int var##_backtracks = backtracks;                                                  \
-    cn_alloc_checkpoint var##_checkpoint = cn_alloc_save_checkpoint();                  \
+    cn_bump_frame_id var##_checkpoint = cn_bump_get_frame_id();                         \
     void *var##_alloc_checkpoint = cn_gen_alloc_save();                                 \
     void *var##_ownership_checkpoint = cn_gen_ownership_save();                         \
     cn_label_##var##_gen:                                                               \
@@ -126,7 +126,7 @@
 #define CN_GEN_LET_END(backtracks, var, last_var, ...)                                  \
         if (cn_gen_backtrack_type() != CN_GEN_BACKTRACK_NONE) {                         \
         cn_label_##var##_backtrack:                                                     \
-            cn_free_after(var##_checkpoint);                                            \
+            cn_bump_free_after(var##_checkpoint);                                       \
             cn_gen_alloc_restore(var##_alloc_checkpoint);                               \
             cn_gen_ownership_restore(var##_ownership_checkpoint);                       \
             if (cn_gen_backtrack_relevant_contains((char*)#var)) {                      \
@@ -199,7 +199,7 @@
     }                                                                                   \
     tmp##_num_choices /= 2;                                                             \
     struct cn_gen_int_urn* tmp##_urn = urn_from_array(tmp##_choices, tmp##_num_choices);\
-    cn_alloc_checkpoint tmp##_checkpoint = cn_alloc_save_checkpoint();                  \
+    cn_bump_frame_id tmp##_checkpoint = cn_bump_get_frame_id();                         \
     void *tmp##_alloc_checkpoint = cn_gen_alloc_save();                                 \
     void *tmp##_ownership_checkpoint = cn_gen_ownership_save();                         \
     cn_label_##tmp##_gen:                                                               \
@@ -207,7 +207,7 @@
     uint64_t tmp = urn_remove(tmp##_urn);                                               \
     if (0) {                                                                            \
     cn_label_##tmp##_backtrack:                                                         \
-        cn_free_after(tmp##_checkpoint);                                                \
+        cn_bump_free_after(tmp##_checkpoint);                                           \
         cn_gen_alloc_restore(tmp##_alloc_checkpoint);                                   \
         cn_gen_ownership_restore(tmp##_ownership_checkpoint);                           \
         if ((cn_gen_backtrack_type() == CN_GEN_BACKTRACK_ASSERT                         \
@@ -237,7 +237,7 @@
 
 #define CN_GEN_SPLIT_BEGIN(tmp, size, ...)                                              \
     int tmp##_backtracks = cn_gen_get_size_split_backtracks_allowed();                  \
-    cn_alloc_checkpoint tmp##_checkpoint = cn_alloc_save_checkpoint();                  \
+    cn_bump_frame_id tmp##_checkpoint = cn_bump_get_frame_id();                         \
     void *tmp##_alloc_checkpoint = cn_gen_alloc_save();                                 \
     void *tmp##_ownership_checkpoint = cn_gen_ownership_save();                         \
     cn_label_##tmp##_gen:                                                               \
@@ -262,7 +262,7 @@
     }                                                                                   \
     if (0) {                                                                            \
     cn_label_##tmp##_backtrack:                                                         \
-        cn_free_after(tmp##_checkpoint);                                                \
+        cn_bump_free_after(tmp##_checkpoint);                                           \
         cn_gen_alloc_restore(tmp##_alloc_checkpoint);                                   \
         cn_gen_ownership_restore(tmp##_ownership_checkpoint);                           \
         if (cn_gen_backtrack_relevant_contains(#tmp)) {                                 \

--- a/runtime/libcn/include/cn-testing/test.h
+++ b/runtime/libcn/include/cn-testing/test.h
@@ -134,7 +134,8 @@ void cn_trap(void);
 int cn_test_main(int argc, char* argv[]);
 
 #define CN_TEST_INIT()                                                                  \
-    cn_free_all();                                                                      \
+    cn_bump_free_all();                                                                 \
+    cn_fl_free_all();                                                                   \
     reset_error_msg_info();                                                             \
     initialise_ownership_ghost_state();                                                 \
     initialise_ghost_stack_depth();                                                     \

--- a/runtime/libcn/include/cn-testing/test.h
+++ b/runtime/libcn/include/cn-testing/test.h
@@ -86,9 +86,9 @@ void cn_trap(void);
                 }                                                                       \
                 return CN_TEST_GEN_FAIL;                                                \
             }                                                                           \
+            CN_TEST_INIT();                                                             \
             size_t sz = cn_gen_uniform_cn_bits_u16(cn_gen_get_max_size())->val + 1;     \
             cn_gen_set_size(sz);                                                        \
-            CN_TEST_INIT();                                                             \
             cn_gen_set_input_timer(cn_gen_get_milliseconds());                          \
             struct cn_gen_##Name##_record *res = cn_gen_##Name();                       \
             if (cn_gen_backtrack_type() != CN_GEN_BACKTRACK_NONE) {                     \

--- a/runtime/libcn/include/cn-testing/test.h
+++ b/runtime/libcn/include/cn-testing/test.h
@@ -134,11 +134,7 @@ void cn_trap(void);
 int cn_test_main(int argc, char* argv[]);
 
 #define CN_TEST_INIT()                                                                  \
-    cn_bump_free_all();                                                                 \
-    cn_fl_free_all();                                                                   \
-    reset_error_msg_info();                                                             \
-    initialise_ownership_ghost_state();                                                 \
-    initialise_ghost_stack_depth();                                                     \
+    reset_fulminate();                                                                  \
     cn_gen_backtrack_reset();                                                           \
     cn_gen_alloc_reset();                                                               \
     cn_gen_ownership_reset();

--- a/runtime/libcn/src/cn-executable/alloc.c
+++ b/runtime/libcn/src/cn-executable/alloc.c
@@ -1,61 +1,425 @@
-#include <stdio.h>
 #include <stdlib.h>
 #include <stdalign.h>
 #include <string.h>
+
+#ifdef CN_DEBUG_PRINTING
+#   include <stdio.h>
+#endif
 
 #include <cn-executable/alloc.h>
 #include <cn-executable/utils.h>
 
 
+////////////////////
+// Bump Allocator //
+////////////////////
 
-#define MEM_SIZE (1024 * 1024 * 1024)
-char buf[MEM_SIZE];
-static char* curr = buf;
+#define BUMP_MEM_SIZE (1024 * 1024 * 512)
+char bump_mem[BUMP_MEM_SIZE];
+static char* bump_curr = bump_mem;
 
-// 268,435,449
 
-void* _cn_aligned_alloc(size_t alignment, size_t nbytes) {
-    size_t max = (uintptr_t)buf + MEM_SIZE;
+#ifdef CN_DEBUG_PRINTING
+void cn_bump_fprint(FILE* file) {
+    fprintf(file, "Start: %p, Next: %p\n", bump_mem, bump_curr);
+}
 
-    if ((uintptr_t)curr % alignment != 0) {
-        size_t padding = (alignment - (uintptr_t)curr % alignment) % alignment;
-        if ((uintptr_t)curr + padding >= max) {
+void cn_bump_print() {
+    cn_bump_fprint(stdout);
+}
+#else
+void cn_bump_fprint(FILE* file) {}
+
+void cn_bump_print() {}
+#endif
+
+void* cn_bump_aligned_alloc(size_t alignment, size_t nbytes) {
+    if (nbytes == 0) {
+        return NULL;
+    }
+
+    uintptr_t max = (uintptr_t)bump_mem + BUMP_MEM_SIZE;
+
+    if ((uintptr_t)bump_curr % alignment != 0) {
+        size_t padding = (alignment - (uintptr_t)bump_curr % alignment) % alignment;
+        if ((uintptr_t)bump_curr + padding >= max) {
             cn_failure(CN_FAILURE_ALLOC);
             return NULL;
         }
-        curr += padding;
+        bump_curr += padding;
     }
 
-    void* res = curr;
-    if ((uintptr_t)curr + nbytes > max) {
+    void* res = bump_curr;
+    if ((uintptr_t)bump_curr + nbytes >= max) {
         cn_failure(CN_FAILURE_ALLOC);
         return NULL;
     }
-    curr += nbytes;
+    bump_curr += nbytes;
 
     return res;
 }
 
-void* cn_alloc(size_t nbytes) {
-    return _cn_aligned_alloc(alignof(max_align_t), nbytes);
+void* cn_bump_malloc(size_t nbytes) {
+    return cn_bump_aligned_alloc(alignof(max_align_t), nbytes);
 }
 
-void* cn_zalloc(size_t nbytes) {
-    void* p = cn_alloc(nbytes);
+void* cn_bump_calloc(size_t count, size_t size) {
+    size_t nbytes = count * size;
+
+    void* p = cn_bump_malloc(nbytes);
     if (p != NULL) {
         memset(p, 0, nbytes);
     }
     return p;
 }
 
-void cn_free_all(void) {
-    curr = buf;
+void cn_bump_free_all(void) {
+    bump_curr = bump_mem;
 }
 
-cn_alloc_checkpoint cn_alloc_save_checkpoint(void) {
-    return (uintptr_t)curr;
+cn_bump_frame_id cn_bump_get_frame_id(void) {
+    return (uintptr_t)bump_curr;
 }
 
-void cn_free_after(cn_alloc_checkpoint ptr) {
-    curr = (char*)ptr;
+void cn_bump_free_after(cn_bump_frame_id frame_id) {
+    bump_curr = (char*)frame_id;
+}
+
+
+//////////////////////////////////
+// Implicit Free List Allocator //
+//////////////////////////////////
+
+typedef struct free_list_node {
+    uint32_t size;
+} free_list_node;
+
+// Has to fit in `uint32_t`
+#define FL_MEM_SIZE (1024 * 1024 * 512)
+char free_list_mem[FL_MEM_SIZE];
+static free_list_node* free_list;
+static free_list_node* first_free;
+
+static inline int fl_is_used(free_list_node* fl) {
+    return fl->size & 1;
+}
+
+static inline uint32_t fl_size(free_list_node* fl) {
+    return fl->size & ~((uint32_t)1);
+}
+
+static inline free_list_node* fl_tag(void* p) {
+    return (free_list_node*)((uintptr_t)p - sizeof(free_list_node));
+}
+
+static inline free_list_node* fl_boundary_tag(free_list_node* fl) {
+    return (free_list_node*)((uintptr_t)fl + sizeof(free_list_node) + fl_size(fl));
+}
+
+static inline void fl_set_size(free_list_node* fl, size_t size) {
+    char used = fl_is_used(fl);
+    fl->size = size | used;
+    fl_boundary_tag(fl)->size = fl->size;
+}
+
+static inline void fl_set_taken(free_list_node* fl) {
+    fl->size |= 1;
+    fl_boundary_tag(fl)->size |= 1;
+}
+
+static inline void fl_set_free(free_list_node* fl) {
+    fl->size &= ~((uint32_t)1);
+    fl_boundary_tag(fl)->size &= ~((uint32_t)1);
+}
+
+static inline free_list_node* fl_next_node(free_list_node* fl) {
+    uintptr_t possible_next = (uintptr_t)fl + fl_size(fl) + 2 * sizeof(free_list_node);
+    uintptr_t max = (uintptr_t)free_list_mem + FL_MEM_SIZE - 2 * sizeof(free_list_node);
+    if (possible_next >= max) {
+        return NULL;
+    }
+
+    return (free_list_node*)possible_next;
+}
+
+static inline free_list_node* fl_prev_node(free_list_node* fl) {
+    free_list_node* possible_boundary_tag = (free_list_node*)((uintptr_t)fl - sizeof(free_list_node));
+    uintptr_t possible_prev = (uintptr_t)possible_boundary_tag - fl_size(possible_boundary_tag) - sizeof(free_list_node);
+    uintptr_t min = (uintptr_t)free_list;
+    if (possible_prev < min) {
+        return NULL;
+    }
+
+    return (free_list_node*)possible_prev;
+}
+
+#ifdef CN_DEBUG_PRINTING
+void cn_fl_fprint(FILE* file) {
+    free_list_node* curr = free_list;
+
+    while (curr) {
+        if (fl_is_used(curr)) {
+            fprintf(file, "Block %d (x) | %d, ", fl_size(curr), fl_boundary_tag(curr)->size);
+        }
+        else {
+            fprintf(file, "Block %d ( ) | %d, ", fl_size(curr), fl_boundary_tag(curr)->size);
+        }
+
+        curr = fl_next_node(curr);
+    }
+    printf("\n");
+}
+
+void cn_fl_print() {
+    cn_fl_fprint(stdout);
+}
+#else
+void cn_fl_fprint(FILE* file) {}
+
+void cn_fl_print() {}
+#endif
+
+void cn_fl_free_all() {
+    size_t padding =
+        (alignof(max_align_t) - ((uintptr_t)free_list_mem + sizeof(free_list_node))
+            % alignof(max_align_t))
+        % alignof(max_align_t);
+    if (!free_list) {
+        free_list = (free_list_node*)((uintptr_t)free_list_mem + padding);
+    }
+    first_free = free_list;
+    fl_set_free(free_list);
+    fl_set_size(free_list, FL_MEM_SIZE - padding - 2 * sizeof(free_list_node));
+}
+
+void cn_fl_init(void) {
+    if (!free_list) {
+        cn_fl_free_all();
+    }
+}
+
+static inline void fl_coalesce(free_list_node* fl) {
+    if (fl == NULL || fl_is_used(fl)) {
+        return;
+    }
+
+    free_list_node* prev = fl_prev_node(fl);
+    free_list_node* next = fl_next_node(fl);
+
+    int prev_used = prev == NULL || fl_is_used(prev);
+    int next_used = next == NULL || fl_is_used(next);
+
+    if (!prev_used && !next_used)
+    {
+        fl_set_size(prev, fl_size(prev) + fl_size(fl) + fl_size(next) + 4 * sizeof(free_list_node));
+    }
+    else if (prev_used && !next_used)
+    {
+        fl_set_size(fl, fl_size(fl) + fl_size(next) + 2 * sizeof(free_list_node));
+    }
+    else if (!prev_used && next_used)
+    {
+        fl_set_size(prev, fl_size(prev) + fl_size(fl) + 2 * sizeof(free_list_node));
+    }
+}
+
+static inline size_t gcd(size_t a, size_t b) {
+    while (b != 0) {
+        size_t temp = b;
+        b = a % b;
+        a = temp;
+    }
+    return a;
+}
+
+static inline size_t lcm(size_t a, size_t b) {
+    return (a * b) / gcd(a, b);
+}
+
+void* cn_fl_aligned_alloc(size_t alignment, size_t size) {
+    if (size == 0) {
+        return NULL;
+    }
+
+    cn_fl_init();
+
+    if (alignment % alignof(free_list_node) != 0) {
+        alignment = lcm(alignment, alignof(free_list_node));
+    }
+
+    free_list_node* curr = first_free;
+
+    while (curr && fl_is_used(curr)) {
+        curr = fl_next_node(curr);
+        first_free = curr;
+    }
+
+    while (curr) {
+        if (fl_is_used(curr)) {
+            curr = fl_next_node(curr);
+            continue;
+        }
+
+        free_list_node* prev = fl_prev_node(curr);
+
+        int was_first_free = curr == first_free;
+
+        // Calculate padding
+        uintptr_t curr_addr = (uintptr_t)curr;
+
+        size_t back_padding =
+            (alignof(free_list_node) - (size)
+                % alignof(free_list_node))
+            % alignof(free_list_node);
+
+        size_t padding = (alignment - (curr_addr + sizeof(free_list_node)) % alignment) % alignment;
+        if (padding != 0) {
+            free_list_node* next = fl_next_node(curr);
+            size_t memory_left = fl_size(curr) - (padding + size + back_padding);
+            size_t memory_left_aligned = (memory_left / alignment) * alignment;
+            if (next == NULL
+                || (fl_is_used(next)
+                    && !fl_is_used(prev)
+                    && memory_left - memory_left_aligned >= 2 * sizeof(free_list_node))) {
+                padding += memory_left_aligned;
+            }
+        }
+
+        uintptr_t aligned_addr = curr_addr + padding;
+
+        if (fl_size(curr) >= padding + size + back_padding) {
+            fl_set_taken(curr);
+
+            if (padding != 0) {
+                if ((prev == NULL || fl_is_used(prev)) && padding >= 2 * sizeof(free_list_node)) {
+                    size_t orig_size = fl_size(curr);
+
+                    // Split padding into new block
+                    /// Make new block
+                    fl_set_size(curr, padding - 2 * sizeof(free_list_node));
+                    fl_set_free(curr);
+                    prev = curr;
+
+                    /// Shift current block
+                    curr = (free_list_node*)aligned_addr;
+                    fl_set_size(curr, orig_size - padding);
+                    fl_set_taken(curr);
+
+                    // `curr` (now `prev`) is still free
+                    if (was_first_free) {
+                        was_first_free = 0;
+                    }
+                }
+                else
+                {
+                    if (prev != NULL) {
+                        // Coalesce padding with previous block
+                        fl_set_size(prev, fl_size(prev) + padding);
+                    }
+
+                    /// Shift current block
+                    curr = (free_list_node*)aligned_addr;
+                    fl_set_size(curr, size - padding);
+                    fl_set_taken(curr);
+                }
+            }
+
+            if (fl_size(curr) > size + back_padding) {
+                size_t memory_left = fl_size(curr) - (size + back_padding);
+                if (memory_left >= 2 * sizeof(free_list_node)) {
+                    fl_set_size(curr, size + back_padding);
+
+                    free_list_node* next = fl_next_node(curr);
+                    fl_set_size(next, memory_left - 2 * sizeof(free_list_node));
+                    fl_set_free(next);
+
+                    fl_coalesce(next);
+                }
+            }
+
+            if (was_first_free) {
+                first_free = fl_next_node(curr);
+            }
+
+            return (void*)(aligned_addr + sizeof(free_list_node));
+        }
+
+        curr = fl_next_node(curr);
+    }
+
+    cn_failure(CN_FAILURE_ALLOC); // Out of memory
+    return NULL;
+}
+
+void* cn_fl_malloc(size_t size) {
+    return cn_fl_aligned_alloc(alignof(max_align_t), size);
+}
+
+void* cn_fl_calloc(size_t count, size_t size) {
+    size_t nbytes = count * size;
+
+    void* p = cn_fl_malloc(nbytes);
+    if (p != NULL) {
+        memset(p, 0, nbytes);
+    }
+    return p;
+}
+
+void* cn_fl_realloc(void* p, size_t nbytes) {
+    if (p == NULL) {
+        return cn_fl_malloc(nbytes);
+    }
+
+    free_list_node* fl = fl_tag(p);
+
+    if (fl_size(fl) >= nbytes) {
+        return p;
+    }
+
+    // Steal some memory from the next block
+    free_list_node* next = fl_next_node(fl);
+    if (next != NULL && !fl_is_used(next)) {
+        size_t back_padding =
+            (alignof(free_list_node) - nbytes
+                % alignof(free_list_node))
+            % alignof(free_list_node);
+
+        size_t memory_available = fl_size(fl) + fl_size(next) + 2 * sizeof(free_list_node);
+        if (memory_available > nbytes + back_padding) {
+            size_t memory_left = memory_available - (nbytes + back_padding);
+            if (memory_left >= 2 * sizeof(free_list_node)) {
+                fl_set_size(fl, nbytes + back_padding);
+
+                free_list_node* next = fl_next_node(fl);
+                fl_set_size(next, memory_left - 2 * sizeof(free_list_node));
+                fl_set_free(next);
+
+                return p;
+            }
+            else {
+                fl_set_size(fl, memory_available);
+                return p;
+            }
+        }
+    }
+
+    // Could steal memory from previous block?
+    // Fuse the free + malloc?
+
+    void* res = cn_fl_malloc(nbytes);
+    size_t copy_size = (nbytes < fl_size(fl)) ? nbytes : fl_size(fl);
+    memcpy(res, p, copy_size);
+    cn_fl_free(p);
+    return res;
+}
+
+void cn_fl_free(void* p) {
+    free_list_node* tag = fl_tag(p);
+    fl_set_free(tag);
+
+    if (!first_free || tag < first_free) {
+        first_free = tag;
+    }
+
+    fl_coalesce(tag);
 }

--- a/runtime/libcn/src/cn-executable/hash_table.c
+++ b/runtime/libcn/src/cn-executable/hash_table.c
@@ -35,7 +35,7 @@ SOFTWARE.
 
 hash_table* ht_create(void) {
     // Allocate space for hash table struct.
-    hash_table* table = cn_alloc(sizeof(hash_table));
+    hash_table* table = cn_fl_malloc(sizeof(hash_table));
     if (table == NULL) {
         return NULL;
     }
@@ -43,32 +43,31 @@ hash_table* ht_create(void) {
     table->capacity = INITIAL_CAPACITY;
 
     // Allocate (zero'd) space for entry buckets.
-    table->entries = cn_zalloc(table->capacity * sizeof(ht_entry));
+    table->entries = cn_fl_calloc(table->capacity, sizeof(ht_entry));
     if (table->entries == NULL) {
-        // free(table); // error, free table before we return!
+        cn_fl_free(table); // error, free table before we return!
         return NULL;
     }
     return table;
 }
 
-// No freeing yet
-// void ht_destroy(ht* table) {
-//     // First free allocated keys.
-//     for (size_t i = 0; i < table->capacity; i++) {
-//         free((void*)table->entries[i].key);
-//     }
+void ht_destroy(hash_table* table) {
+    // First free allocated keys.
+    for (size_t i = 0; i < table->capacity; i++) {
+        cn_fl_free((void*)table->entries[i].key);
+    }
 
-//     // Then free entries array and table itself.
-//     free(table->entries);
-//     free(table);
-// }
+    // Then free entries array and table itself.
+    cn_fl_free(table->entries);
+    cn_fl_free(table);
+}
 
 #define FNV_OFFSET 14695981039346656037U
 #define FNV_PRIME 1099511628211U
 
 // Return 64-bit FNV-1a hash for key (NUL-terminated). See description:
 // https://en.wikipedia.org/wiki/Fowler–Noll–Vo_hash_function
-static uint64_t hash_key(signed long *key) {
+static uint64_t hash_key(signed long* key) {
     uint64_t hash = FNV_OFFSET;
     hash ^= *key;
     hash *= FNV_PRIME;
@@ -76,7 +75,7 @@ static uint64_t hash_key(signed long *key) {
 }
 
 
-void* ht_get(hash_table* table, signed long *key) {
+void* ht_get(hash_table* table, signed long* key) {
     // AND hash with capacity-1 to ensure it's within entries array.
     unsigned long hash = hash_key(key);
     size_t index = (size_t)(hash & (unsigned long)(table->capacity - 1));
@@ -99,15 +98,15 @@ void* ht_get(hash_table* table, signed long *key) {
     return NULL;
 }
 
-signed long *duplicate_key(signed long *key) {
-    signed long *new_key = cn_alloc(sizeof(signed long));
+signed long* duplicate_key(signed long* key) {
+    signed long* new_key = cn_fl_malloc(sizeof(signed long));
     *new_key = *key;
     return new_key;
 }
 
 // Internal function to set an entry (without expanding table).
 static signed long* ht_set_entry(ht_entry* entries, size_t capacity,
-        signed long *key, void* value, int* plength) {
+    signed long* key, void* value, int* plength) {
     // AND hash with capacity-1 to ensure it's within entries array.
     unsigned long hash = hash_key(key);
     size_t index = (size_t)(hash & (unsigned long)(capacity - 1));
@@ -148,7 +147,7 @@ static _Bool ht_expand(hash_table* table) {
     if (new_capacity < table->capacity) {
         return 0;  // overflow (capacity would be too big)
     }
-    ht_entry* new_entries = cn_zalloc(new_capacity * sizeof(ht_entry));
+    ht_entry* new_entries = cn_fl_calloc(new_capacity, sizeof(ht_entry));
     if (new_entries == NULL) {
         return 0;
     }
@@ -158,12 +157,12 @@ static _Bool ht_expand(hash_table* table) {
         ht_entry entry = table->entries[i];
         if (entry.key != NULL) {
             ht_set_entry(new_entries, new_capacity, entry.key,
-                         entry.value, NULL);
+                entry.value, NULL);
         }
     }
 
     // Free old entries array and update this table's details.
-    // free(table->entries);'
+    cn_fl_free(table->entries);
     table->entries = new_entries;
     table->capacity = new_capacity;
     return 1;
@@ -185,7 +184,7 @@ signed long* ht_set(hash_table* table, signed long* key, void* value) {
 
     // Set entry and update length.
     return ht_set_entry(table->entries, table->capacity, key, value,
-                        &table->length);
+        &table->length);
 }
 
 int ht_size(hash_table* table) {

--- a/runtime/libcn/src/cn-executable/hash_table.c
+++ b/runtime/libcn/src/cn-executable/hash_table.c
@@ -52,6 +52,10 @@ hash_table* ht_create(void) {
 }
 
 void ht_destroy(hash_table* table) {
+    if (table == NULL) {
+        return;
+    }
+
     // First free allocated keys.
     for (size_t i = 0; i < table->capacity; i++) {
         cn_fl_free((void*)table->entries[i].key);

--- a/runtime/libcn/src/cn-executable/utils.c
+++ b/runtime/libcn/src/cn-executable/utils.c
@@ -8,7 +8,7 @@ typedef hash_table ownership_ghost_state;
 ownership_ghost_state* cn_ownership_global_ghost_state;
 
 
-struct cn_error_message_info *error_msg_info;
+struct cn_error_message_info* error_msg_info;
 
 signed long cn_stack_depth;
 
@@ -18,23 +18,23 @@ signed long nr_owned_predicates;
 static enum cn_logging_level logging_level = CN_LOGGING_INFO;
 
 enum cn_logging_level get_cn_logging_level(void) {
-    return logging_level;
+  return logging_level;
 }
 
 enum cn_logging_level set_cn_logging_level(enum cn_logging_level new_level) {
-    enum cn_logging_level old_level = logging_level;
-    logging_level = new_level;
-    return old_level;
+  enum cn_logging_level old_level = logging_level;
+  logging_level = new_level;
+  return old_level;
 }
 
 void cn_failure_default(enum cn_failure_mode mode) {
   switch (mode) {
-    case CN_FAILURE_ALLOC:
-      printf("Out of memory!");
-    case CN_FAILURE_ASSERT:
-    case CN_FAILURE_CHECK_OWNERSHIP:
-    case CN_FAILURE_OWNERSHIP_LEAK:
-      exit(SIGABRT);
+  case CN_FAILURE_ALLOC:
+    printf("Out of memory!");
+  case CN_FAILURE_ASSERT:
+  case CN_FAILURE_CHECK_OWNERSHIP:
+  case CN_FAILURE_OWNERSHIP_LEAK:
+    exit(SIGABRT);
   }
 }
 
@@ -52,15 +52,15 @@ void reset_cn_failure_cb(void) {
   cn_failure_aux = &cn_failure_default;
 }
 
-void print_error_msg_info(struct cn_error_message_info *info) {
-  if(info) {
+void print_error_msg_info(struct cn_error_message_info* info) {
+  if (info) {
     if (info->parent != NULL) {
       print_error_msg_info(info->parent);
       cn_printf(CN_LOGGING_ERROR, "************************************************************\n");
     }
     cn_printf(CN_LOGGING_ERROR, "function %s, file %s, line %d\n", info->function_name, info->file_name, info->line_number);
     if (info->cn_source_loc) {
-        cn_printf(CN_LOGGING_ERROR, "original source location: \n%s\n", info->cn_source_loc);
+      cn_printf(CN_LOGGING_ERROR, "original source location: \n%s\n", info->cn_source_loc);
     }
   }
   else {
@@ -69,24 +69,24 @@ void print_error_msg_info(struct cn_error_message_info *info) {
   }
 }
 
-cn_bool *convert_to_cn_bool(_Bool b) {
-    cn_bool *res = cn_alloc(sizeof(cn_bool));
-    if (!res) exit(1);
-    res->val = b;
-    return res;
+cn_bool* convert_to_cn_bool(_Bool b) {
+  cn_bool* res = cn_bump_malloc(sizeof(cn_bool));
+  if (!res) exit(1);
+  res->val = b;
+  return res;
 }
 
-_Bool convert_from_cn_bool(cn_bool *b) {
-    return b->val;
+_Bool convert_from_cn_bool(cn_bool* b) {
+  return b->val;
 }
 
-void cn_assert(cn_bool *cn_b) {
-    // cn_printf(CN_LOGGING_INFO, "[CN: assertion] function %s, file %s, line %d\n", error_msg_info.function_name, error_msg_info.file_name, error_msg_info.line_number);
-    if (!(cn_b->val)) {
-        print_error_msg_info(error_msg_info);
-        cn_printf(CN_LOGGING_ERROR, "CN assertion failed.");
-        cn_failure(CN_FAILURE_ASSERT);
-    }
+void cn_assert(cn_bool* cn_b) {
+  // cn_printf(CN_LOGGING_INFO, "[CN: assertion] function %s, file %s, line %d\n", error_msg_info.function_name, error_msg_info.file_name, error_msg_info.line_number);
+  if (!(cn_b->val)) {
+    print_error_msg_info(error_msg_info);
+    cn_printf(CN_LOGGING_ERROR, "CN assertion failed.");
+    cn_failure(CN_FAILURE_ASSERT);
+  }
 }
 
 /* void c_ghost_assert(cn_bool *cn_b) { */
@@ -99,58 +99,58 @@ void cn_assert(cn_bool *cn_b) {
 /*     } */
 /* } */
 
-cn_bool *cn_bool_and(cn_bool *b1, cn_bool *b2) {
-    cn_bool *res = cn_alloc(sizeof(cn_bool));
-    res->val = b1->val && b2->val;
-    return res;
+cn_bool* cn_bool_and(cn_bool* b1, cn_bool* b2) {
+  cn_bool* res = cn_bump_malloc(sizeof(cn_bool));
+  res->val = b1->val && b2->val;
+  return res;
 }
 
-cn_bool *cn_bool_or(cn_bool *b1, cn_bool *b2) {
-    cn_bool *res = cn_alloc(sizeof(cn_bool));
-    res->val = b1->val || b2->val;
-    return res;
+cn_bool* cn_bool_or(cn_bool* b1, cn_bool* b2) {
+  cn_bool* res = cn_bump_malloc(sizeof(cn_bool));
+  res->val = b1->val || b2->val;
+  return res;
 }
 
-cn_bool *cn_bool_implies(cn_bool *b1, cn_bool *b2) {
-    cn_bool *res = cn_alloc(sizeof(cn_bool));
-    res->val = !b1->val || b2->val;
-    return res;
+cn_bool* cn_bool_implies(cn_bool* b1, cn_bool* b2) {
+  cn_bool* res = cn_bump_malloc(sizeof(cn_bool));
+  res->val = !b1->val || b2->val;
+  return res;
 }
 
-cn_bool *cn_bool_not(cn_bool *b) {
-    cn_bool *res = cn_alloc(sizeof(cn_bool));
-    res->val = !(b->val);
-    return res;
+cn_bool* cn_bool_not(cn_bool* b) {
+  cn_bool* res = cn_bump_malloc(sizeof(cn_bool));
+  res->val = !(b->val);
+  return res;
 }
 
-cn_bool *cn_bool_equality(cn_bool *b1, cn_bool *b2) {
-    return convert_to_cn_bool(b1->val == b2->val);
+cn_bool* cn_bool_equality(cn_bool* b1, cn_bool* b2) {
+  return convert_to_cn_bool(b1->val == b2->val);
 }
 
-void *cn_ite(cn_bool *b, void *e1, void *e2) {
-    return b->val ? e1 : e2;
+void* cn_ite(cn_bool* b, void* e1, void* e2) {
+  return b->val ? e1 : e2;
 }
 
 
-cn_map *map_create(void) {
-    return ht_create();
+cn_map* map_create(void) {
+  return ht_create();
 }
 
 void initialise_ownership_ghost_state(void) {
-    nr_owned_predicates = 0;
-    cn_ownership_global_ghost_state = ht_create();
+  nr_owned_predicates = 0;
+  cn_ownership_global_ghost_state = ht_create();
 }
 
 void initialise_ghost_stack_depth(void) {
-    cn_stack_depth = 0;
+  cn_stack_depth = 0;
 }
 
 signed long get_cn_stack_depth(void) {
-    return cn_stack_depth;
+  return cn_stack_depth;
 }
 
 void ghost_stack_depth_incr(void) {
-    cn_stack_depth++;
+  cn_stack_depth++;
 }
 
 
@@ -160,38 +160,38 @@ void ghost_stack_depth_incr(void) {
 #define FMT_PTR_2 "\x1B[35m%#lx\x1B[0m"
 
 void ghost_stack_depth_decr(void) {
-    cn_stack_depth--;
-    // update_error_message_info(0);
-    // print_error_msg_info();
-    // leak checking
-    hash_table_iterator it = ht_iterator(cn_ownership_global_ghost_state);
-    // cn_printf(CN_LOGGING_INFO, "CN pointers leaked at (%ld) stack-depth: ", cn_stack_depth);
-    while (ht_next(&it)) {
-        uintptr_t *key = (uintptr_t *) it.key;
-        int *depth = it.value;
-        if (*depth > cn_stack_depth) {
-          print_error_msg_info(error_msg_info);
-          cn_printf(CN_LOGGING_ERROR, "Leak check failed, ownership leaked for pointer "FMT_PTR"\n", *key);
-          cn_failure(CN_FAILURE_OWNERSHIP_LEAK);
-            // cn_printf(CN_LOGGING_INFO, FMT_PTR_2 " (%d),", *key, *depth);
-        }
+  cn_stack_depth--;
+  // update_error_message_info(0);
+  // print_error_msg_info();
+  // leak checking
+  hash_table_iterator it = ht_iterator(cn_ownership_global_ghost_state);
+  // cn_printf(CN_LOGGING_INFO, "CN pointers leaked at (%ld) stack-depth: ", cn_stack_depth);
+  while (ht_next(&it)) {
+    uintptr_t* key = (uintptr_t*)it.key;
+    int* depth = it.value;
+    if (*depth > cn_stack_depth) {
+      print_error_msg_info(error_msg_info);
+      cn_printf(CN_LOGGING_ERROR, "Leak check failed, ownership leaked for pointer "FMT_PTR"\n", *key);
+      cn_failure(CN_FAILURE_OWNERSHIP_LEAK);
+      // cn_printf(CN_LOGGING_INFO, FMT_PTR_2 " (%d),", *key, *depth);
     }
-    // cn_printf(CN_LOGGING_INFO, "\n");
+  }
+  // cn_printf(CN_LOGGING_INFO, "\n");
 }
 
-int ownership_ghost_state_get(signed long *address_key) {
-    int *curr_depth_maybe = (int *) ht_get(cn_ownership_global_ghost_state, address_key);
-    return curr_depth_maybe ? *curr_depth_maybe : -1;
+int ownership_ghost_state_get(signed long* address_key) {
+  int* curr_depth_maybe = (int*)ht_get(cn_ownership_global_ghost_state, address_key);
+  return curr_depth_maybe ? *curr_depth_maybe : -1;
 }
 
 void ownership_ghost_state_set(signed long* address_key, int stack_depth_val) {
-    int *new_depth = cn_alloc(sizeof(int));
-    *new_depth = stack_depth_val;
-    ht_set(cn_ownership_global_ghost_state, address_key, new_depth);
+  int* new_depth = cn_bump_malloc(sizeof(int));
+  *new_depth = stack_depth_val;
+  ht_set(cn_ownership_global_ghost_state, address_key, new_depth);
 }
 
 void ownership_ghost_state_remove(signed long* address_key) {
-    ownership_ghost_state_set(address_key, -1);
+  ownership_ghost_state_set(address_key, -1);
 }
 
 
@@ -208,222 +208,223 @@ void dump_ownership_state()
 
 
 void cn_get_ownership(uintptr_t generic_c_ptr, size_t size) {
-    // cn_printf(CN_LOGGING_INFO, "[CN: getting ownership] " FMT_PTR_2 ", size: %lu\n", generic_c_ptr, size);
-    //// print_error_msg_info();
-  c_ownership_check("Precondition ownership check", generic_c_ptr, (int) size, cn_stack_depth - 1);
+  // cn_printf(CN_LOGGING_INFO, "[CN: getting ownership] " FMT_PTR_2 ", size: %lu\n", generic_c_ptr, size);
+  //// print_error_msg_info();
+  c_ownership_check("Precondition ownership check", generic_c_ptr, (int)size, cn_stack_depth - 1);
   c_add_to_ghost_state(generic_c_ptr, size, cn_stack_depth);
 }
 
 void cn_put_ownership(uintptr_t generic_c_ptr, size_t size) {
-    // cn_printf(CN_LOGGING_INFO, "[CN: returning ownership] " FMT_PTR_2 ", size: %lu\n", generic_c_ptr, size);
-    //// print_error_msg_info();
-  c_ownership_check("Postcondition ownership check", generic_c_ptr, (int) size, cn_stack_depth);
+  // cn_printf(CN_LOGGING_INFO, "[CN: returning ownership] " FMT_PTR_2 ", size: %lu\n", generic_c_ptr, size);
+  //// print_error_msg_info();
+  c_ownership_check("Postcondition ownership check", generic_c_ptr, (int)size, cn_stack_depth);
   c_add_to_ghost_state(generic_c_ptr, size, cn_stack_depth - 1);
 }
 
-void cn_assume_ownership(void *generic_c_ptr, unsigned long size, char *fun) {
-    // cn_printf(CN_LOGGING_INFO, "[CN: assuming ownership (%s)] " FMT_PTR_2 ", size: %lu\n", fun, (uintptr_t) generic_c_ptr, size);
-    //// print_error_msg_info();
-    for (int i = 0; i < size; i++) { 
-        signed long *address_key = cn_alloc(sizeof(long));
-        *address_key = ((uintptr_t) generic_c_ptr) + i;
-        /* // cn_printf(CN_LOGGING_INFO, "CN: Assuming ownership for %lu (function: %s)\n",  */
-        /*        ((uintptr_t) generic_c_ptr) + i, fun); */
-        ownership_ghost_state_set(address_key, cn_stack_depth);
-    }
+void cn_assume_ownership(void* generic_c_ptr, unsigned long size, char* fun) {
+  // cn_printf(CN_LOGGING_INFO, "[CN: assuming ownership (%s)] " FMT_PTR_2 ", size: %lu\n", fun, (uintptr_t) generic_c_ptr, size);
+  //// print_error_msg_info();
+  for (int i = 0; i < size; i++) {
+    signed long* address_key = cn_bump_malloc(sizeof(long));
+    *address_key = ((uintptr_t)generic_c_ptr) + i;
+    /* // cn_printf(CN_LOGGING_INFO, "CN: Assuming ownership for %lu (function: %s)\n",  */
+    /*        ((uintptr_t) generic_c_ptr) + i, fun); */
+    ownership_ghost_state_set(address_key, cn_stack_depth);
+  }
 }
 
 
 void cn_get_or_put_ownership(enum OWNERSHIP owned_enum, uintptr_t generic_c_ptr, size_t size) {
   nr_owned_predicates++;
   switch (owned_enum)
-    {
-      case GET:
-      {
-        cn_get_ownership(generic_c_ptr, size);
-        break;
-      }
-      case PUT:
-      {
-        cn_put_ownership(generic_c_ptr, size);
-        break;
-      }
-    }
+  {
+  case GET:
+  {
+    cn_get_ownership(generic_c_ptr, size);
+    break;
+  }
+  case PUT:
+  {
+    cn_put_ownership(generic_c_ptr, size);
+    break;
+  }
+  }
 }
 
 
 void c_add_to_ghost_state(uintptr_t ptr_to_local, size_t size, signed long stack_depth) {
   // cn_printf(CN_LOGGING_INFO, "[C access checking] add local:" FMT_PTR ", size: %lu\n", ptr_to_local, size);
-  for (int i = 0; i < size; i++) { 
-      signed long *address_key = cn_alloc(sizeof(long));
-      *address_key = ptr_to_local + i;
-      /* // cn_printf(CN_LOGGING_INFO, " off: %d [" FMT_PTR "]\n", i, *address_key); */
-      ownership_ghost_state_set(address_key, stack_depth);
+  for (int i = 0; i < size; i++) {
+    signed long* address_key = cn_bump_malloc(sizeof(long));
+    *address_key = ptr_to_local + i;
+    /* // cn_printf(CN_LOGGING_INFO, " off: %d [" FMT_PTR "]\n", i, *address_key); */
+    ownership_ghost_state_set(address_key, stack_depth);
   }
 }
 
 void c_remove_from_ghost_state(uintptr_t ptr_to_local, size_t size) {
   // cn_printf(CN_LOGGING_INFO, "[C access checking] remove local:" FMT_PTR ", size: %lu\n", ptr_to_local, size);
-  for (int i = 0; i < size; i++) { 
-      signed long *address_key = cn_alloc(sizeof(long));
-      *address_key = ptr_to_local + i;
-      /* // cn_printf(CN_LOGGING_INFO, " off: %d [" FMT_PTR "]\n", i, *address_key); */
-      ownership_ghost_state_remove(address_key);
+  for (int i = 0; i < size; i++) {
+    signed long* address_key = cn_bump_malloc(sizeof(long));
+    *address_key = ptr_to_local + i;
+    /* // cn_printf(CN_LOGGING_INFO, " off: %d [" FMT_PTR "]\n", i, *address_key); */
+    ownership_ghost_state_remove(address_key);
   }
 }
 
-void c_ownership_check(char *access_kind, uintptr_t generic_c_ptr, int offset, signed long expected_stack_depth) {
-    signed long address_key = 0;
-    // cn_printf(CN_LOGGING_INFO, "C: Checking ownership for [ " FMT_PTR " .. " FMT_PTR " ] -- ", generic_c_ptr, generic_c_ptr + offset);
-    for (int i = 0; i<offset; i++) {
-      address_key = generic_c_ptr + i;
-      int curr_depth = ownership_ghost_state_get(&address_key);
-      if (curr_depth != expected_stack_depth) {
-        print_error_msg_info(error_msg_info);
-        cn_printf(CN_LOGGING_ERROR, "%s failed.\n", access_kind);
-        if (curr_depth == -1) {
-          cn_printf(CN_LOGGING_ERROR, "  ==> "FMT_PTR"[%d] ("FMT_PTR") not owned\n", generic_c_ptr, i, (uintptr_t)((char*)generic_c_ptr + i));
-        }
-        else {
-          cn_printf(CN_LOGGING_ERROR, "  ==> "FMT_PTR"[%d] ("FMT_PTR") not owned at expected function call stack depth %ld\n", generic_c_ptr, i, (uintptr_t)((char*)generic_c_ptr + i), expected_stack_depth);
-          cn_printf(CN_LOGGING_ERROR, "  ==> (owned at stack depth: %d)\n", curr_depth);
-        }
-        cn_failure(CN_FAILURE_CHECK_OWNERSHIP);
+void c_ownership_check(char* access_kind, uintptr_t generic_c_ptr, int offset, signed long expected_stack_depth) {
+  signed long address_key = 0;
+  // cn_printf(CN_LOGGING_INFO, "C: Checking ownership for [ " FMT_PTR " .. " FMT_PTR " ] -- ", generic_c_ptr, generic_c_ptr + offset);
+  for (int i = 0; i < offset; i++) {
+    address_key = generic_c_ptr + i;
+    int curr_depth = ownership_ghost_state_get(&address_key);
+    if (curr_depth != expected_stack_depth) {
+      print_error_msg_info(error_msg_info);
+      cn_printf(CN_LOGGING_ERROR, "%s failed.\n", access_kind);
+      if (curr_depth == -1) {
+        cn_printf(CN_LOGGING_ERROR, "  ==> "FMT_PTR"[%d] ("FMT_PTR") not owned\n", generic_c_ptr, i, (uintptr_t)((char*)generic_c_ptr + i));
       }
+      else {
+        cn_printf(CN_LOGGING_ERROR, "  ==> "FMT_PTR"[%d] ("FMT_PTR") not owned at expected function call stack depth %ld\n", generic_c_ptr, i, (uintptr_t)((char*)generic_c_ptr + i), expected_stack_depth);
+        cn_printf(CN_LOGGING_ERROR, "  ==> (owned at stack depth: %d)\n", curr_depth);
+      }
+      cn_failure(CN_FAILURE_CHECK_OWNERSHIP);
     }
-    // cn_printf(CN_LOGGING_INFO, "\n");
+  }
+  // cn_printf(CN_LOGGING_INFO, "\n");
 }
 
 /* TODO: Need address of and size of every stack-allocated variable - could store in struct and pass through. But this is an optimisation */
 // void c_map_locals_to_stack_depth(ownership_ghost_state *cn_ownership_global_ghost_state, size_t size, int cn_stack_depth, ...) {
 //     va_list args;
- 
+
 //     va_start(args, n);
- 
+
 //     for (int i = 0; i < n; i++) {
 //         uintptr_t fn_local_ptr = va_arg(args, uintptr_t);
-//         signed long *address_key = cn_alloc(sizeof(long));
+//         signed long *address_key = cn_bump_malloc(sizeof(long));
 //         *address_key = fn_local_ptr;
 //         ghost_state_set(cn_ownership_global_ghost_state, address_key, cn_stack_depth);
 //     }
- 
+
 //     va_end(args);
 // }
 
 
-cn_map *cn_map_set(cn_map *m, cn_integer *key, void *value) {
-    signed long *key_ptr = cn_alloc(sizeof(signed long));
-    *key_ptr = key->val;
-    ht_set(m, key_ptr, value);
-    return m;
+cn_map* cn_map_set(cn_map* m, cn_integer* key, void* value) {
+  signed long* key_ptr = cn_bump_malloc(sizeof(signed long));
+  *key_ptr = key->val;
+  ht_set(m, key_ptr, value);
+  return m;
 }
 
 
-cn_map *cn_map_deep_copy(cn_map *m1) {
-    cn_map *m2 = map_create();
+cn_map* cn_map_deep_copy(cn_map* m1) {
+  cn_map* m2 = map_create();
 
-    hash_table_iterator hti = ht_iterator(m1);
+  hash_table_iterator hti = ht_iterator(m1);
 
-    while (ht_next(&hti)) {
-        signed long* curr_key = hti.key;
-        void *val = ht_get(m1, curr_key);
-        ht_set(m2, curr_key, val);
-    }
+  while (ht_next(&hti)) {
+    signed long* curr_key = hti.key;
+    void* val = ht_get(m1, curr_key);
+    ht_set(m2, curr_key, val);
+  }
 
-    return m2;
+  return m2;
 }
 
 
-cn_map *default_cn_map(void) {
-    return map_create();
+cn_map* default_cn_map(void) {
+  return map_create();
 }
 
-cn_bool *default_cn_bool(void) {
-    return convert_to_cn_bool(false);
+cn_bool* default_cn_bool(void) {
+  return convert_to_cn_bool(false);
 }
 
-cn_bool *cn_pointer_equality(void *i1, void *i2) {
-    return convert_to_cn_bool((((cn_pointer *) i1)->ptr) == (((cn_pointer *) i2)->ptr));
+cn_bool* cn_pointer_equality(void* i1, void* i2) {
+  return convert_to_cn_bool((((cn_pointer*)i1)->ptr) == (((cn_pointer*)i2)->ptr));
 }
 
-cn_bool *cn_pointer_is_null(cn_pointer *p) {
-    return convert_to_cn_bool(p->ptr == NULL);
+cn_bool* cn_pointer_is_null(cn_pointer* p) {
+  return convert_to_cn_bool(p->ptr == NULL);
 }
 
-cn_bool *cn_pointer_lt(cn_pointer *p1, cn_pointer *p2) {
-    return convert_to_cn_bool(p1->ptr < p2->ptr);
+cn_bool* cn_pointer_lt(cn_pointer* p1, cn_pointer* p2) {
+  return convert_to_cn_bool(p1->ptr < p2->ptr);
 }
 
-cn_bool *cn_pointer_le(cn_pointer *p1, cn_pointer *p2) {
-    return convert_to_cn_bool(p1->ptr <= p2->ptr);
+cn_bool* cn_pointer_le(cn_pointer* p1, cn_pointer* p2) {
+  return convert_to_cn_bool(p1->ptr <= p2->ptr);
 }
 
-cn_bool *cn_pointer_gt(cn_pointer *p1, cn_pointer *p2) {
-    return convert_to_cn_bool(p1->ptr > p2->ptr);
+cn_bool* cn_pointer_gt(cn_pointer* p1, cn_pointer* p2) {
+  return convert_to_cn_bool(p1->ptr > p2->ptr);
 }
 
-cn_bool *cn_pointer_ge(cn_pointer *p1, cn_pointer *p2) {
-    return convert_to_cn_bool(p1->ptr >= p2->ptr);
+cn_bool* cn_pointer_ge(cn_pointer* p1, cn_pointer* p2) {
+  return convert_to_cn_bool(p1->ptr >= p2->ptr);
 }
 
-cn_pointer *cast_cn_pointer_to_cn_pointer(cn_pointer *p) {\
-        return p;
+cn_pointer* cast_cn_pointer_to_cn_pointer(cn_pointer* p) {
+  \
+    return p;
 }
 
 
 
 // Check if m2 is a subset of m1
-cn_bool *cn_map_subset(cn_map *m1, cn_map *m2, cn_bool *(value_equality_fun)(void *, void *)) {
-    if (ht_size(m1) != ht_size(m2)) return convert_to_cn_bool(0);
-    
-    hash_table_iterator hti1 = ht_iterator(m1);
+cn_bool* cn_map_subset(cn_map* m1, cn_map* m2, cn_bool* (value_equality_fun)(void*, void*)) {
+  if (ht_size(m1) != ht_size(m2)) return convert_to_cn_bool(0);
 
-    while (ht_next(&hti1)) {
-        signed long* curr_key = hti1.key;
-        void *val1 = ht_get(m1, curr_key);
-        void *val2 = ht_get(m2, curr_key);
+  hash_table_iterator hti1 = ht_iterator(m1);
 
-        /* Check if other map has this key at all */
-        if (!val2) return convert_to_cn_bool(0);
+  while (ht_next(&hti1)) {
+    signed long* curr_key = hti1.key;
+    void* val1 = ht_get(m1, curr_key);
+    void* val2 = ht_get(m2, curr_key);
 
-        if (convert_from_cn_bool(cn_bool_not(value_equality_fun(val1, val2)))) {
-            // cn_printf(CN_LOGGING_INFO, "Values not equal!\n");
-            return convert_to_cn_bool(0);
-        } 
+    /* Check if other map has this key at all */
+    if (!val2) return convert_to_cn_bool(0);
+
+    if (convert_from_cn_bool(cn_bool_not(value_equality_fun(val1, val2)))) {
+      // cn_printf(CN_LOGGING_INFO, "Values not equal!\n");
+      return convert_to_cn_bool(0);
     }
+  }
 
-    return convert_to_cn_bool(1);
+  return convert_to_cn_bool(1);
 }
 
-cn_bool *cn_map_equality(cn_map *m1, cn_map *m2, cn_bool *(value_equality_fun)(void *, void *)) {
-    return cn_bool_and(cn_map_subset(m1, m2, value_equality_fun), cn_map_subset(m2, m1, value_equality_fun));
+cn_bool* cn_map_equality(cn_map* m1, cn_map* m2, cn_bool* (value_equality_fun)(void*, void*)) {
+  return cn_bool_and(cn_map_subset(m1, m2, value_equality_fun), cn_map_subset(m2, m1, value_equality_fun));
 }
 
 // TODO (RB) does this need to be in here, or should it be auto-generated?
 // See https://github.com/rems-project/cerberus/pull/652 for details
-cn_bool *void_pointer_equality(void *p1, void *p2) {
-    cn_bool *res = cn_alloc(sizeof(cn_bool));
-    res->val = (p1 == p2);
-    return res;
+cn_bool* void_pointer_equality(void* p1, void* p2) {
+  cn_bool* res = cn_bump_malloc(sizeof(cn_bool));
+  res->val = (p1 == p2);
+  return res;
 }
 
-cn_pointer *convert_to_cn_pointer(void *ptr) {
-    cn_pointer *res = (cn_pointer *) cn_alloc(sizeof(cn_pointer));
-    res->ptr = ptr; // Carries around an address
-    return res;
+cn_pointer* convert_to_cn_pointer(void* ptr) {
+  cn_pointer* res = (cn_pointer*)cn_bump_malloc(sizeof(cn_pointer));
+  res->ptr = ptr; // Carries around an address
+  return res;
 }
 
-void *convert_from_cn_pointer(cn_pointer *cn_ptr) {
-    return cn_ptr->ptr;
+void* convert_from_cn_pointer(cn_pointer* cn_ptr) {
+  return cn_ptr->ptr;
 }
 
-struct cn_error_message_info *make_error_message_info_entry(const char *function_name, 
-                                   char *file_name, 
-                                   int line_number, 
-                                   char *cn_source_loc, 
-                                   struct cn_error_message_info *parent)
+struct cn_error_message_info* make_error_message_info_entry(const char* function_name,
+  char* file_name,
+  int line_number,
+  char* cn_source_loc,
+  struct cn_error_message_info* parent)
 {
-  struct cn_error_message_info *entry = (struct cn_error_message_info *) cn_alloc(sizeof(struct cn_error_message_info));
+  struct cn_error_message_info* entry = (struct cn_error_message_info*)cn_bump_malloc(sizeof(struct cn_error_message_info));
   entry->function_name = function_name;
   entry->file_name = file_name;
   entry->line_number = line_number;
@@ -432,12 +433,12 @@ struct cn_error_message_info *make_error_message_info_entry(const char *function
   return entry;
 }
 
-void update_error_message_info_(const char *function_name, char *file_name, int line_number, char *cn_source_loc) 
+void update_error_message_info_(const char* function_name, char* file_name, int line_number, char* cn_source_loc)
 {
-    error_msg_info = make_error_message_info_entry(function_name, file_name, line_number, cn_source_loc, error_msg_info);
+  error_msg_info = make_error_message_info_entry(function_name, file_name, line_number, cn_source_loc, error_msg_info);
 }
 
-void initialise_error_msg_info_(const char *function_name, char *file_name, int line_number) {
+void initialise_error_msg_info_(const char* function_name, char* file_name, int line_number) {
   // cn_printf(CN_LOGGING_INFO, "Initialising error message info\n");
   error_msg_info = make_error_message_info_entry(function_name, file_name, line_number, 0, NULL);
 }
@@ -446,9 +447,9 @@ void reset_error_msg_info() {
   error_msg_info = NULL;
 }
 
-void cn_pop_msg_info ()
+void cn_pop_msg_info()
 {
-  struct cn_error_message_info *old = error_msg_info;
+  struct cn_error_message_info* old = error_msg_info;
   error_msg_info = old->parent;
   //TODO: free(old);  
 }
@@ -456,62 +457,65 @@ void cn_pop_msg_info ()
 
 static uint32_t cn_fls(uint32_t x)
 {
-    return x ? sizeof(x) * 8 - __builtin_clz(x) : 0;
+  return x ? sizeof(x) * 8 - __builtin_clz(x) : 0;
 }
 
 static uint64_t cn_flsl(uint64_t x)
 {
-    return x ? sizeof(x) * 8 - __builtin_clzl(x) : 0;
+  return x ? sizeof(x) * 8 - __builtin_clzl(x) : 0;
 }
 
 
-cn_bits_u32 *cn_bits_u32_fls(cn_bits_u32 *i1) {
-        cn_bits_u32 *res = (cn_bits_u32 *) cn_alloc(sizeof(cn_bits_u32));
-        res->val = cn_fls(i1->val);
-        return res;
-    }
+cn_bits_u32* cn_bits_u32_fls(cn_bits_u32* i1) {
+  cn_bits_u32* res = (cn_bits_u32*)cn_bump_malloc(sizeof(cn_bits_u32));
+  res->val = cn_fls(i1->val);
+  return res;
+}
 
-cn_bits_u64 *cn_bits_u64_flsl(cn_bits_u64 *i1) {
-        cn_bits_u64 *res = (cn_bits_u64 *) cn_alloc(sizeof(cn_bits_u64));
-        res->val = cn_flsl(i1->val);
-        return res;
-    }
+cn_bits_u64* cn_bits_u64_flsl(cn_bits_u64* i1) {
+  cn_bits_u64* res = (cn_bits_u64*)cn_bump_malloc(sizeof(cn_bits_u64));
+  res->val = cn_flsl(i1->val);
+  return res;
+}
 
 
-void *cn_aligned_alloc(size_t align, size_t size) 
+void* cn_aligned_alloc(size_t align, size_t size)
 {
-  void *p = aligned_alloc(align, size);
+  void* p = aligned_alloc(align, size);
   char str[] = "cn_aligned_malloc";
   if (p) {
-    cn_assume_ownership((void*) p, size, str);
+    cn_assume_ownership((void*)p, size, str);
     return p;
-  } else {
+  }
+  else {
     cn_printf(CN_LOGGING_INFO, "aligned_alloc failed\n");
     return p;
   }
 }
 
-void *cn_malloc(unsigned long size) 
+void* cn_malloc(unsigned long size)
 {
-  void *p = malloc(size);
+  void* p = malloc(size);
   char str[] = "cn_malloc";
   if (p) {
-    cn_assume_ownership((void*) p, size, str);
+    cn_assume_ownership((void*)p, size, str);
     return p;
-  } else {
+  }
+  else {
     cn_printf(CN_LOGGING_INFO, "malloc failed\n");
     return p;
   }
 }
 
-void *cn_calloc(size_t num, size_t size) 
+void* cn_calloc(size_t num, size_t size)
 {
-  void *p = calloc(num, size);
+  void* p = calloc(num, size);
   char str[] = "cn_calloc";
   if (p) {
-    cn_assume_ownership((void*) p, num*size, str);
+    cn_assume_ownership((void*)p, num * size, str);
     return p;
-  } else {
+  }
+  else {
     cn_printf(CN_LOGGING_INFO, "calloc failed\n");
     return p;
   }
@@ -520,15 +524,15 @@ void *cn_calloc(size_t num, size_t size)
 void cn_free_sized(void* malloced_ptr, size_t size)
 {
   // cn_printf(CN_LOGGING_INFO, "[CN: freeing ownership] " FMT_PTR ", size: %lu\n", (uintptr_t) malloced_ptr, size);
-  c_ownership_check("Free", (uintptr_t) malloced_ptr, (int) size, cn_stack_depth);
-  c_remove_from_ghost_state((uintptr_t) malloced_ptr, size);
+  c_ownership_check("Free", (uintptr_t)malloced_ptr, (int)size, cn_stack_depth);
+  c_remove_from_ghost_state((uintptr_t)malloced_ptr, size);
 }
 
 void cn_print_nr_owned_predicates(void) {
-    printf("Owned predicates £%lu\n", nr_owned_predicates);
+  printf("Owned predicates £%lu\n", nr_owned_predicates);
 }
- 
-void cn_print_u64(const char *str, unsigned long u)
+
+void cn_print_u64(const char* str, unsigned long u)
 {
   // cn_printf(CN_LOGGING_INFO, "\n\nprint %s: %20lx,  %20lu\n\n", str, u, u);
 }

--- a/runtime/libcn/src/cn-executable/utils.c
+++ b/runtime/libcn/src/cn-executable/utils.c
@@ -141,6 +141,11 @@ void initialise_ownership_ghost_state(void) {
   cn_ownership_global_ghost_state = ht_create();
 }
 
+void free_ownership_ghost_state(void) {
+  nr_owned_predicates = 0;
+  ht_destroy(cn_ownership_global_ghost_state);
+}
+
 void initialise_ghost_stack_depth(void) {
   cn_stack_depth = 0;
 }
@@ -424,7 +429,7 @@ struct cn_error_message_info* make_error_message_info_entry(const char* function
   char* cn_source_loc,
   struct cn_error_message_info* parent)
 {
-  struct cn_error_message_info* entry = (struct cn_error_message_info*)cn_bump_malloc(sizeof(struct cn_error_message_info));
+  struct cn_error_message_info* entry = (struct cn_error_message_info*)cn_fl_malloc(sizeof(struct cn_error_message_info));
   entry->function_name = function_name;
   entry->file_name = file_name;
   entry->line_number = line_number;
@@ -447,11 +452,17 @@ void reset_error_msg_info() {
   error_msg_info = NULL;
 }
 
+void free_error_msg_info() {
+  while (error_msg_info != NULL) {
+    cn_pop_msg_info();
+  }
+}
+
 void cn_pop_msg_info()
 {
   struct cn_error_message_info* old = error_msg_info;
   error_msg_info = old->parent;
-  //TODO: free(old);  
+  cn_fl_free(old);
 }
 
 

--- a/runtime/libcn/src/cn-executable/utils.c
+++ b/runtime/libcn/src/cn-executable/utils.c
@@ -14,6 +14,13 @@ signed long cn_stack_depth;
 
 signed long nr_owned_predicates;
 
+void reset_fulminate(void) {
+  cn_bump_free_all();
+  cn_fl_free_all();
+  reset_error_msg_info();
+  initialise_ownership_ghost_state();
+  initialise_ghost_stack_depth();
+}
 
 static enum cn_logging_level logging_level = CN_LOGGING_INFO;
 

--- a/runtime/libcn/src/cn-testing/gen_alloc.c
+++ b/runtime/libcn/src/cn-testing/gen_alloc.c
@@ -115,7 +115,7 @@ cn_pointer* cn_gen_alloc(cn_bits_u64* sz) {
         return convert_to_cn_pointer(NULL);
     }
     else {
-        void* p = cn_alloc(bytes);
+        void* p = cn_bump_malloc(bytes);
         update_alloc(p, bytes);
         return convert_to_cn_pointer(p);
     }


### PR DESCRIPTION
- Adds an explicit free list allocator
  - Move hash tables and error messages to using this allocator
  - Modifies bump allocator to be backed by the FL allocator
- Reduce memory usage by using `cn_bump_aligned_alloc` for integers
- Add `reset_fulminate` to reset all the Fulminate-specific state

Makes progress on #859 