### PR TITLE
Fix runtime path lookup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,5 +65,5 @@ cerb_times.csv
 .DS_Store
 .AppleDouble
 .LSOverride
-Icon[]
+Icon[\]
 ._*

--- a/util/cerb_runtime.ml
+++ b/util/cerb_runtime.ml
@@ -44,7 +44,7 @@ let detect_runtime : unit -> runtime_loc = fun _ ->
           (* Then check for build time runtime (in repository). *)
           find_cerblib_sourceroot ()
         else None
-    ; mk= fun ~pkg -> source, prefix / "lib" / pkg / "runtime" } in
+    ; mk= fun ~pkg -> source, prefix / pkg / "runtime" } in
   match !specified_runtime with Some(path) -> wrap `SPECIFIED path | None ->
   (* Then check the CERB_INSTALL_PREFIX environment variable. *)
   try wrap `ENV_VAR (Sys.getenv "CERB_INSTALL_PREFIX") with Not_found ->


### PR DESCRIPTION
After installing cerberus, I was never able to run it previously. I did more digging and found that with this patch, after I `dune install` it works. 

Also fixed an invalid gitignore