### PR TITLE
CN: Deprecate use of Generic error constructor

### DIFF
--- a/backend/cn/lib/cLogicalFuns.ml
+++ b/backend/cn/lib/cLogicalFuns.ml
@@ -67,7 +67,12 @@ let is_local_ptr ptr =
 
 let get_local_ptr loc ptr =
   match is_local_ptr ptr with
-  | None -> fail_n { loc; msg = Generic (Pp.item "use of non-local pointer" (IT.pp ptr)) }
+  | None ->
+    fail_n
+      { loc;
+        msg =
+          Generic (Pp.item "use of non-local pointer" (IT.pp ptr)) [@alert "-deprecated"]
+      }
   | Some ix -> return ix
 
 
@@ -89,7 +94,7 @@ let simp_const loc lpp it =
           Generic
             (Pp.item
                "getting expr from C syntax: failed to simplify integer to numeral"
-               (Pp.typ (Lazy.force lpp) (IT.pp it2)))
+               (Pp.typ (Lazy.force lpp) (IT.pp it2))) [@alert "-deprecated"]
       }
   | _, _ -> return it2
 
@@ -106,7 +111,8 @@ let do_wrapI loc ct it =
     fail_n
       { loc;
         msg =
-          Generic (Pp.item "expr from C syntax: coercion to non-int type" (Sctypes.pp ct))
+          Generic (Pp.item "expr from C syntax: coercion to non-int type" (Sctypes.pp ct)) 
+          [@alert "-deprecated"]
       }
 
 
@@ -141,7 +147,8 @@ let rec add_pattern p v var_map =
               Generic
                 (Pp.item
                    "getting expr from C syntax: cannot tuple-split val"
-                   (Pp.typ (IT.pp it) (Pp_mucore.Basic.pp_pattern p)))
+                   (Pp.typ (IT.pp it) (Pp_mucore.Basic.pp_pattern p))) [@alert
+                                                                         "-deprecated"]
           }
     in
     assert (List.length vs == List.length ps);
@@ -156,7 +163,7 @@ let rec add_pattern p v var_map =
           Generic
             (Pp.item
                "getting expr from C syntax: unsupported pattern"
-               (Pp_mucore.Basic.pp_pattern p))
+               (Pp_mucore.Basic.pp_pattern p)) [@alert "-deprecated"]
       }
 
 
@@ -198,7 +205,7 @@ let eval_fun f args orig_pexpr =
                  "function application result out of range"
                  (Pp_mucore_ast.pp_pexpr orig_pexpr
                   ^^ Pp.hardline
-                  ^^ Pp.typ (Pp.z z) (BT.pp bt)))
+                  ^^ Pp.typ (Pp.z z) (BT.pp bt))) [@alert "-deprecated"]
         }
   | None ->
     fail_n
@@ -210,7 +217,7 @@ let eval_fun f args orig_pexpr =
                (Pp_mucore_ast.pp_pexpr orig_pexpr
                 ^^ Pp.hardline
                 ^^ !^"arg vals:"
-                ^^^ Pp.brackets (Pp.list IT.pp args)))
+                ^^^ Pp.brackets (Pp.list IT.pp args))) [@alert "-deprecated"]
       }
 
 
@@ -237,7 +244,7 @@ let rec symb_exec_pexpr ctxt var_map pexpr =
           Generic
             (Pp.item
                ("getting expr from C syntax: unsupported: " ^ msg)
-               (Pp.typ doc (Pp_mucore_ast.pp_pexpr pexpr)))
+               (Pp.typ doc (Pp_mucore_ast.pp_pexpr pexpr))) [@alert "-deprecated"]
       }
   in
   match pe with
