### PR TITLE
Track location in pre-processed file, as well references to source.

### DIFF
--- a/backend/cn/lib/cStatements.ml
+++ b/backend/cn/lib/cStatements.ml
@@ -6,7 +6,9 @@ module LocCompare = struct
 
   type pre_cmp = int * (int * int * int * string) list * string list [@@deriving eq, ord]
 
-  let lex_to_cmp l =
+  let lex_to_cmp pos =
+    let l = Cerb_position.to_file_lexing pos in
+    (* XXX: file or source location? not sure why we are compring positions here, *)
     let open Lexing in
     (l.pos_lnum, l.pos_bol, l.pos_cnum, l.pos_fname)
 

--- a/backend/cn/lib/executable_spec.ml
+++ b/backend/cn/lib/executable_spec.ml
@@ -77,7 +77,8 @@ let rec inject_injs_to_multiple_files ail_prog in_stmt_injs block_return_injs cn
              program = ail_prog;
              pre_post = [];
              in_stmt = in_stmt_injs_for_fn';
-             returns = return_injs_for_fn'
+             returns = return_injs_for_fn';
+             inject_in_preproc = false
            })
      with
      | Ok () -> ()
@@ -200,6 +201,7 @@ let main
   ?(with_test_gen = false)
   ?(copy_source_dir = false)
   filename
+  ~use_preproc
   ((_, sigm) as ail_prog)
   output_decorated
   output_decorated_dir
@@ -292,6 +294,8 @@ let main
       (String.concat "\n" cn_header_decls_list)
   in
   output_to_oc cn_header_oc [ cn_header_oc_str ];
+  (* Genereate CN.c *)
+
   (* TODO: Topological sort *)
   let cn_defs_list =
     [ cn_header;
@@ -306,6 +310,7 @@ let main
     ]
   in
   output_to_oc cn_oc cn_defs_list;
+  (* Generate myfile-exec.c *)
   let incls =
     [ ("assert.h", true); ("stdlib.h", true); ("stdbool.h", true); ("math.h", true) ]
   in
@@ -368,7 +373,10 @@ let main
     @ List.map (fun (loc, _) -> Cerb_location.get_filename loc) squashed_block_return_injs
   in
   let remaining_fns_and_ocs =
-    open_auxilliary_files filename prefix included_filenames' []
+    if use_preproc then
+      []
+    else
+      open_auxilliary_files filename prefix included_filenames' []
   in
   let pre_post_pairs =
     if with_test_gen then
@@ -393,7 +401,8 @@ let main
            program = ail_prog;
            pre_post = pre_post_pairs;
            in_stmt = source_file_in_stmt_injs;
-           returns = source_file_return_injs
+           returns = source_file_return_injs;
+           inject_in_preproc = use_preproc
          })
    with
    | Ok () -> ()

--- a/backend/cn/lib/executable_spec_internal.ml
+++ b/backend/cn/lib/executable_spec_internal.ml
@@ -107,11 +107,9 @@ let generate_c_specs_internal
   let modify_magic_comment_loc loc =
     match loc with
     | Cerb_location.Loc_region (start_pos, end_pos, cursor) ->
-      Cerb_location.(
-        region
-          ( { start_pos with pos_cnum = start_pos.pos_cnum - 3 },
-            { end_pos with pos_cnum = end_pos.pos_cnum + 2 } )
-          cursor)
+      Cerb_location.region
+        (Cerb_position.change_cnum start_pos (-3), Cerb_position.change_cnum end_pos 2)
+        cursor
     | _ -> assert false (* loc should always be a region *)
   in
   let in_stmt =

