### PR TITLE
Makefile: replace `which` with `command -v` (#895)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 # Checking for required tools.
-ifeq (,$(shell which dune 2> /dev/null))
+ifeq (,$(shell command -v dune 2> /dev/null))
 $(error "Compilation requires [dune].")
 endif
-ifeq (,$(shell which lem 2> /dev/null))
+ifeq (,$(shell command -v lem 2> /dev/null))
 $(error "Compilation requires [lem].")
 endif
 


### PR DESCRIPTION
Preserves functionality completely, but allows it to be built on some slightly exotic distros that have a different relationship with sandboxing than current assumptions. 

Closes #895 

See threads: 
- [coq discourse](https://coq.discourse.group/t/refinedc-install-make-under-opam-cant-find-dune/2544)
- [opam issues](https://github.com/ocaml/opam/issues/6405)