@@ -354,7 +361,9 @@ let rec symb_exec_pexpr ctxt var_map pexpr =
       | None ->
         fail_n
           { loc;
-            msg = Generic (Pp.item "expr from C syntax: non-constant type" (IT.pp ct_it))
+            msg =
+              Generic (Pp.item "expr from C syntax: non-constant type" (IT.pp ct_it)) [@alert
+                                                                                        "-deprecated"]
           }
     in
     (match ct with
@@ -402,7 +411,8 @@ let rec symb_exec_pexpr ctxt var_map pexpr =
              Generic
                (Pp.item
                   "getting expr from C syntax: c-function ptr"
-                  (Pp.typ (IT.pp x) (Pp_mucore_ast.pp_pexpr pexpr)))
+                  (Pp.typ (IT.pp x) (Pp_mucore_ast.pp_pexpr pexpr))) [@alert
+                                                                       "-deprecated"]
          })
   | _ -> unsupported "pure-expression type" !^""
 
@@ -465,7 +475,9 @@ let rec symb_exec_expr ctxt state_vars expr =
       | Call_Ret _ ->
         fail_n
           { loc;
-            msg = Generic (Pp.item "unsequenced return" (Pp_mucore.pp_expr orig_expr))
+            msg =
+              Generic (Pp.item "unsequenced return" (Pp_mucore.pp_expr orig_expr)) [@alert
+                                                                                     "-deprecated"]
           }
       | Compute (v, state) -> cont1 state (v :: exp_vals) exps
       | If_Else (t, x, y) ->
@@ -481,7 +493,12 @@ let rec symb_exec_expr ctxt state_vars expr =
        assert (List.length args == 1);
        return (Call_Ret (List.hd arg_vs))
      | _ ->
-       fail_n { loc; msg = Generic Pp.(!^"function has goto-labels in control-flow") })
+       fail_n
+         { loc;
+           msg =
+             Generic Pp.(!^"function has goto-labels in control-flow") [@alert
+                                                                         "-deprecated"]
+         })
   | Ebound ex -> symb_exec_expr ctxt (state, var_map) ex
   | Eaction (Paction (_, Action (_, action))) ->
     (match action with
@@ -500,10 +517,18 @@ let rec symb_exec_expr ctxt state_vars expr =
          match IntMap.find_opt ix state.loc_map with
          | None ->
            fail_n
-             { loc; msg = Generic (Pp.item "unavailable memory address" (IT.pp p_v)) }
+             { loc;
+               msg =
+                 Generic (Pp.item "unavailable memory address" (IT.pp p_v)) [@alert
+                                                                              "-deprecated"]
+             }
          | Some None ->
            fail_n
-             { loc; msg = Generic (Pp.item "uninitialised memory address" (IT.pp p_v)) }
+             { loc;
+               msg =
+                 Generic (Pp.item "uninitialised memory address" (IT.pp p_v)) [@alert
+                                                                                "-deprecated"]
+             }
          | Some (Some ix) -> return ix
        in
        rcval v state
@@ -518,7 +543,7 @@ let rec symb_exec_expr ctxt state_vars expr =
              Generic
                (Pp.item
                   "getting expr from C syntax: unsupported memory op"
-                  (Pp_mucore.pp_expr expr))
+                  (Pp_mucore.pp_expr expr)) [@alert "-deprecated"]
          })
   | Eccall (_act, fun_pe, args_pe) ->
     let@ fun_it = symb_exec_pexpr ctxt var_map fun_pe in
@@ -530,7 +555,8 @@ let rec symb_exec_expr ctxt state_vars expr =
             Generic
               (Pp.item
                  ("getting expr from C syntax: function val: " ^ msg)
-                 (Pp.typ (Pp_mucore.pp_pexpr fun_pe) (IT.pp fun_it)))
+                 (Pp.typ (Pp_mucore.pp_pexpr fun_pe) (IT.pp fun_it))) [@alert
+                                                                        "-deprecated"]
         }
     in
     let@ nm =
@@ -565,7 +591,8 @@ let rec symb_exec_expr ctxt state_vars expr =
       { loc;
         msg =
           Generic
-            (Pp.item "getting expr from C syntax: unsupported" (Pp_mucore.pp_expr expr))
+            (Pp.item "getting expr from C syntax: unsupported" (Pp_mucore.pp_expr expr)) [@alert
+                                                                                          "-deprecated"]
       }
 
 
