### PR TITLE
CN: Fix #860, escape ampersand in pp string HTML

### DIFF
--- a/backend/cn/lib/pp.ml
+++ b/backend/cn/lib/pp.ml
@@ -349,3 +349,12 @@ let document_of_yojson (json : Yojson.Safe.t) : (document, string) Result.t =
   | `String str -> Ok (PPrint.arbitrary_string str)
   | _ ->
     Error ("document_of_yojson: expected `String, found " ^ Yojson.Safe.to_string json)
+
+
+let string str =
+  let amp = Str.regexp "&" in
+  if !html_escapes then (
+    let str = Str.global_replace amp "&amp;" str in
+    string str)
+  else
+    string str


### PR DESCRIPTION
We don't have automatic testing for HTML output (yet) and so this is the test case:

```c
void f(void)
{
    int region = 1;
    /*@ assert(false); @*/
}
```

If the ampersand is not escaped, on the last page of the output, the &region turns into "(R)ion".