### PR TITLE
Make shebangs consistent

### DIFF
--- a/coq/extracted/patch.sh
+++ b/coq/extracted/patch.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env -S bash -euo pipefail
 patch -p0 -r 0 -s --read-only=ignore --follow-symlinks -o - $1 -i extracted/CRelationClasses.mli.patch
 

--- a/docker_entry_point.sh
+++ b/docker_entry_point.sh
@@ -1,2 +1,2 @@
-#!/bin/sh
+#!/usr/bin/env -S bash -euo pipefail
 eval `opam env` && $*

--- a/public/deploy.sh
+++ b/public/deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env -S bash -euo pipefail
 
 ## This script deploy Cerberus UI and send it to the server
 ## PS: only works in my machine due to SSH credentials

--- a/tests/bmc/run_bmc_tests_slow.sh
+++ b/tests/bmc/run_bmc_tests_slow.sh
@@ -1,2 +1,2 @@
-#!/bin/sh
+#!/usr/bin/env -S bash -euo pipefail
 ./run_bmc_tests.ml --check-rcu

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env -S bash -euo pipefail
 
 # Sets the CERB and CERB_INSTALL_PREFIX variables for a given backend
 # (given in $1).

--- a/tests/csmith/small_arrays/gen.sh
+++ b/tests/csmith/small_arrays/gen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env -S bash -euo pipefail
 
 GENOPTS="\
   --no-pointers \

--- a/tests/csmith/small_int_arith/gen.sh
+++ b/tests/csmith/small_int_arith/gen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env -S bash -euo pipefail
 
 GENOPTS="\
   --no-arrays \

--- a/tests/csmith/small_mix/gen.sh
+++ b/tests/csmith/small_mix/gen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env -S bash -euo pipefail
 
 GENOPTS="\
   --argc \

--- a/tests/csmith/tools/run_compare.sh
+++ b/tests/csmith/tools/run_compare.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env -S bash -euo pipefail
 
 gtimeout 10s clang -DCSMITH_MINIMAL -I ../runtime -w -o compare.out $@ && ./compare.out
 gtimeout 30s cerberus --cpp="cc -E -nostdinc -undef -D__cerb__ -I $CERB_PATH/include/c/libc -I $CERB_PATH/include/c/posix -DCSMITH_MINIMAL -I ../runtime" --exec --batch $@

--- a/tests/gcc-torture/breakdown/run.sh
+++ b/tests/gcc-torture/breakdown/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env -S bash -euo pipefail
 
 SUCCESS=$(git ls-files success/*.c | wc -l)
 LIMBUS=$(git ls-files limbus/*.c | wc -l)

--- a/tests/gcc-torture/run.sh
+++ b/tests/gcc-torture/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env -S bash -euo pipefail
 
 rm -rf tmp
 mkdir -p tmp

--- a/tests/hacl-star/build.sh
+++ b/tests/hacl-star/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env -S bash -euo pipefail
 #gcc -fPIC -Wall -Wextra -Wno-parentheses -Wno-unused compact/*.c minimal/*.c -I. -Iinclude -Icompact -Iminimal -shared -olibhacl.so -Xlinker -z -Xlinker noexecstack -Xlinker --unresolved-symbols=report-all
 
 CERBERUS="../../_build/default/backend/driver/main.exe"

--- a/tests/popl/cppmem/run.sh
+++ b/tests/popl/cppmem/run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env -S bash -euo pipefail
 
 time ../../../cerbcore --impl gcc_4.9.0_x86_64-apple-darwin10.8.0 $@.core > $@.dot
 dot -Tpdf $@.dot > $@.pdf

--- a/tests/popl/section4/run.sh
+++ b/tests/popl/section4/run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env -S bash -euo pipefail
 
 time ../../../cerbcore --impl gcc_4.9.0_x86_64-apple-darwin10.8.0 $@.core > $@.dot
 dot -Tpdf $@.dot > $@.pdf

--- a/tests/run-cheri.sh
+++ b/tests/run-cheri.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env -S bash -euo pipefail
 
 TESTSDIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd ${TESTSDIR}

--- a/tests/run-ci.sh
+++ b/tests/run-ci.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env -S bash -euo pipefail
 
 TESTSDIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd ${TESTSDIR}

--- a/tests/run-core.sh
+++ b/tests/run-core.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env -S bash -euo pipefail
 # This script tests if Core pretty printer and parse coincide!
 
 function report {

--- a/tests/run-ocaml.sh
+++ b/tests/run-ocaml.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env -S bash -euo pipefail
 
 source tests.sh
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env -S bash -euo pipefail
 
 export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:`ocamlfind query z3`
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`ocamlfind query z3`

--- a/tests/run_tcc.sh
+++ b/tests/run_tcc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env -S bash -euo pipefail
 
 trap ctrl_c INT
 function ctrl_c() {

--- a/tests/tests-cheri.sh
+++ b/tests/tests-cheri.sh
@@ -1,4 +1,4 @@
-#!/usr/bash
+#!/usr/bin/env -S bash -euo pipefail
 
 citests=(
   0001-emptymain.c

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -1,4 +1,4 @@
-#!/usr/bash
+#!/usr/bin/env -S bash -euo pipefail
 
 citests=(
   0001-emptymain.c

--- a/tools/colours.sh
+++ b/tools/colours.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env -S bash -euo pipefail
 
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
   $@

--- a/tools/hack.sh
+++ b/tools/hack.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env -S bash -euo pipefail
 
 for f in _lem/*.lem
 do

--- a/tools/jenkins.sh
+++ b/tools/jenkins.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env -S bash -euo pipefail
 
 export CERB_PATH=/local/jenkins/home/workspace/rems/cerberus
 export DEPPATH=$CERB_PATH/dependencies

--- a/tools/load-wg14.sh
+++ b/tools/load-wg14.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env -S bash -euo pipefail
 
 #DIR=/home/jm/work/wg14
 DIR=/home/pes20/tmp/wg14

--- a/tools/mysloc
+++ b/tools/mysloc
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env -S bash -euo pipefail
 echo $@
 rm -rf tmp-los/*
 cp $@  tmp-los

--- a/tools/tex.sh
+++ b/tools/tex.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env -S bash -euo pipefail
 
 for FILE in "$@"
 do


### PR DESCRIPTION
This was done with rg and sed so let me know if there are any mistakes. My untrained eyes think it is fine. 

1. Use /usr/bin/env for lookup
2. Use bash instead of sh
3. Set euo pipefail for bash

If there are files that requires that `euo pipefail` is not set, then I can unset them for those files.