@@ -598,7 +625,7 @@ let rec get_ret_it loc body bt = function
               Generic
                 (Pp.item
                    "get_ret_it: basetype mismatch"
-                   (Pp.infix_arrow (IT.pp_with_typ v) (BT.pp bt)))
+                   (Pp.infix_arrow (IT.pp_with_typ v) (BT.pp bt))) [@alert "-deprecated"]
           }
     in
     return v
@@ -609,7 +636,7 @@ let rec get_ret_it loc body bt = function
           Generic
             (Pp.item
                "cn_function c->logical conversion: does not return"
-               (Pp_mucore.pp_expr body))
+               (Pp_mucore.pp_expr body)) [@alert "-deprecated"]
       }
   | If_Else (t, x, y) ->
     let@ x_v = get_ret_it loc body bt x in
@@ -652,7 +679,7 @@ let c_fun_to_it id_loc glob_context (id : Sym.t) fsym def (fn : 'bty Mu.fun_map_
                     !^"mismatched arguments:"
                     ^^^ parens (BT.pp (IT.get_bt v) ^^^ IT.pp v)
                     ^^^ !^"and"
-                    ^^^ parens (BT.pp bt ^^^ Sym.pp s))
+                    ^^^ parens (BT.pp bt ^^^ Sym.pp s)) [@alert "-deprecated"]
             }
       | L l, [] -> return (acc, ignore_l l)
       | _ ->
@@ -662,7 +689,7 @@ let c_fun_to_it id_loc glob_context (id : Sym.t) fsym def (fn : 'bty Mu.fun_map_
               Generic
                 Pp.(
                   !^"mismatched argument number for"
-                  ^^^ Pp.infix_arrow (Sym.pp fsym) (Sym.pp id))
+                  ^^^ Pp.infix_arrow (Sym.pp fsym) (Sym.pp id)) [@alert "-deprecated"]
           }
     in
     let rec in_computational_ctxt args_and_body m =
@@ -689,7 +716,7 @@ let c_fun_to_it id_loc glob_context (id : Sym.t) fsym def (fn : 'bty Mu.fun_map_
                      "cn_function: return-type mismatch"
                      (Pp.infix_arrow
                         (Pp.typ (Sym.pp fsym) (BT.pp bt))
-                        (Pp.typ (Sym.pp id) (BT.pp l_ret_bt))))
+                        (Pp.typ (Sym.pp id) (BT.pp l_ret_bt)))) [@alert "-deprecated"]
             }
     in
     let ctxt = { glob_context with label_defs = labels } in
@@ -703,7 +730,9 @@ let c_fun_to_it id_loc glob_context (id : Sym.t) fsym def (fn : 'bty Mu.fun_map_
   | _ ->
     fail_n
       { loc = id_loc;
-        msg = Generic (Pp.string ("cn_function: not defined: " ^ Sym.pp_string fsym))
+        msg =
+          Generic (Pp.string ("cn_function: not defined: " ^ Sym.pp_string fsym)) [@alert
+                                                                                    "-deprecated"]
       }
 
 
@@ -716,7 +745,8 @@ let upd_def (loc, sym, def_tm) =
     fail_n
       { loc;
         msg =
-          Generic (Pp.typ (Pp.string "logical predicate already defined") (Sym.pp sym))
+          Generic (Pp.typ (Pp.string "logical predicate already defined") (Sym.pp sym)) [@alert
+                                                                                          "-deprecated"]
       }
 
 

--- a/backend/cn/lib/check.ml
+++ b/backend/cn/lib/check.ml
@@ -215,7 +215,7 @@ let rec check_object_value (loc : Locations.t) (Mu.OV (expect, ov)) : IT.t m =
           msg =
             Generic
               (!^"integer literal not representable at type"
-               ^^^ Pp.typ (Pp.z z) (BT.pp expect))
+               ^^^ Pp.typ (Pp.z z) (BT.pp expect)) [@alert "-deprecated"]
         })
   | OVpointer p -> check_ptrval loc ~expect p
   | OVarray items ->
