### PR TITLE
Fix web build for Yojson 3.0.0

### DIFF
--- a/backend/web/web.ml
+++ b/backend/web/web.ml
@@ -687,7 +687,7 @@ let cerberus ~rheader ~conf ~flow content =
   do_action msg.action >|= json_of_result >>= fun json ->
   let time = Some ((Sys.time () -. start_time) *. 1000.) in
   Sys.remove filename;
-  respond_json ~time ~rheader json
+  respond_json ~time ~rheader (json : Cerb_json.json :> Yojson.t)
 
 (* GET and POST *)
 
@@ -760,7 +760,7 @@ let post ~conf ~rheader ~flow uri path content =
     | Lwt_io.Channel_closed msg ->
       Debug.warn @@ "Lwt channel closed: " ^ msg;
       respond_json ~time:None ~rheader
-      @@ json_of_result
+      @@ (json_of_result : _ -> Cerb_json.json :> _ -> Yojson.t)
       @@ Failure "Error: timeout!"
     | e ->
       Debug.error_exception "POST" e;


### PR DESCRIPTION
Commit f11e6b33 fixed the build for CI but not for the web (oops) after the update for Yojson 3.0.0 (it removes `Tuple and `Variant constructors, but those are unused and so can be coerced away).

This commit applies similar coercions to fix the build for the web.