### PR TITLE
Fix build for Yojson 3.0.0

### DIFF
--- a/backend/common/driver_ocaml.ml
+++ b/backend/common/driver_ocaml.ml
@@ -117,7 +117,7 @@ let string_of_batch_output ?(json=false) ?(is_charon=false) i_opt (z3_strs, exec
             `Assoc [ "status", `String "Undefined"
                    ; "details", `Assoc [ "ub", `String (Undefined.stringFromUndefined_behaviour ub)
                                        ; "stderr", `String (String.escaped stderr)
-                                       ; "loc", Cerb_location.to_json loc ] ]
+                                       ; "loc", (Cerb_location.to_json loc :> Yojson.t) ] ]
           end
         end else
           Printf.bprintf buf "Undefined {ub: \"%s\", stderr: \"%s\", loc: \"%s\"}%s"

--- a/util/cerb_json.ml
+++ b/util/cerb_json.ml
@@ -8,9 +8,7 @@ type json =
     | `List of json list
     | `Null
     | `String of string
-    | `Stringlit of string
-    | `Tuple of json list
-    | `Variant of string * json option ]
+    | `Stringlit of string ]
 
 let of_string s = `String s
 


### PR DESCRIPTION
Yojson 3.0.0 removed the `Tuple and `Variant constructors, and this caused a mismatch between it and Cerb_json.t.

https://github.com/ocaml-community/yojson/blob/master/CHANGES.md#removed-1

This commit removes those constructors too, but adds in a subtyping cast to retain backwards compatibility with prior verisons.