@@ -319,7 +319,10 @@ let try_prove_constant loc expr =
   | None ->
     (* backup strategy, try to figure out the single value *)
     let fail2 msg =
-      fail (fun _ -> { loc; msg = Generic (!^"model constant calculation:" ^^^ !^msg) })
+      fail (fun _ ->
+        { loc;
+          msg = Generic (!^"model constant calculation:" ^^^ !^msg) [@alert "-deprecated"]
+        })
     in
     let fail_on_none msg = function Some m -> return m | None -> fail2 msg in
     let here = Locations.other __LOC__ in
@@ -343,7 +346,11 @@ let check_single_ct loc expr =
   | Some (IT.CType_const ct, _) -> return ct
   | Some _ -> assert false (* should be impossible given the type *)
   | None ->
-    fail (fun _ -> { loc; msg = Generic !^"use of non-constant ctype mucore expression" })
+    fail (fun _ ->
+      { loc;
+        msg =
+          Generic !^"use of non-constant ctype mucore expression" [@alert "-deprecated"]
+      })
 
 
 let is_fun_addr global t =
@@ -379,7 +386,7 @@ let known_function_pointer loc p =
           Generic
             (Pp.item
                "function pointer must be provably equal to a defined function"
-               (IT.pp p))
+               (IT.pp p)) [@alert "-deprecated"]
       })
 
 
@@ -425,7 +432,8 @@ let check_conv_int loc ~expect ct arg =
 
 let check_against_core_bt loc msg2 cbt bt =
   CoreTypeChecks.check_against_core_bt cbt bt
-  |> Result.map_error (fun msg -> { loc; msg = Generic (msg ^^ Pp.hardline ^^ msg2) })
+  |> Result.map_error (fun msg ->
+    { loc; msg = Generic (msg ^^ Pp.hardline ^^ msg2) [@alert "-deprecated"] })
   |> Typing.lift
 
 
@@ -772,7 +780,8 @@ let rec check_pexpr (pe : BT.t Mu.pexpr) (k : IT.t -> unit m) : unit m =
              { loc;
                msg =
                  Generic
-                   (Pp.item "untypeable mucore function" (Pp_mucore_ast.pp_pexpr orig_pe))
+                   (Pp.item "untypeable mucore function" (Pp_mucore_ast.pp_pexpr orig_pe)) 
+                 [@alert "-deprecated"]
              })
        in
        let expect_args = Mucore.fun_param_types fun_id in
@@ -825,7 +834,11 @@ let rec check_pexpr (pe : BT.t Mu.pexpr) (k : IT.t -> unit m) : unit m =
          | Some it -> k it
          | None ->
            fail (fun _ ->
-             { loc; msg = Generic (!^"unsupported c-type in sig of:" ^^^ Sym.pp sym) }))
+             { loc;
+               msg =
+                 Generic (!^"unsupported c-type in sig of:" ^^^ Sym.pp sym) [@alert
+                                                                              "-deprecated"]
+             }))
      | PEmemberof _ -> Cerb_debug.error "todo: PEmemberof"
      | PEbool_to_integer pe ->
        let@ _ = ensure_bitvector_type loc ~expect in
@@ -1220,7 +1233,7 @@ let _check_used_distinct loc used =
                      ^^^ break 1
                      ^^^ render_upd h
                      ^^^ break 1
-                     ^^^ render_upd h2))
+                     ^^^ render_upd h2)) [@alert "-deprecated"]
            }))
   in
   let@ w_map = check_ws IntMap.empty (List.concat (List.map snd used)) in
@@ -1239,7 +1252,7 @@ let _check_used_distinct loc used =
                   ^^^ break 1
                   ^^^ render_read h
                   ^^^ break 1