--- a/backend/cn/lib/executable_spec_utils.ml
+++ b/backend/cn/lib/executable_spec_utils.ml
@@ -170,33 +170,33 @@ let create_declaration sym decl = (sym, (Cerb_location.unknown, CF.Annot.Attrs [
 
 let get_start_loc ?(offset = 0) = function
   | Cerb_location.Loc_region (start_pos, _, _) ->
-    let new_start_pos = { start_pos with pos_cnum = start_pos.pos_cnum + offset } in
+    let new_start_pos = Cerb_position.change_cnum start_pos offset in
     Cerb_location.point new_start_pos
   | Loc_regions (pos_list, _) ->
     (match List.last pos_list with
      | Some (_, start_pos) ->
-       let new_start_pos = { start_pos with pos_cnum = start_pos.pos_cnum + offset } in
+       let new_start_pos = Cerb_position.change_cnum start_pos offset in
        Cerb_location.point new_start_pos
      | None ->
        failwith
          "get_start_loc: Loc_regions has empty list of positions (should be non-empty)")
-  | Loc_point pos -> Cerb_location.point { pos with pos_cnum = pos.pos_cnum + offset }
+  | Loc_point pos -> Cerb_location.point (Cerb_position.change_cnum pos offset)
   | Loc_unknown | Loc_other _ ->
     failwith "get_start_loc: Location should be Loc_region, Loc_regions or Loc_point"
 
 
 let get_end_loc ?(offset = 0) = function
   | Cerb_location.Loc_region (_, end_pos, _) ->
-    let new_end_pos = { end_pos with pos_cnum = end_pos.pos_cnum + offset } in
+    let new_end_pos = Cerb_position.change_cnum end_pos offset in
     Cerb_location.point new_end_pos
   | Loc_regions (pos_list, _) ->
     (match List.last pos_list with
      | Some (_, end_pos) ->
-       let new_end_pos = { end_pos with pos_cnum = end_pos.pos_cnum + offset } in
+       let new_end_pos = Cerb_position.change_cnum end_pos offset in
        Cerb_location.point new_end_pos
      | None ->
        failwith
          "get_end_loc: Loc_regions has empty list of positions (should be non-empty)")
-  | Loc_point pos -> Cerb_location.point { pos with pos_cnum = pos.pos_cnum + offset }
+  | Loc_point pos -> Cerb_location.point (Cerb_position.change_cnum pos offset)
   | Loc_unknown | Loc_other _ ->
     failwith "get_end_loc: Location should be Loc_region, Loc_regions or Loc_point"

--- a/backend/cn/lib/explain.ml
+++ b/backend/cn/lib/explain.ml
@@ -140,8 +140,8 @@ let state (ctxt : C.t) log model_with_q extras =
     in
     let loc_cartesian, (loc_head, _loc_pos) =
       match (ctxt.where.statement, ctxt.where.expression) with
-      | _, Some loc -> (Cerb_location.to_cartesian loc, head_pos "expr" loc)
-      | Some loc, None -> (Cerb_location.to_cartesian loc, head_pos "stmt" loc)
+      | _, Some loc -> (Cerb_location.to_cartesian_user loc, head_pos "expr" loc)
+      | Some loc, None -> (Cerb_location.to_cartesian_user loc, head_pos "stmt" loc)
       | None, None -> (None, ("", "\n"))
     in
     let fnction = Option.map Sym.pp_string ctxt.where.fnction in

--- a/backend/cn/lib/locations.ml
+++ b/backend/cn/lib/locations.ml
@@ -59,12 +59,11 @@ let unpack l = l
  *      pos_cnum : int;
  * } *)
 
-let json_lexing_position p =
-  let open Lexing in
+let json_lexing_position pos =
   `Assoc
-    [ ("file", `String p.pos_fname);
-      ("line", `Int p.pos_lnum);
-      ("char", `Int (p.pos_cnum - p.pos_bol))
+    [ ("file", `String (Cerb_position.file pos));
+      ("line", `Int (Cerb_position.line pos));
+      ("char", `Int (Cerb_position.column pos - 1))
     ]
 
 
@@ -131,7 +130,7 @@ let json_path locs : Yojson.Safe.t =
   `Variant ("path", Some (`List locs_json))
 
 
-type region = Lexing.position * Lexing.position
+type region = Cerb_position.t * Cerb_position.t
 
 let point = Cerb_location.point
 

--- a/backend/cn/lib/locations.mli
+++ b/backend/cn/lib/locations.mli
@@ -40,9 +40,9 @@ val json_loc : t -> Yojson.Safe.t
 
 val json_path : path -> Yojson.Safe.t
 
-type region = Lexing.position * Lexing.position
+type region = Cerb_position.t * Cerb_position.t
 
-val point : Lexing.position -> t
+val point : Cerb_position.t -> t
 
 val region : region -> Cerb_location.cursor -> t
 
@@ -54,8 +54,8 @@ val line_numbers : t -> (int * int) option
 
 val is_region : t -> region option
 
-val start_pos : t -> Lexing.position option
+val start_pos : t -> Cerb_position.t option
 
-val end_pos : t -> Lexing.position option
+val end_pos : t -> Cerb_position.t option
 
-val get_region : t -> (Lexing.position * Lexing.position * Cerb_location.cursor) option
+val get_region : t -> (Cerb_position.t * Cerb_position.t * Cerb_location.cursor) option

--- a/backend/cn/lib/pp_mucore_coq.ml
+++ b/backend/cn/lib/pp_mucore_coq.ml
@@ -451,7 +451,11 @@ let pp_memory_order = function
 
 let pp_polarity = function Core.Pos -> !^"Pos" | Core.Neg -> !^"Neg"
 
-let pp_lexing_position { Lexing.pos_fname; pos_lnum; pos_bol; pos_cnum } =
+(* XXX: use the original source locations? *)
+let pp_lexing_position pos =
+  let { Lexing.pos_fname; pos_lnum; pos_bol; pos_cnum } =
+    Cerb_position.to_file_lexing pos
+  in
   pp_record
     [ ("pos_fname", pp_string pos_fname);
       ("pos_lnum", pp_nat pos_lnum);

--- a/backend/cn/lib/setup.ml
+++ b/backend/cn/lib/setup.ml
@@ -23,7 +23,7 @@ let cpp_str macros_def incl_dirs incl_files =
      @ [ " -DDEBUG -DCN_MODE" ])
 
 
-let conf macros incl_dirs incl_files astprints =
+let conf macros incl_dirs incl_files astprints save_cpp =
   { debug_level = 0;
     pprints = [];
     astprints;
@@ -33,5 +33,6 @@ let conf macros incl_dirs incl_files astprints =
     rewrite_core = true;
     sequentialise_core = true;
     cpp_cmd = cpp_str macros incl_dirs incl_files;
-    cpp_stderr = true
+    cpp_stderr = true;
+    cpp_save = save_cpp
   }

--- a/backend/cn/lib/setup.mli
+++ b/backend/cn/lib/setup.mli
@@ -11,4 +11,5 @@ val conf
   string list ->
   string list ->
   Cerb_backend.Pipeline.language list ->
+  string option ->
   Cerb_backend.Pipeline.configuration

--- a/backend/cn/lib/source_injection.mli
+++ b/backend/cn/lib/source_injection.mli
@@ -1,18 +1,24 @@
 open Cerb_frontend
 
 type 'a cn_injection =
-  { filename : string;
+  { filename : string; (** The file we are going to be injecting into *)
     program : 'a AilSyntax.ail_program;
+    (** The processed form of the program in [filename].
+        This is used to find the locations of the symbols in [pre_post]. *)
     pre_post : (Symbol.sym * (string list * string list)) list;
+    (** Pre- and post-condition checks to inject for the given symbols.
+        The locations of the symbols are found by consulting [program]. *)
     in_stmt : (Cerb_location.t * string list) list;
-    returns : (Cerb_location.t * 'a AilSyntax.expression option * string list) list
+    (** Additional statement injections to insert at the given locations. *)
+    returns : (Cerb_location.t * 'a AilSyntax.expression option * string list) list;
+    (** Injections to add when a function returns. *)
+    inject_in_preproc : bool
+    (** Should we inject using pre-processed locations (true) or not (false). *)
   }
 
+(** [output_injections oc inj] performs the injections specified by [inj]
+    and outputs them to channel [oc] *)
 val output_injections
   :  Stdlib.out_channel ->
   'a cn_injection ->
   (unit, string) Result.result
-
-val get_magics_of_statement
-  :  'a AilSyntax.statement ->
-  (Cerb_location.t * string) list list

--- a/backend/common/pipeline.ml
+++ b/backend/common/pipeline.ml
@@ -80,6 +80,7 @@ type configuration = {
   sequentialise_core: bool;
   cpp_cmd: string;
   cpp_stderr: bool; (* pipe cpp stderr to stderr *)
+  cpp_save: string option;
 }
 
 type io_helpers = {
@@ -163,7 +164,17 @@ let cpp (conf, io) ~filename =
       if n <> 0 then
         Exception.fail (Cerb_location.unknown, Errors.CPP (String.concat "\n" err))
       else
-        return @@ String.concat "\n" out
+        let txt = String.concat "\n" out in
+        (match conf.cpp_save with
+        | None -> ()
+        | Some cpp_file ->
+          try 
+            let out = open_out cpp_file in
+            Printf.fprintf out "%s" txt;
+            close_out out
+          with e -> ()
+        );
+        return txt
   end ()
 
 let c_frontend ?(cn_init_scope=Cn_desugaring.empty_init) (conf, io) (core_stdlib, core_impl) ~filename =

--- a/backend/common/pipeline.mli
+++ b/backend/common/pipeline.mli
@@ -18,6 +18,7 @@ type configuration = {
   sequentialise_core: bool;
   cpp_cmd: string;
   cpp_stderr: bool;
+  cpp_save: string option; (* Save the result of pre-processing to this file *)
 }
 
 type io_helpers = {

--- a/backend/driver/main.ml
+++ b/backend/driver/main.ml
@@ -125,7 +125,7 @@ let cerberus debug_level progress core_obj
   (* set global configuration *)
   set_cerb_conf ~backend_name:"Driver" ~exec exec_mode ~concurrency QuoteStd ~defacto ~permissive ~agnostic ~ignore_bitfields;
   let conf = { astprints; pprints; ppflags; ppouts; debug_level; typecheck_core;
-               rewrite_core; sequentialise_core; cpp_cmd; cpp_stderr = true } in
+               rewrite_core; sequentialise_core; cpp_cmd; cpp_stderr = true; cpp_save = None } in
   let prelude =
     (* Looking for and parsing the core standard library *)
     let switches =

--- a/memory/cheri-coq/impl_mem.ml
+++ b/memory/cheri-coq/impl_mem.ml
@@ -44,12 +44,13 @@ end
 
 module CerbTagDefs = struct
 
-  let toCoq_lexing_position (lp:Lexing.position): CoqLocation.lexing_position =
+  let toCoq_lexing_position (lp:Cerb_position.t): CoqLocation.lexing_position =
+    let f = Cerb_position.to_file_lexing lp in
     {
-      pos_fname = lp.pos_fname;
-      pos_lnum = Z.of_int lp.pos_lnum;
-      pos_bol = Z.of_int lp.pos_bol;
-      pos_cnum = Z.of_int lp.pos_cnum;
+      pos_fname = Cerb_position.file lp;
+      pos_lnum = Z.of_int (Cerb_position.line lp);
+      pos_bol = Z.of_int f.pos_bol;
+      pos_cnum = Z.of_int f.pos_cnum;
     }
 
   let toCoq_location_cursor: Cerb_location.cursor -> CoqLocation.location_cursor = function
@@ -339,13 +340,14 @@ module CHERIMorello : Memory = struct
     | Coq_inl errs -> failwith errs
     | Coq_inr v -> v
 
-  let fromCoq_lexing_position (lp:CoqLocation.lexing_position): Lexing.position =
+  let fromCoq_lexing_position (lp:CoqLocation.lexing_position): Cerb_position.t =
+    let pos: Lexing.position =
     {
       pos_fname = lp.pos_fname;
       pos_lnum = Z.to_int lp.pos_lnum;
       pos_bol = Z.to_int lp.pos_bol;
       pos_cnum = Z.to_int lp.pos_cnum;
-    }
+    } in Cerb_position.from_lexing pos
 
   let fromCoq_location_cursor: CoqLocation.location_cursor -> Cerb_location.cursor = function
     | NoCursor -> NoCursor

--- a/parsers/c/c_parser_driver.mli
+++ b/parsers/c/c_parser_driver.mli
@@ -1,0 +1,41 @@
+
+(** Run only the lexer on a given string.
+The result is (token string, (line,column))
+XXX: It might be nice to generalize this to show both source and file locs.
+*)
+val diagnostic_get_tokens :
+  inside_cn:bool ->
+  Cerb_location.t -> string -> string list * (int * int) list
+
+
+(** Parse something in CN.
+The first argument is the thing we are parsing,
+the second one is a located string that needs to be parsed. *)
+val parse_loc_string :
+  ((Lexing.lexbuf -> Tokens.token) -> Lexing.lexbuf -> 'a) ->
+  Cerb_location.t * string ->
+  ('a, Cerb_location.t * Cerb_frontend.Errors.cause)
+  Cerb_frontend.Exception.exceptM
+
+
+(** Parse a C translation unit from a file.
+The first argument is the name of the file to parse. *)
+val parse_from_channel :
+  string ->
+  (Cerb_frontend.Cabs.translation_unit,
+   Cerb_location.t * Cerb_frontend.Errors.cause)
+  Cerb_frontend.Exception.exceptM
+
+
+(** Parse a C translation unit from the given string.
+
+When working with a pre-processed file, the name should be the
+name of the preprocessed file.  The original source name can be recovered
+from the pre-processing annotations.
+*)
+val parse_from_string :
+  filename:string ->
+  string ->
+  (Cerb_frontend.Cabs.translation_unit,
+   Cerb_location.t * Cerb_frontend.Errors.cause)
+  Cerb_frontend.Exception.exceptM

--- a/parsers/core/core_lexer.mll
+++ b/parsers/core/core_lexer.mll
@@ -202,7 +202,8 @@ let scan_sym lexbuf =
   try
     Pmap.find id keywords
   with Not_found ->
-    T.SYM (id, (Lexing.lexeme_start_p lexbuf, Lexing.lexeme_end_p lexbuf))
+    let get_pos f = Cerb_position.from_lexing (f lexbuf) in
+    T.SYM (id, (get_pos Lexing.lexeme_start_p, get_pos Lexing.lexeme_end_p))
 
 
 let scan_impl lexbuf =

--- a/parsers/core/core_parser_driver.ml
+++ b/parsers/core/core_parser_driver.ml
@@ -16,19 +16,20 @@ let genparse mode std filename =
     let lexbuf = Lexing.from_channel ic in
     (* TODO: I don't know why Lexing is losing the filename information!! *)
     lexbuf.lex_curr_p <- { lexbuf.lex_curr_p  with pos_fname= filename };
+    let to_pos = Cerb_position.from_lexing in
     try
       Exception.except_return @@ Parser.start Core_lexer.main lexbuf
     with
       | Core_lexer.Error cause ->
-          let loc = Cerb_location.point @@ Lexing.lexeme_start_p lexbuf in
+          let loc = Cerb_location.point (to_pos (Lexing.lexeme_start_p lexbuf)) in
           Exception.fail (loc, Errors.(CORE_PARSER (Core_lexer cause)))
       | Parser.Error ->
-          let loc = Cerb_location.(region (Lexing.lexeme_start_p lexbuf, Lexing.lexeme_end_p lexbuf) NoCursor) in
+          let loc = Cerb_location.(region (to_pos (Lexing.lexeme_start_p lexbuf), to_pos (Lexing.lexeme_end_p lexbuf)) NoCursor) in
           Exception.fail (loc, Errors.(CORE_PARSER (Core_parser_unexpected_token (Lexing.lexeme lexbuf))))
       | Core_parser_util.Core_error (loc, err) ->
           Exception.fail (loc, Errors.CORE_PARSER err)
       | exn ->
-          let loc = Cerb_location.point @@ Lexing.lexeme_start_p lexbuf in
+          let loc = Cerb_location.point (to_pos (Lexing.lexeme_start_p lexbuf)) in
           let str = Printf.sprintf "[uncaught exception] '%s'" (String.escaped (Printexc.to_string_default exn)) in
           Exception.fail (loc, Errors.(CORE_PARSER (Core_parser_internal_error str)))
   in
@@ -44,7 +45,7 @@ let parse stdlib =
         let Symbol (_, _, sd) = fsym in
         match sd with
         | SD_Id str ->
-          let std_pos = {Lexing.dummy_pos with Lexing.pos_fname= "core_stdlib"} in
+          let std_pos = Cerb_position.from_lexing {Lexing.dummy_pos with Lexing.pos_fname= "core_stdlib"} in
           Pmap.add (str, (std_pos, std_pos)) fsym acc
         | SD_unnamed_tag _
         | SD_CN_Id _

--- a/parsers/core/core_parser_util.ml
+++ b/parsers/core/core_parser_util.ml
@@ -1,7 +1,7 @@
 open Cerb_frontend
 
 type _sym =
-  string * (Lexing.position * Lexing.position)
+  string * (Cerb_position.t * Cerb_position.t)
 
 let _sym_compare (str1, _) (str2, _) =
   compare str1 str2

--- a/util/cerb_location.mli
+++ b/util/cerb_location.mli
@@ -1,26 +1,27 @@
+
 type cursor =
   | NoCursor
-  | PointCursor of Lexing.position
-  | RegionCursor of Lexing.position * Lexing.position
+  | PointCursor of Cerb_position.t
+  | RegionCursor of Cerb_position.t * Cerb_position.t
 
 type t = private
   | Loc_unknown
   | Loc_other of string
-  | Loc_point of Lexing.position
+  | Loc_point of Cerb_position.t
     (* start, end, cursor *)
-  | Loc_region of Lexing.position * Lexing.position * cursor
-  | Loc_regions of (Lexing.position * Lexing.position) list * cursor
+  | Loc_region of Cerb_position.t * Cerb_position.t * cursor
+  | Loc_regions of (Cerb_position.t * Cerb_position.t) list * cursor
 
 val unknown: t
 val is_unknown_location: t -> bool
 val other: string -> t
-val point: Lexing.position -> t
-val region: Lexing.position * Lexing.position -> cursor -> t
-val regions: (Lexing.position * Lexing.position) list -> cursor -> t
+val point: Cerb_position.t -> t
+val region: Cerb_position.t * Cerb_position.t -> cursor -> t
+val regions: (Cerb_position.t * Cerb_position.t) list -> cursor -> t
 
 val with_cursor: t -> t (* NOTE: useful when pointing to an expanded macro *)
 val with_cursor_from: t -> t -> t
-val bbox: t list -> [ `Bbox of Lexing.position * Lexing.position | `Other of t ]
+val bbox: t list -> [ `Bbox of Cerb_position.t * Cerb_position.t | `Other of t ]
 val bbox_location: t list -> t
 val with_regions_and_cursor: t list -> t option -> t
 
@@ -28,7 +29,19 @@ val from_main_file: t -> bool
 val location_to_string: ?charon:bool -> t -> string
 
 val to_json: t -> Cerb_json.json
-val to_cartesian: t -> ((int * int) * (int * int)) option
+
+(** The range corresponding to this location, in the user visible source.
+Returns ((start_line, start_col), (end_line, end_col)) *)
+val to_cartesian_user: t -> ((int * int) * (int * int)) option
+
+
+(** The range corresponding to this location,
+in the actual (pre-processed) source.
+Returns ((start_line, start_col), (end_line, end_col)) *)
+val to_cartesian_raw: t -> ((int * int) * (int * int)) option
+
+
+
 val print_location: t -> PPrint.document
 val pp_location: ?clever:bool -> t -> PPrint.document
 val head_pos_of_location: t -> (string * string)

--- a/util/cerb_position.ml
+++ b/util/cerb_position.ml
@@ -1,0 +1,66 @@
+
+(* The lexing position is the real location in the file parsed.
+In particular, this is likely a file that was produced by the pre-processor.
+The `source_file` and `source_line` refer to the locations in the original
+source, if one is available, otherwise they should match what's in `file`.
+*)
+type t = {
+  file: Lexing.position; (* position in the pre-processed file *)
+  source_file: string;   (* file containing the original source *)
+  source_line: int;      (* line number in the original file *)
+}
+
+let dummy = { file = Lexing.dummy_pos; source_file = ""; source_line = 0 }
+
+let from_lexing p =
+  { file = p; source_file = p.pos_fname; source_line = p.pos_lnum; }
+
+let line pos = pos.source_line
+let file pos = pos.source_file
+
+
+(* Column for this position, 1 based *)
+let column pos =
+  let f = pos.file in
+  Lexing.(1 + f.pos_cnum - f.pos_bol)
+
+let to_file_lexing p = p.file
+
+let change_cnum pos n =
+  { pos with file = { pos.file with pos_cnum = pos.file.pos_cnum + n } }
+
+let set_source (f,n) pos = { pos with source_file = f; source_line = n }
+
+
+module LineMap = struct
+  module Map = Map.Make(Int)
+
+  type t = {
+    file:   string;               (* pre-processed file *)
+    lines:  (string * int) Map.t 
+    (* The map associates lines in the pre-processed file with
+       declarations about the original source (file, line number).
+       We keep a whole map, rather than just the last locations,
+       to support parsing in mulitple passes.  For example, we first parse
+       CN magic comments as just a literal, and then we parse them fully
+       in a secondary pass. *)
+
+
+  }
+
+  let empty file = { file = file; lines = Map.empty }
+
+  let add k v mp = { mp with lines = Map.add k v mp.lines }
+
+  let lookup k mp =
+    match Map.find_last_opt (fun l -> l < k) mp.lines with
+    | None           -> (mp.file, k)
+    | Some (l,(f,n)) -> (f, n + (k - l - 1))
+
+  let dump mp =
+    Printf.printf "+--- %s\n" mp.file;
+    Map.iter (fun k (f,n) ->
+      Printf.printf "| %d: %s:%d\n" k f n
+    ) mp.lines;
+    Printf.printf "+--------------------\n"
+end

--- a/util/cerb_position.mli
+++ b/util/cerb_position.mli
@@ -1,0 +1,53 @@
+type t
+
+(** A placeholder position *)
+val dummy: t
+
+(** A position in the pre-processed file. The source file and line are
+the same as the pre-processed file *)
+val from_lexing: Lexing.position -> t
+
+(** Change the column number by the given amount. *)
+val change_cnum: t -> int -> t
+
+(** Set the file and line in the original source file. *)
+val set_source: (string * int) -> t -> t
+
+(** Source file for position *)
+val file: t -> string
+
+(** Source line for the position. 1 based *)
+val line: t -> int
+
+(** Column of position, 1 based. *)
+val column: t -> int
+
+
+(** Location in the pre-processed file *)
+val to_file_lexing: t -> Lexing.position
+
+
+
+module LineMap : sig
+  (** Information about original source locations in a pre-processed file. *)
+  type t
+
+  (** No source location information. The argument is the name of the
+      pre-processed file, which will be used for locations that have no
+      additional information. *)
+  val empty: string -> t
+
+  (** [add line (srouce_file, souce_line) mp] updates [mp] with the
+      information that on line [line] of the pre-processd file there was
+      a declaration that the following lines
+      correspond to [(source_file,souce_line)] *)
+  val add: int -> (string * int) -> t -> t
+
+  (** [lookup line mp] consults [mp] to get source information about [line]
+      in the prepcoessed file.   If there is no additional source information
+      we return a location in the pre-processed file. *)
+  val lookup: int -> t -> (string * int)
+
+  (** Display the line map, for debugging. *)
+  val dump: t -> unit
+end


### PR DESCRIPTION
This is the first step of solving #823.

We introduce a new module `Cerb_location.position`, which defines a type replacing `Lexing.position` as the base type to use for positions. Values of the new position type keep the `Lexing.position` corresponding to the actual location in the preprocessed file, as well as the file name and line in the original source associated with the location.