### PR TITLE
Use compound assigns for preincrement etc

### DIFF
--- a/frontend/model/cabs_to_ail.lem
+++ b/frontend/model/cabs_to_ail.lem
@@ -2309,24 +2309,14 @@ STD_ "§6.5.2.1#2, sentence 2" $
           E.return (AilEcompound qs ty' d_e))
     | CabsEpreincr e ->
         AnnotatedExpression () [] loc <$>
-(STD_ "§6.5.3.1#2, sentence 3" $
-(*
+          (STD_ "§6.5.3.1#2, sentence 3" $
           desugar_expression e >>= fun d_e ->
-          E.return $ AilEcompoundAssign d_e Add oneAil
-*)
-          (* TODO: temporary hack, while the elab doesn't support compound assigns *)
-          desugar_expression e >>= fun d_e ->
-          E.return $ AilEassign d_e (AnnotatedExpression () [] loc (AilEbinary d_e (Arithmetic Add) oneAil)))
+          E.return $ AilEcompoundAssign d_e Add oneAil)
     | CabsEpredecr e ->
         AnnotatedExpression () [] loc <$>
-(STD_ "§6.5.3.1#3" $
-(*
+          (STD_ "§6.5.3.1#3" $
           desugar_expression e >>= fun d_e ->
-          E.return $ AilEcompoundAssign d_e Sub oneAil
-*)
-          (* TODO: temporary hack, while the elab doesn't support compound assigns *)
-          desugar_expression e >>= fun d_e ->
-          E.return $ AilEassign d_e (AnnotatedExpression () [] loc (AilEbinary d_e (Arithmetic Sub) oneAil)))
+          E.return $ AilEcompoundAssign d_e Sub oneAil)
           (* (§6.5.3.3#5) *)
     | CabsEunary CabsNot e ->
         AnnotatedExpression () [] loc <$>


### PR DESCRIPTION
We could carry the location, but it would give the false impression to `fulminate` that this term was parsed from a specific range of the file. This change is needed for a `cn` PR I am creating now.