-                  ^^^ render_upd h2))
+                  ^^^ render_upd h2)) [@alert "-deprecated"]
         })
   in
   ListM.iterM check_rd (List.concat (List.map fst used))
@@ -1780,7 +1793,11 @@ let rec check_expr labels (e : BT.t Mu.expr) (k : IT.t -> unit m) : unit m =
            | Some ft -> return ft
            | None ->
              fail (fun _ ->
-               { loc; msg = Generic (!^"Call to function with no spec:" ^^^ Sym.pp fsym) })
+               { loc;
+                 msg =
+                   Generic (!^"Call to function with no spec:" ^^^ Sym.pp fsym) [@alert
+                                                                                  "-deprecated"]
+               })
          in
          (* checks pes against their annotations, and that they match ft's argument types *)
          Spine.calltype_ft loc ~fsym pes ft (fun (Computational ((_, bt), _, _) as rt) ->
@@ -1947,7 +1964,10 @@ let rec check_expr labels (e : BT.t Mu.expr) (k : IT.t -> unit m) : unit m =
             | Init -> add_c loc (LC.T (bytes_constraints ~value ~byte_arr ct)))
          | Have lc ->
            let@ _lc = WellTyped.logical_constraint loc lc in
-           fail (fun _ -> { loc; msg = Generic !^"todo: 'have' not implemented yet" })
+           fail (fun _ ->
+             { loc;
+               msg = Generic !^"todo: 'have' not implemented yet" [@alert "-deprecated"]
+             })
          | Instantiate (to_instantiate, it) ->
            let@ filter =
              match to_instantiate with
@@ -1967,16 +1987,16 @@ let rec check_expr labels (e : BT.t Mu.expr) (k : IT.t -> unit m) : unit m =
              match to_extract with
              | E_Everything ->
                let msg = "'extract' requires a predicate name annotation" in
-               fail (fun _ -> { loc; msg = Generic !^msg })
+               fail (fun _ -> { loc; msg = Generic !^msg [@alert "-deprecated"] })
              | E_Pred (CN_owned None) ->
                let msg = "'extract' requires a C-type annotation for 'Owned'" in
-               fail (fun _ -> { loc; msg = Generic !^msg })
+               fail (fun _ -> { loc; msg = Generic !^msg [@alert "-deprecated"] })
              | E_Pred (CN_owned (Some ct)) ->
                let@ () = WellTyped.check_ct loc ct in
                return (Request.Owned (ct, Init))
              | E_Pred (CN_block None) ->
                let msg = "'extract' requires a C-type annotation for 'Block'" in
-               fail (fun _ -> { loc; msg = Generic !^msg })
+               fail (fun _ -> { loc; msg = Generic !^msg [@alert "-deprecated"] })
              | E_Pred (CN_block (Some ct)) ->
                let@ () = WellTyped.check_ct loc ct in
                return (Request.Owned (ct, Uninit))
@@ -2016,7 +2036,7 @@ let rec check_expr labels (e : BT.t Mu.expr) (k : IT.t -> unit m) : unit m =
               let msg =
                 !^"Cannot unfold definition of uninterpreted function" ^^^ Sym.pp f ^^ dot
               in
-              fail (fun _ -> { loc; msg = Generic msg })
+              fail (fun _ -> { loc; msg = Generic msg [@alert "-deprecated"] })
             | Some body ->
               add_c loc (LC.T (eq_ (apply_ f args def.return_bt loc, body) loc)))
          | Apply (lemma, args) ->
@@ -2073,7 +2093,11 @@ let rec check_expr labels (e : BT.t Mu.expr) (k : IT.t -> unit m) : unit m =
                 | T it -> return it
                 | Forall ((_sym, _bt), _it) ->
                   fail (fun _ ->
-                    { loc; msg = Generic !^"Cannot split on forall condition" })
+                    { loc;
+                      msg =
+                        Generic !^"Cannot split on forall condition" [@alert
+                                                                       "-deprecated"]
+                    })
               in
               let branch it nm =
                 let@ () = add_c loc (LC.T it) in
