### PR TITLE
Use menhir 3.0 in dune-project (fix #927)

### DIFF
--- a/cerberus.opam
+++ b/cerberus.opam
@@ -20,7 +20,7 @@ bug-reports: "https://github.com/rems-project/cerberus/issues"
 depends: [
   "cerberus-lib"
   "ocaml" {>= "4.12.0"}
-  "dune" {(>= "3.8.0" & < "3.13.0") | (>= "3.15.0")}
+  "dune" {>= "3.15.0"}
   "sha" {>= "1.12"}
   "pprint" {>= "20180528"}
   "ppx_sexp_conv" {>= "v0.14.3" }

--- a/dune-project
+++ b/dune-project
@@ -1,5 +1,5 @@
-(lang dune 3.8)
+(lang dune 3.13)
 (name cerberus)
 
-(using menhir 2.0)
+(using menhir 3.0)
 (using coq 0.8) 

--- a/parsers/c/dune
+++ b/parsers/c/dune
@@ -9,7 +9,7 @@
 
 (ocamllex c_lexer)
 (menhir
- (flags (--external-tokens Tokens --explain --exn-carries-state))
+ (flags (--external-tokens Tokens --exn-carries-state))
  (modules c_parser))
 
 ;; integrating and checking .messages file


### PR DESCRIPTION
This is to get a .conflicts file produced by default for parser conflicts.