### PR TITLE
Fix #926: Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -299,7 +299,7 @@ install_lib: cerberus-lib
 	$(Q)dune install cerberus-lib
 
 .PHONY: install
-install: cerberus install_lib
+install: install_lib cerberus
 	@echo "[DUNE] install cerberus"
 	$(Q)dune install cerberus
 


### PR DESCRIPTION
Commit 7d7271caa0d1c415f6c1088716627a0d0c29224d split apart cerberus-lib, which can be built without building cerberus itself, but put the dependency in the wrong order, causing a confusing dune error about missing install files. This commit fixes that order.