@@ -2115,7 +2139,11 @@ let rec check_expr labels (e : BT.t Mu.expr) (k : IT.t -> unit m) : unit m =
          match Sym.Map.find_opt label_sym labels with
          | None ->
            fail (fun _ ->
-             { loc; msg = Generic (!^"undefined code label" ^/^ Sym.pp label_sym) })
+             { loc;
+               msg =
+                 Generic (!^"undefined code label" ^/^ Sym.pp label_sym) [@alert
+                                                                           "-deprecated"]
+             })
          | Some (lt, lkind, _) -> return (lt, lkind)
        in
        let@ original_resources = all_resources_tagged loc in
@@ -2137,7 +2165,7 @@ let check_expr_top loc labels rt e =
         return ())
     | _ ->
       let msg = "Non-void-return function does not call 'return'." in
-      fail (fun _ -> { loc; msg = Generic !^msg }))
+      fail (fun _ -> { loc; msg = Generic !^msg [@alert "-deprecated"] }))
 
 
 (* let check_pexpr_rt loc pexpr (RT.Computational ((return_s, return_bt), info, lrt)) = *)

--- a/backend/cn/lib/core_to_mucore.ml
+++ b/backend/cn/lib/core_to_mucore.ml
@@ -39,7 +39,7 @@ let do_ail_desugar_op desugar_state f =
   match f desugar_state with
   | CF.Exception.Result (x, st2) -> return (x, st2)
   | CF.Exception.Exception (loc, msg) ->
-    fail { loc; msg = Generic !^(CF.Pp_errors.short_message msg) }
+    fail { loc; msg = Generic !^(CF.Pp_errors.short_message msg) [@alert "-deprecated"] }
 
 
 let do_ail_desugar_rdonly desugar_state f =
@@ -931,7 +931,8 @@ let is_pass_by_pointer = function By_pointer -> true | By_value -> false
 
 let check_against_core_bt loc cbt bt =
   CoreTypeChecks.check_against_core_bt cbt bt
-  |> Result.map_error (fun msg -> TypeErrors.{ loc; msg = Generic msg })
+  |> Result.map_error (fun msg ->
+    TypeErrors.{ loc; msg = Generic msg [@alert "-deprecated"] })
 
 
 let make_label_args f_i loc env st args (accesses, inv) =
@@ -1018,7 +1019,7 @@ let make_fun_with_spec_args f_i loc env args (accesses, requires) =
                    ^^^ BT.pp bt
                    ^^^ parens (!^"from" ^^^ Sctypes.pp ct)
                    ^^^ !^"and"
-                   ^^^ BT.pp (SBT.proj sbt2))
+                   ^^^ BT.pp (SBT.proj sbt2)) [@alert "-deprecated"]
             }
       in
       let env = C.add_computational pure_arg sbt env in
@@ -1042,7 +1043,12 @@ let desugar_access d_st global_types (loc, id) =
     match var_kind with
     | Var_kind_c C_kind_var -> return ()
     | Var_kind_c C_kind_enum ->
-      fail { loc; msg = Generic !^"accesses: expected global, not enum constant" }
+      fail
+        { loc;
+          msg =
+            Generic !^"accesses: expected global, not enum constant" [@alert
+                                                                       "-deprecated"]
+        }
     | Var_kind_cn ->
       let msg =
         !^"The name"
@@ -1050,12 +1056,14 @@ let desugar_access d_st global_types (loc, id) =
         ^^^ !^"is not bound to a C global variable."
         ^^^ !^"Perhaps it has been shadowed by a CN variable?"
       in
-      fail { loc; msg = Generic msg }
+      fail { loc; msg = Generic msg [@alert "-deprecated"] }
   in
   let@ ct =
     match List.assoc_opt Sym.equal s global_types with
     | Some ct -> return (convert_ct loc ct)
