### PR TITLE
Remove unused annotation (fix #919)

### DIFF
--- a/backend/cn/lib/pp_mucore.ml
+++ b/backend/cn/lib/pp_mucore.ml
@@ -494,7 +494,6 @@ module Make (Config : CONFIG) = struct
     | Abmc annot -> (match annot with Abmc_id id -> [ !^(string_of_int id) ])
     | Atypedef sym -> [ pp_symbol sym ]
     | Aattrs _ -> [ !^"TODO(Aattrs)" ]
-    | Anot_explode -> [ !^"not-explode" ]
     | Alabel _ -> [ !^"TODO(label)" ]
     | Acerb _ -> []
     | Avalue (Ainteger ity) -> [ !^"type" ^^^ Pp_core_ctype.pp_integer_ctype ity ]

--- a/backend/cn/lib/pp_mucore_coq.ml
+++ b/backend/cn/lib/pp_mucore_coq.ml
@@ -612,7 +612,6 @@ let rec pp_annot_t = function
   | Annot.Abmc bmc -> pp_constructor "Abmc" [ pp_bmc_annot bmc ]
   | Annot.Aattrs attrs -> pp_constructor "Aattrs" [ pp_attributes attrs ]
   | Annot.Atypedef sym -> pp_constructor "Atypedef" [ pp_symbol sym ]
-  | Annot.Anot_explode -> pp_constructor0 "Anot_explode"
   | Annot.Alabel la -> pp_constructor "Alabel" [ pp_label_annot la ]
   | Annot.Acerb ca -> pp_constructor "Acerb" [ pp_cerb_attribute ca ]
   | Annot.Avalue va -> pp_constructor "Avalue" [ pp_value_annot va ]

--- a/frontend/model/annot.lem
+++ b/frontend/model/annot.lem
@@ -73,7 +73,6 @@ type annot =
   | Aattrs of attributes (* C2X attributes *)
   | Atypedef of Symbol.sym (* (TODO: I don't like but hey)
                               must only be used on a ctype to indicate it is a unfolding of a typedef *)
-  | Anot_explode (* tell the a-normalisation not to explode if-then-else *)
   | Alabel of label_annot
   | Acerb of cerb_attribute
   | Avalue of value_annot
@@ -118,8 +117,6 @@ let rec get_loc annots =
     | (Aattrs _ :: annots') ->
         get_loc annots'
     | (Atypedef _ :: annots') ->
-        get_loc annots'
-    | (Anot_explode :: annots') ->
         get_loc annots'
     | (Alabel _ :: annots') ->
         get_loc annots'
@@ -184,8 +181,6 @@ let rec get_attrs annots =
        | Just (Attrs attributes') -> Just (Attrs (attributes ++ attributes'))
        | Nothing -> Just (Attrs attributes)       
        end
-    | (Anot_explode :: annots') ->
-        get_attrs annots'
     | (Alabel _ :: annots') ->
         get_attrs annots'
     | (Acerb _ :: annots') ->
@@ -280,8 +275,6 @@ let rec get_uid annots =
         get_uid annots'
     | (Aattrs _ :: annots') ->
         get_uid annots'
-    | (Anot_explode :: annots') ->
-        get_uid annots'
     | (Alabel _ :: annots') ->
         get_uid annots'
     | (Acerb _ :: annots') ->
@@ -295,18 +288,6 @@ let rec get_uid annots =
     | (Aexpr :: annots') ->
         get_uid annots'
   end
-
-
-(* adapting code from get_loc *)
-val     explode: list annot -> bool
-let rec explode annots =
-  match annots with
-  | Anot_explode :: _ -> false
-  | _ :: annots -> explode annots
-  | [] -> true
-  end
-
-
 
 
 val is_return: list annot -> bool

--- a/frontend/model/translation.lem
+++ b/frontend/model/translation.lem
@@ -388,10 +388,10 @@ else
                                   ; Caux.mk_specified_pat obj2_wrp.E.sym_pat ]
               , Caux.mk_let_pe conv1_wrp.E.sym_pat promoted1_pe (
                   Caux.mk_let_pe conv2_wrp.E.sym_pat promoted2_pe (
-                    Caux.mk_if_pe_ [Annot.Anot_explode] (Caux.mk_op_pe C.OpEq conv2_wrp.E.sym_pe zero_pe)
+                    Caux.mk_if_pe (Caux.mk_op_pe C.OpEq conv2_wrp.E.sym_pe zero_pe)
                       (Caux.mk_std_undef_pe loc "§6.5.5#5, sentence 2" ub)
                       (* if a/b is representable *)
-                      ( Caux.mk_if_pe_ [Annot.Anot_explode] (stdlib.mkcall_is_representable (Caux.mk_op_pe C.OpDiv promoted1_pe conv2_wrp.E.sym_pe) result_ty)
+                      ( Caux.mk_if_pe (stdlib.mkcall_is_representable (Caux.mk_op_pe C.OpDiv promoted1_pe conv2_wrp.E.sym_pe) result_ty)
                           begin
                             Caux.mk_specified_pe (Caux.mk_std_pe "§6.5.5#5, sentence 1" begin
                               if AilTypesAux.is_signed_integer_type result_ty then
@@ -454,7 +454,7 @@ begin if AilTypesAux.is_real (ctype_of e1) then
                     (usual_arithmetic_conversion (ctype_of e1) (ctype_of e2) obj1_wrp.E.sym_pe obj2_wrp.E.sym_pe) in
                 Caux.add_std "§6.5.8#6" (
                   Caux.mk_pure_e (
-                    Caux.mk_if_pe_ [Annot.Anot_explode] (Caux.mk_op_pe real_bop promoted1_pe promoted2_pe)
+                    Caux.mk_if_pe (Caux.mk_op_pe real_bop promoted1_pe promoted2_pe)
                       (Caux.mk_specified_pe (Caux.mk_integer_pe 1))
                       (Caux.mk_specified_pe (Caux.mk_integer_pe 0))
                   )
@@ -470,7 +470,7 @@ else
                 Caux.mk_wseq_e memop_wrp.E.sym_pat (C.Expr [] (C.Ememop memop [obj1_wrp.E.sym_pe; obj2_wrp.E.sym_pe])) (
                   Caux.add_std "§6.5.8#6" (
                     Caux.mk_pure_e (
-                      Caux.mk_if_pe_ [Annot.Anot_explode] memop_wrp.E.sym_pe
+                      Caux.mk_if_pe memop_wrp.E.sym_pe
                         (Caux.mk_specified_pe (Caux.mk_integer_pe 1))
                         (Caux.mk_specified_pe (Caux.mk_integer_pe 0))
                     )
@@ -518,7 +518,7 @@ if    Aaux.is_null_pointer_constant e1 && AilTypesAux.is_pointer (ctype_of e2)
           , Caux.mk_wseq_e memop_wrp.E.sym_pat (Caux.mk_memop_e memop [obj_wrp.E.sym_pe; nullptr_pe]) begin
               Caux.add_std "§6.5.9#3" begin
                 Caux.mk_pure_e begin
-                  Caux.mk_if_pe_ [Annot.Anot_explode] memop_wrp.E.sym_pe
+                  Caux.mk_if_pe memop_wrp.E.sym_pe
                     (Caux.mk_specified_pe (Caux.mk_integer_pe 1))
                     (Caux.mk_specified_pe (Caux.mk_integer_pe 0))
                 end
@@ -556,7 +556,7 @@ if AilTypesAux.is_arithmetic (ctype_of e1) && AilTypesAux.is_arithmetic (ctype_o
                 Caux.mk_std_pair_pe "§6.5.9#4, sentence 1"
                   (usual_arithmetic_conversion (ctype_of e1) (ctype_of e2) obj1_wrp.E.sym_pe obj2_wrp.E.sym_pe) in
               Caux.mk_std_pe "§6.5.9#3" begin
-                Caux.mk_if_pe_ [Annot.Anot_explode] (Caux.mk_std_pe "§6.5.9#4, sentence 3" (mk_op_pe promoted1_pe promoted2_pe))
+                Caux.mk_if_pe (Caux.mk_std_pe "§6.5.9#4, sentence 3" (mk_op_pe promoted1_pe promoted2_pe))
                   (Caux.mk_specified_pe (Caux.mk_integer_pe 1))
                   (Caux.mk_specified_pe (Caux.mk_integer_pe 0))
               end )
@@ -578,7 +578,7 @@ else (* both operand have pointer type *)
           , Caux.mk_wseq_e memop_wrp.E.sym_pat (C.Expr [] (C.Ememop memop [obj1_wrp.E.sym_pe; obj2_wrp.E.sym_pe])) begin
               Caux.mk_pure_e begin
                 Caux.mk_std_pe "§6.5.9#3" begin
-                  Caux.mk_if_pe_ [Annot.Anot_explode] memop_wrp.E.sym_pe
+                  Caux.mk_if_pe memop_wrp.E.sym_pe
                     (Caux.mk_specified_pe (Caux.mk_integer_pe 1))
                     (Caux.mk_specified_pe (Caux.mk_integer_pe 0))
                 end
@@ -887,7 +887,7 @@ let translate_function_call loc is_used translate_expr stdlib e es =
     E.return
       ( n+1
       , (Caux.mk_let_e param_ty_wrp.E.sym_pat (stdlib.mkcall_params_nth params_wrp.E.sym_pe (Caux.mk_integer_pe n))
-        (Caux.mk_if_e_ [Annot.Anot_explode]
+        (Caux.mk_if_e_ []
           (Caux.mk_not_pe (Caux.mk_are_compatible expect_param_ty_pe param_ty_wrp.E.sym_pe))
           (Caux.mk_pure_e (Caux.mk_std_undef_pe loc "§6.5.2.2#9" Undefined.UB041_function_not_compatible))
           begin
@@ -938,7 +938,7 @@ let translate_function_call loc is_used translate_expr stdlib e es =
       E.return
         ( n+1
         , (Caux.mk_let_pe param_ty_wrp.E.sym_pat (stdlib.mkcall_params_nth params_wrp.E.sym_pe (Caux.mk_integer_pe n))
-          (Caux.mk_if_pe_ [Annot.Anot_explode]
+          (Caux.mk_if_pe
             (Caux.mk_not_pe (Caux.mk_are_compatible expect_param_ty_pe param_ty_wrp.E.sym_pe))
             (Caux.mk_std_undef_pe loc "§6.5.2.2#9" Undefined.UB041_function_not_compatible)
             begin
@@ -1013,12 +1013,12 @@ let translate_function_call loc is_used translate_expr stdlib e es =
       end
 begin if expect_is_variadic then
       (* check number of parameters *)
-      (Caux.mk_if_e_ [Annot.Anot_explode]
+      (Caux.mk_if_e_ []
         (Caux.mk_not_pe (Caux.mk_op_pe C.OpLe (stdlib.mkcall_params_length params_wrp.E.sym_pe)
                                               (Caux.mk_integer_pe (integerFromNat n_args))))
         (Caux.mk_pure_e (Caux.mk_std_undef_pe loc "§6.5.2.2#6, sentence 3" Undefined.UB038_number_of_args))
         (* check if function types are compatible *)
-        (Caux.mk_if_e_ [Annot.Anot_explode]
+        (Caux.mk_if_e_ []
           (Caux.mk_op_pe C.OpOr (Caux.mk_not_pe is_variadic_wrp.E.sym_pe)
                           (Caux.mk_not_pe (Caux.mk_are_compatible (Caux.mk_ail_ctype_pe expect_ret_ty) ret_wrp.E.sym_pe)))
           (Caux.mk_pure_e (Caux.mk_std_undef_pe loc "§6.5.2.2#9" Undefined.UB041_function_not_compatible))
@@ -1090,12 +1090,12 @@ end
       )
 else
       (* check number of parameters *)
-      (Caux.mk_if_e_ [Annot.Anot_explode]
+      (Caux.mk_if_e_ []
         (Caux.mk_not_pe (Caux.mk_op_pe C.OpEq (stdlib.mkcall_params_length params_wrp.E.sym_pe)
                                               (Caux.mk_integer_pe (integerFromNat n_args))))
         (Caux.mk_pure_e (Caux.mk_std_undef_pe loc "§6.5.2.2#6, sentence 3" Undefined.UB038_number_of_args))
         (* check if function types are compatible *)
-        (Caux.mk_if_e_ [Annot.Anot_explode]
+        (Caux.mk_if_e_ []
           (Caux.mk_op_pe C.OpOr is_variadic_wrp.E.sym_pe
                           (Caux.mk_not_pe (Caux.mk_are_compatible (Caux.mk_ail_ctype_pe expect_ret_ty) ret_wrp.E.sym_pe)))
           (Caux.mk_pure_e (Caux.mk_std_undef_pe loc "§6.5.2.2#9" Undefined.UB041_function_not_compatible))
@@ -1433,22 +1433,22 @@ let rec translate_expression is_used ctx variadic_env stdlib tagDefs a_expr =
                     of the type of the operand with unsigned integer type, then the operand with unsigned integer
                     type is converted to the type of the operand with signed integer type." *)
                 else if AilTypesAux.is_signed_integer_type ty1' then
-                  (Caux.mk_if_pe_ [Annot.Anot_explode] (stdlib.mkcall_all_values_representable_in ty2' ty1')
+                  (Caux.mk_if_pe (stdlib.mkcall_all_values_representable_in ty2' ty1')
                      (mk_conv_int ity1' e1)
                      (* "Otherwise, both operands are converted to the unsigned integer type corresponding to the type
                          of the operand with signed integer type". *)
                      (mk_conv_int (AilTypesAux.make_corresponding_unsigned ity1') e1)
                   ,
-                  Caux.mk_if_pe_ [Annot.Anot_explode] (stdlib.mkcall_all_values_representable_in ty2' ty1')
+                  Caux.mk_if_pe (stdlib.mkcall_all_values_representable_in ty2' ty1')
                      (mk_conv_int ity1' e2)
                      (mk_conv_int (AilTypesAux.make_corresponding_unsigned ity1') e2)
                   )
                 else
-                  (Caux.mk_if_pe_ [Annot.Anot_explode] (stdlib.mkcall_all_values_representable_in ty1' ty2')
+                  (Caux.mk_if_pe (stdlib.mkcall_all_values_representable_in ty1' ty2')
                      (mk_conv_int ity2' e1)
                      (mk_conv_int (AilTypesAux.make_corresponding_unsigned ity2') e1)
                   ,
-                  Caux.mk_if_pe_ [Annot.Anot_explode] (stdlib.mkcall_all_values_representable_in ty1' ty2')
+                  Caux.mk_if_pe (stdlib.mkcall_all_values_representable_in ty1' ty2')
                      (mk_conv_int ity2' e2)
                      (mk_conv_int (AilTypesAux.make_corresponding_unsigned ity2') e2)
                   )
@@ -1615,7 +1615,7 @@ else match AilTypesAux.referenced_type (ctype_of e) with
                     , Caux.mk_wseq_e test_wrp.E.sym_pat
                         (Caux.mk_memop_e Mem_common.PtrValidForDeref [Caux.mk_ail_ctype_pe ref_ty; obj_wrp.E.sym_pe]) begin
                           Caux.mk_pure_e begin
-                            Caux.mk_if_pe_ [Annot.Anot_explode] test_wrp.E.sym_pe
+                            Caux.mk_if_pe test_wrp.E.sym_pe
                               obj_wrp.E.sym_pe
                               (Caux.mk_std_undef_pe loc "§6.5.3.3#4, sentence 4" Undefined.UB043_indirection_invalid_value)
                           end
@@ -1667,10 +1667,10 @@ end
                         (Caux.mk_let_pe promoted2_wrp.E.sym_pat
                           (Caux.mk_std_pe "§6.5.7#3, sentence 1" promoted2_def)
                         (* (§6.5.7#2) if promoted2 < 0 then undef *)
-                        (Caux.mk_if_pe_ [Annot.Anot_explode] (Caux.mk_op_pe C.OpLt promoted2_wrp.E.sym_pe (Caux.mk_integer_pe 0))
+                        (Caux.mk_if_pe (Caux.mk_op_pe C.OpLt promoted2_wrp.E.sym_pe (Caux.mk_integer_pe 0))
                           (Caux.mk_std_undef_pe loc "§6.5.7#3, sentence 3" Undefined.UB051a_negative_shift)
                         (* ctype_width(result_ty) <= promoted2 *)
-                        (Caux.mk_if_pe_ [Annot.Anot_explode] (Caux.mk_op_pe C.OpOr 
+                        (Caux.mk_if_pe (Caux.mk_op_pe C.OpOr 
                               (Caux.mk_op_pe C.OpLt (Caux.annotate_integer_type_pexpr promoted2_ity (stdlib.mkcall_ctype_width result_ty)) promoted2_wrp.E.sym_pe)
                               (Caux.mk_op_pe C.OpEq (Caux.annotate_integer_type_pexpr promoted2_ity (stdlib.mkcall_ctype_width result_ty)) promoted2_wrp.E.sym_pe))
                           (Caux.mk_std_undef_pe loc "§6.5.7#4, sentence 3" Undefined.UB51b_shift_too_large)
@@ -1700,14 +1700,14 @@ if is_unsigned_shift then
       end
 else
                         Caux.mk_std_pe "§6.5.7#4, sentence 3"
-                          (Caux.mk_if_pe_ [Annot.Anot_explode] (Caux.mk_op_pe C.OpLt promoted1_wrp.E.sym_pe (Caux.mk_integer_pe 0))
+                          (Caux.mk_if_pe (Caux.mk_op_pe C.OpLt promoted1_wrp.E.sym_pe (Caux.mk_integer_pe 0))
                             (Caux.mk_std_undef_pe loc "§6.5.7#3, sentence 3" Undefined.UB052a_negative_left_shift)
   begin if Global.backend_name () = "Cn" then
                           Caux.mk_specified_pe (Caux.mk_catch_exceptional_condition_pe result_ity C.IOpShl promoted1_wrp.E.sym_pe promoted2_wrp.E.sym_pe)
   else
                           (Caux.mk_let_pe res_wrp.E.sym_pat
                             (Caux.mk_op_pe C.OpMul promoted1_wrp.E.sym_pe (Caux.mk_op_pe C.OpExp (Caux.mk_integer_pe 2) promoted2_wrp.E.sym_pe))
-                          (Caux.mk_if_pe_ [Annot.Anot_explode] (stdlib.mkcall_is_representable res_wrp.E.sym_pe result_ty)
+                          (Caux.mk_if_pe (stdlib.mkcall_is_representable res_wrp.E.sym_pe result_ty)
     begin if Global.is_CHERI () && Ctype.is_ptr_t result_ty then
                           Caux.mk_specified_pe begin
                             Caux.mk_memop_pe Mem_common.CapAssignValue
@@ -1756,10 +1756,10 @@ end
                         Caux.mk_let_pe promoted1_wrp.E.sym_pat (integer_promotion (ctype_of e1) obj1_wrp.E.sym_pe)
                         (Caux.mk_let_pe promoted2_wrp.E.sym_pat promoted2_def
                         (* (§6.5.7#2) if promoted2 < 0 then undef *)
-                        (Caux.mk_if_pe_ [Annot.Anot_explode] (Caux.mk_op_pe C.OpLt promoted2_wrp.E.sym_pe (Caux.mk_integer_pe 0))
+                        (Caux.mk_if_pe (Caux.mk_op_pe C.OpLt promoted2_wrp.E.sym_pe (Caux.mk_integer_pe 0))
                           (Caux.mk_std_undef_pe loc "§6.5.7#3, sentence 3" Undefined.UB051a_negative_shift)
                         (* ctype_width(result_ty) <= promoted2 *)
-                        (Caux.mk_if_pe_ [Annot.Anot_explode] (Caux.mk_op_pe C.OpOr 
+                        (Caux.mk_if_pe (Caux.mk_op_pe C.OpOr 
                                   (Caux.mk_op_pe C.OpLt (Caux.annotate_integer_type_pexpr promoted2_ity (stdlib.mkcall_ctype_width result_ty)) promoted2_wrp.E.sym_pe)
                                   (Caux.mk_op_pe C.OpEq (Caux.annotate_integer_type_pexpr promoted2_ity (stdlib.mkcall_ctype_width result_ty)) promoted2_wrp.E.sym_pe))
                           (Caux.mk_std_undef_pe loc "§6.5.7#3, sentence 3" Undefined.UB51b_shift_too_large)
@@ -1790,7 +1790,7 @@ if AilTypesAux.is_unsigned_integer_type result_ty then
   end
 else
                                Caux.mk_std_pe "6.5.7#5, sentence 3" begin
-                                Caux.mk_if_pe_ [Annot.Anot_explode] (Caux.mk_op_pe C.OpGe promoted1_wrp.E.sym_pe (Caux.mk_integer_pe 0))
+                                Caux.mk_if_pe (Caux.mk_op_pe C.OpGe promoted1_wrp.E.sym_pe (Caux.mk_integer_pe 0))
   begin if Global.backend_name () = "Cn" then
                                   Caux.mk_catch_exceptional_condition_pe result_ity C.IOpShr promoted1_wrp.E.sym_pe promoted2_wrp.E.sym_pe
   else
@@ -1939,7 +1939,7 @@ else (* pointer <-> pointer cast *)
                         [ ( Caux.mk_specified_pat obj_wrp.E.sym_pat
                           , Caux.mk_wseq_e (Caux.mk_sym_pat let_sym C.BTy_boolean)
                               (C.Expr [] (C.Ememop Mem_common.PtrWellAligned [Caux.mk_ail_ctype_pe cast_ref_ty; obj_wrp.E.sym_pe]))
-                              (Caux.mk_pure_e (Caux.mk_specified_pe (Caux.mk_if_pe_ [Annot.Anot_explode] (Caux.mk_sym_pe let_sym) obj_wrp.E.sym_pe ub_pe))) )
+                              (Caux.mk_pure_e (Caux.mk_specified_pe (Caux.mk_if_pe (Caux.mk_sym_pe let_sym) obj_wrp.E.sym_pe ub_pe))) )
                         ; ( Caux.mk_unspecified_pat (Caux.mk_empty_pat C.BTy_ctype)
                           , (* we are being daemonic (case where the resulting pointer would be misaligned) *)
                             Caux.mk_pure_e ub_pe ) ]
@@ -2135,7 +2135,7 @@ else if AilTypesAux.is_pointer (ctype_of e1) && AilTypesAux.is_pointer (ctype_of
                         (C.Expr [] (C.Ememop Mem_common.Ptrdiff [diff_ty_pe; obj1_wrp.E.sym_pe; obj2_wrp.E.sym_pe]))
                         begin
                           Caux.mk_pure_e begin
-                            Caux.mk_if_pe_ [Annot.Anot_explode] (stdlib.mkcall_is_representable memop_wrp.E.sym_pe Ctype.ptrdiff_t)
+                            Caux.mk_if_pe (stdlib.mkcall_is_representable memop_wrp.E.sym_pe Ctype.ptrdiff_t)
                               (Caux.mk_specified_pe memop_wrp.E.sym_pe)
                               (Caux.mk_undef_pe loc Undefined.UB050_pointers_subtraction_not_representable)
                           end
@@ -2586,10 +2586,10 @@ end
               (Caux.mk_tuple_pat [ret_wrp.E.sym_pat; params_wrp.E.sym_pat; Caux.mk_empty_pat C.BTy_boolean; Caux.mk_empty_pat C.BTy_boolean])
               (Caux.mk_cfunction_pe fun_wrp.E.sym_pe)
               begin
-                Caux.mk_if_e_ [Annot.Anot_explode]
+                Caux.mk_if_e_ []
                   (Caux.mk_op_pe C.OpEq (stdlib.mkcall_params_length params_wrp.E.sym_pe) (Caux.mk_integer_pe 0))
                     begin
-                      Caux.mk_if_e_ [Annot.Anot_explode]
+                      Caux.mk_if_e_ []
                         (Caux.mk_are_compatible (Caux.mk_ail_ctype_pe ret_ty) ret_wrp.E.sym_pe)
                           (Caux.mk_ccall_e (Caux.mk_ail_ctype_pe (ctype_of e)) fun_wrp.E.sym_pe [(*Caux.mk_boolean_pe is_used*)])
                           (Caux.mk_pure_e (Caux.mk_std_undef_pe loc "§6.5.2.2#9" Undefined.UB041_function_not_compatible))
@@ -2619,7 +2619,7 @@ begin if AilTypesAux.is_arithmetic (ctype_of e) then
               Caux.mk_pure_e begin
                 Caux.mk_case_pe e_wrp.E.sym_pe
                   [ ( Caux.mk_specified_pat obj_wrp.E.sym_pat
-                    , Caux.mk_if_pe_ [Annot.Anot_explode] (Caux.mk_op_pe C.OpEq obj_wrp.E.sym_pe zero_pe)
+                    , Caux.mk_if_pe (Caux.mk_op_pe C.OpEq obj_wrp.E.sym_pe zero_pe)
                        (Caux.mk_error_pe "assert() failure" Caux.mk_unit_pe)
                       Caux.mk_unit_pe )
                   ; ( Caux.mk_empty_pat (C.BTy_loaded oTy)
@@ -2632,7 +2632,7 @@ else (* is_pointer *)
                      (Caux.mk_memop_e Mem_common.PtrEq [obj_wrp.E.sym_pe; Caux.mk_nullptr_pe Cty.void])
                      begin
                        Caux.mk_pure_e begin
-                         Caux.mk_if_pe_ [Annot.Anot_explode] memop_wrp.E.sym_pe
+                         Caux.mk_if_pe memop_wrp.E.sym_pe
                            (Caux.mk_error_pe "assert() failure" Caux.mk_unit_pe)
                            Caux.mk_unit_pe
                        end
@@ -2869,7 +2869,7 @@ end
                       else
                           begin
                             Caux.mk_pure_e begin
-                              Caux.mk_if_pe_ [Annot.Anot_explode] test_wrp.E.sym_pe
+                              Caux.mk_if_pe test_wrp.E.sym_pe
                                 (Caux.mk_member_shift_pe obj_wrp.E.sym_pe tag_sym ident)
                                 (Caux.mk_std_undef_pe loc "§6.5.2.3#4, sentence 4" Undefined.UB043_indirection_invalid_value)
                             end
@@ -3594,7 +3594,7 @@ let rec translate_stmt stdlib tagDefs f env (A.AnnotatedStatement loc stmt_attrs
               Caux.mk_case_e test_wrp.E.sym_pe
                 [ ( Caux.mk_specified_pat case_wrp.E.sym_pat
                   , Caux.mk_pure_e begin
-                      Caux.mk_if_pe_ [Annot.Anot_explode] (Caux.mk_not_pe (Caux.mk_op_pe C.OpEq case_wrp.E.sym_pe (Caux.mk_integer_pe 1)))
+                      Caux.mk_if_pe (Caux.mk_not_pe (Caux.mk_op_pe C.OpEq case_wrp.E.sym_pe (Caux.mk_integer_pe 1)))
                         (Caux.mk_boolean_pe true) (Caux.mk_boolean_pe false)
                     end )
                   (* non-deterministic branching if the test expression had unspecified value *)
@@ -3629,7 +3629,7 @@ let rec translate_stmt stdlib tagDefs f env (A.AnnotatedStatement loc stmt_attrs
                 Caux.mk_case_e test_wrp.E.sym_pe
                   [ ( Caux.mk_specified_pat case_wrp.E.sym_pat
                     , Caux.mk_pure_e begin
-                        Caux.mk_if_pe_ [Annot.Anot_explode] (Caux.mk_not_pe (Caux.mk_op_pe C.OpEq case_wrp.E.sym_pe (Caux.mk_integer_pe 1)))
+                        Caux.mk_if_pe (Caux.mk_not_pe (Caux.mk_op_pe C.OpEq case_wrp.E.sym_pe (Caux.mk_integer_pe 1)))
                           (Caux.mk_boolean_pe true) (Caux.mk_boolean_pe false)
                       end )
                     (* non-deterministic branching if the test expression had unspecified value *)

--- a/memory/cheri-coq/impl_mem.ml
+++ b/memory/cheri-coq/impl_mem.ml
@@ -178,7 +178,6 @@ module CerbTagDefs = struct
     | Abmc ba      -> Abmc (toCoq_annot ba)
     | Aattrs atr   -> Aattrs (toCoq_attributes atr)
     | Atypedef s   -> Atypedef (toCoq_Symbol_sym s)
-    | Anot_explode -> Anot_explode
     | Alabel la    -> Alabel (toCoq_label_annot la)
     | Acerb ca -> Acerb (toCoq_cerb_attribute ca)
     | Avalue va -> Avalue (toCoq_value_annot va)
@@ -765,7 +764,6 @@ module CHERIMorello : Memory = struct
   | Abmc ba      -> Abmc (fromCoq_annot ba)
   | Aattrs atr   -> Aattrs (fromCoq_attributes atr)
   | Atypedef s   -> Atypedef (fromCoq_Symbol_sym s)
-  | Anot_explode -> Anot_explode
   | Alabel la    -> Alabel (fromCoq_label_annot la)
   | Acerb ca     -> Acerb (fromCoq_cerb_attribute ca)
   | Avalue va     -> Avalue (fromCoq_value_annot va)

--- a/ocaml_frontend/pprinters/pp_core.ml
+++ b/ocaml_frontend/pprinters/pp_core.ml
@@ -66,17 +66,6 @@ let maybe_print_location (annot: Annot.annot list) : P.document =
       | _ ->
           P.empty
 
-let maybe_print_explode_annot (annot: Annot.annot list) : P.document =
-  if not show_explode_annot then
-    P.empty
-  else
-    match Annot.explode annot with
-      | false ->
-          !^ "{- not-explode -}" ^^ P.space
-      | _ ->
-          P.empty
-
-
 let precedence_pexpr = function
   | PEundef _
   | PEerror _
@@ -444,7 +433,6 @@ let pp_pexpr pe =
     let prec' = precedence_pexpr pe in
     let pp z = P.group (pp prec' z) in
     (maybe_print_location annot) ^^
-    (maybe_print_explode_annot annot) ^^
     (if compare_precedence prec' prec then fun z -> z else P.parens)
     begin P.group begin match pe with
       | PEundef (_, ub) ->
@@ -596,9 +584,6 @@ let rec pp_expr expr =
                   end ^^ acc
                 else
                   acc
-            | Anot_explode ->
-               (* !^"{-not-explode-}" ^^  *)
-               acc
             | Alabel _ -> 
                acc
             | Acerb _ ->


### PR DESCRIPTION
Commit 335253d928 added this annotation to control whether Core if-expressions were A-normalised for CN or not, to reduce control-flow explosion.

Commit 350fefc removed the A-normalisation for CN, but left this annotation there and unused, so this commit deletes it.