-    | None -> fail { loc; msg = Generic (Sym.pp s ^^^ !^"is not a global") }
+    | None ->
+      fail
+        { loc; msg = Generic (Sym.pp s ^^^ !^"is not a global") [@alert "-deprecated"] }
   in
   let ct = Sctypes.to_ctype ct in
   return (loc, (s, ct))

--- a/backend/cn/lib/lemmata.ml
+++ b/backend/cn/lib/lemmata.ml
@@ -129,7 +129,7 @@ let fail msg details =
 
 (* print the error message, but continue with a default value when possible *)
 let fail_m rv loc msg =
-  let err = TypeErrors.{ loc; msg = Generic msg } in
+  let err = TypeErrors.{ loc; msg = Generic msg [@alert "-deprecated"] } in
   Pp.error loc msg [];
   let@ () = upd (fun st -> { st with failures = err :: st.failures }) in
   return rv

--- a/backend/cn/lib/resourceInference.ml
+++ b/backend/cn/lib/resourceInference.ml
@@ -263,7 +263,7 @@ module General = struct
             ^^ colon
             ^^^ IT.pp step)
         in
-        fail (fun _ -> { loc; msg = TypeErrors.Generic doc }))
+        fail (fun _ -> { loc; msg = TypeErrors.Generic doc [@alert "-deprecated"] }))
     in
     let@ (needed, oarg), rw_time =
       map_and_fold_resources

--- a/backend/cn/lib/typeErrors.ml
+++ b/backend/cn/lib/typeErrors.ml
@@ -175,12 +175,13 @@ type message =
         ctxt : Context.t * Explain.log;
         model : Solver.model_with_q
       }
-  | Generic of Pp.document (** TODO delete this *)
+  | Generic of Pp.document [@deprecated "Please add a specific constructor"]
+  (** TODO delete this *)
   | Generic_with_model of
       { err : document;
         model : Solver.model_with_q;
         ctxt : Context.t * Explain.log
-      }
+      } [@deprecated "Please add a specific constructor"]
   | Unsupported of document
   | Parser of Cerb_frontend.Errors.cparser_cause
   | Empty_provenance
@@ -300,7 +301,7 @@ let pp_welltyped = function
   | Empty_pattern ->
     let short = !^"Empty match expression." in
     { short; descr = None; state = None }
-  | Generic err ->
+  | ((Generic err) [@alert "-deprecated"]) ->
     let short = err in
     { short; descr = None; state = None }
   | Redundant_pattern p' ->
@@ -489,10 +490,10 @@ let pp_message = function
     let state = Explain.trace ctxt model Explain.no_ex in
     let descr = !^err in
     { short; descr = Some descr; state = Some state }
-  | Generic err ->
+  | ((Generic err) [@alert "-deprecated"]) ->
     let short = err in
     { short; descr = None; state = None }
-  | Generic_with_model { err; model; ctxt } ->
+  | ((Generic_with_model { err; model; ctxt }) [@alert "-deprecated"]) ->
     let short = err in
     let state = Explain.trace ctxt model Explain.no_ex in
     { short; descr = None; state = Some state }

--- a/backend/cn/lib/typeErrors.mli
+++ b/backend/cn/lib/typeErrors.mli
@@ -113,12 +113,13 @@ type message =
         ctxt : Context.t * Explain.log;
         model : Solver.model_with_q
       }
-  | Generic of Pp.document (** TODO delete this *)
+  | Generic of Pp.document [@deprecated "Please add a specific constructor"]
+  (** TODO delete this *)
   | Generic_with_model of
-      { err : Pp.document; (** TODO delete this too *)
+      { err : Pp.document;
         model : Solver.model_with_q;
         ctxt : Context.t * Explain.log
-      }
+      } [@deprecated "Please add a specific constructor"] (** TODO delete this too *)
   | Unsupported of Pp.document (** TODO add source location *)
   | Parser of Cerb_frontend.Errors.cparser_cause
   | Empty_provenance

--- a/backend/cn/lib/typing.ml
+++ b/backend/cn/lib/typing.ml
@@ -512,7 +512,10 @@ let do_check_model loc m prop =
   match prover (LogicalConstraints.T (IT.and_ (prop :: eqs) here)) with
   | `False -> return ()
   | `True ->
-    fail (fun _ -> { loc; msg = Generic (Pp.string "Solver model inconsistent") })
+    fail (fun _ ->
+      { loc;
+        msg = Generic (Pp.string "Solver model inconsistent") [@alert "-deprecated"]
+      })
 
 
 let cond_check_model loc m prop =

--- a/backend/cn/lib/wellTyped.mli
+++ b/backend/cn/lib/wellTyped.mli
@@ -6,7 +6,7 @@ type message =
       { has : Pp.document;
         expect : Pp.document
       }
-  | Generic of Pp.document
+  | Generic of Pp.document [@deprecated "Please add a specific constructor"]
   | Illtyped_it of
       { it : Pp.document;
         has : Pp.document;

--- a/tests/cn/tree16/as_mutual_dt/tree16.c.verify
+++ b/tests/cn/tree16/as_mutual_dt/tree16.c.verify
@@ -8,8 +8,8 @@ tests/cn/tree16/as_mutual_dt/tree16.c:111:19: warning: 'each' expects a 'u64', b
 tests/cn/tree16/as_mutual_dt/tree16.c:121:18: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
             take Xs2 = each (i32 j; (0i32 <= j) && (j < path_len))
                  ^
-other location (File "backend/cn/lib/compile.ml", line 1593, characters 38-45)  warning: 'focus' expects a 'u64', but 'read_&i1' with type 'i32' was provided. This will become an error in the future.
+other location (File "backend/cn/lib/compile.ml", line 1608, characters 38-45)  warning: 'focus' expects a 'u64', but 'read_&i1' with type 'i32' was provided. This will become an error in the future.
 
-other location (File "backend/cn/lib/compile.ml", line 1593, characters 38-45)  warning: 'focus' expects a 'u64', but 'read_&idx0' with type 'i32' was provided. This will become an error in the future.
+other location (File "backend/cn/lib/compile.ml", line 1608, characters 38-45)  warning: 'focus' expects a 'u64', but 'read_&idx0' with type 'i32' was provided. This will become an error in the future.
 
 [1/1]: lookup_rec -- pass

--- a/tests/cn/tree16/as_partial_map/tree16.c.verify
+++ b/tests/cn/tree16/as_partial_map/tree16.c.verify
@@ -14,9 +14,9 @@ tests/cn/tree16/as_partial_map/tree16.c:137:19: warning: 'each' expects a 'u64',
 tests/cn/tree16/as_partial_map/tree16.c:146:18: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
             take Xs2 = each (i32 j; (0i32 <= j) && (j < path_len))
                  ^
-other location (File "backend/cn/lib/compile.ml", line 1593, characters 38-45)  warning: 'focus' expects a 'u64', but 'read_&i2' with type 'i32' was provided. This will become an error in the future.
+other location (File "backend/cn/lib/compile.ml", line 1608, characters 38-45)  warning: 'focus' expects a 'u64', but 'read_&i2' with type 'i32' was provided. This will become an error in the future.
 
-other location (File "backend/cn/lib/compile.ml", line 1593, characters 38-45)  warning: 'focus' expects a 'u64', but 'read_&idx0' with type 'i32' was provided. This will become an error in the future.
+other location (File "backend/cn/lib/compile.ml", line 1608, characters 38-45)  warning: 'focus' expects a 'u64', but 'read_&idx0' with type 'i32' was provided. This will become an error in the future.
 
 [1/2]: cn_get_num_nodes -- pass
 [2/2]: lookup_rec -- pass


### PR DESCRIPTION
Using the generic constructor fixes and places the error message formatting at the callsite rather than whatever backend is displaying the error (e.g. command line vs VS code).