### PR TITLE
Parse CN ghost return of C function calls

### DIFF
--- a/parsers/c/c_parser.mly
+++ b/parsers/c/c_parser.mly
@@ -341,7 +341,7 @@ type asm_qualifier =
 %type<(Symbol.identifier, Cabs.type_name) Cn.cn_loop_spec> loop_spec
 %type<(Symbol.identifier, Cabs.type_name) Cn.cn_statement> cn_statement
 %type<((Symbol.identifier, Cabs.type_name) Cn.cn_statement) list> cn_statements
-%type<((Symbol.identifier, Cabs.type_name) Cn.cn_expr) list> cn_ghost_args
+%type<((Symbol.identifier, Cabs.type_name) Cn.cn_expr) list * Symbol.identifier list> cn_ghost_args
 %type<(Symbol.identifier * Symbol.identifier Cn.cn_base_type) list> cn_args
 
 
@@ -2535,9 +2535,16 @@ cn_statements:
 | ls=nonempty_list(cn_statement) EOF
     { ls }
 
+cn_ghost_args_out:
+| SEMICOLON
+  gso=separated_list(COMMA, cn_variable)
+    { gso }
+
 cn_ghost_args:
-| gs = separated_list(COMMA, expr) EOF
-    { gs }
+| gs=separated_list(COMMA, expr)
+  gso=option(cn_ghost_args_out)
+  EOF
+    { (gs, Option.value gso ~default:[]) }
 
 cn_toplevel_elem:
 | pred= cn_predicate

--- a/parsers/c/c_parser_error.messages
+++ b/parsers/c/c_parser_error.messages
@@ -1,6 +1,6 @@
 cn_statements: WHILE
 ##
-## Ends in an error in state: 1368.
+## Ends in an error in state: 1387.
 ##
 ## cn_statements' -> . cn_statements [ # ]
 ##
@@ -13,7 +13,7 @@ Hint: these start with 'extract', 'instantiate', 'split_case', 'assert', 'print'
 
 cn_statements: INLINE WHILE
 ##
-## Ends in an error in state: 1369.
+## Ends in an error in state: 1388.
 ##
 ## cn_statement -> INLINE . loption(separated_nonempty_list(COMMA,cn_variable)) SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -25,9 +25,9 @@ parsing "cn_statement": seen "INLINE", expecting "loption(separated_nonempty_lis
 
 cn_statements: INLINE UNAME VARIABLE COMMA WHILE
 ##
-## Ends in an error in state: 1372.
+## Ends in an error in state: 1369.
 ##
-## separated_nonempty_list(COMMA,cn_variable) -> UNAME VARIABLE COMMA . separated_nonempty_list(COMMA,cn_variable) [ SEMICOLON RBRACK ]
+## separated_nonempty_list(COMMA,cn_variable) -> UNAME VARIABLE COMMA . separated_nonempty_list(COMMA,cn_variable) [ SEMICOLON RBRACK EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## UNAME VARIABLE COMMA
@@ -37,9 +37,9 @@ parsing "separated_nonempty_list(COMMA,cn_variable)": seen "UNAME VARIABLE COMMA
 
 cn_statements: INLINE LNAME VARIABLE COMMA WHILE
 ##
-## Ends in an error in state: 1375.
+## Ends in an error in state: 1372.
 ##
-## separated_nonempty_list(COMMA,cn_variable) -> LNAME VARIABLE COMMA . separated_nonempty_list(COMMA,cn_variable) [ SEMICOLON RBRACK ]
+## separated_nonempty_list(COMMA,cn_variable) -> LNAME VARIABLE COMMA . separated_nonempty_list(COMMA,cn_variable) [ SEMICOLON RBRACK EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## LNAME VARIABLE COMMA
@@ -49,9 +49,9 @@ parsing "separated_nonempty_list(COMMA,cn_variable)": seen "LNAME VARIABLE COMMA
 
 cn_statements: INLINE LNAME TYPE COMMA WHILE
 ##
-## Ends in an error in state: 1378.
+## Ends in an error in state: 1375.
 ##
-## separated_nonempty_list(COMMA,cn_variable) -> LNAME TYPE COMMA . separated_nonempty_list(COMMA,cn_variable) [ SEMICOLON RBRACK ]
+## separated_nonempty_list(COMMA,cn_variable) -> LNAME TYPE COMMA . separated_nonempty_list(COMMA,cn_variable) [ SEMICOLON RBRACK EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## LNAME TYPE COMMA
@@ -61,9 +61,9 @@ parsing "separated_nonempty_list(COMMA,cn_variable)": seen "LNAME TYPE COMMA", e
 
 cn_statements: INLINE UNAME TYPE COMMA WHILE
 ##
-## Ends in an error in state: 1382.
+## Ends in an error in state: 1379.
 ##
-## separated_nonempty_list(COMMA,cn_variable) -> UNAME TYPE COMMA . separated_nonempty_list(COMMA,cn_variable) [ SEMICOLON RBRACK ]
+## separated_nonempty_list(COMMA,cn_variable) -> UNAME TYPE COMMA . separated_nonempty_list(COMMA,cn_variable) [ SEMICOLON RBRACK EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## UNAME TYPE COMMA
@@ -73,7 +73,7 @@ parsing "separated_nonempty_list(COMMA,cn_variable)": seen "UNAME TYPE COMMA", e
 
 cn_statements: CN_UNPACK WHILE
 ##
-## Ends in an error in state: 1387.
+## Ends in an error in state: 1391.
 ##
 ## cn_statement -> CN_UNPACK . pred LPAREN cn_exprs_or_elipsis RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -85,7 +85,7 @@ parsing "cn_statement": seen "CN_UNPACK", expecting "pred LPAREN loption(separat
 
 cn_statements: CN_PACK UNAME WHILE
 ##
-## Ends in an error in state: 1388.
+## Ends in an error in state: 1392.
 ##
 ## pred -> UNAME . VARIABLE [ LPAREN ]
 ##
@@ -97,7 +97,7 @@ parsing "pred": seen "UNAME", expecting "VARIABLE"
 
 cn_statements: CN_EXTRACT CN_OWNED LT WHILE
 ##
-## Ends in an error in state: 1391.
+## Ends in an error in state: 1395.
 ##
 ## pred -> CN_OWNED LT . ctype GT [ LPAREN COMMA ]
 ##
@@ -2142,7 +2142,7 @@ parsing "postfix_expression": seen "VA_START LPAREN assignment_expression COMMA 
 
 cn_statements: CN_EXTRACT CN_BLOCK WHILE
 ##
-## Ends in an error in state: 1394.
+## Ends in an error in state: 1398.
 ##
 ## pred -> CN_BLOCK . LT ctype GT [ LPAREN COMMA ]
 ## pred -> CN_BLOCK . [ LPAREN COMMA ]
@@ -2155,7 +2155,7 @@ parsing "pred": seen "CN_BLOCK", expecting "LT ctype GT"
 
 cn_statements: CN_EXTRACT CN_BLOCK LT WHILE
 ##
-## Ends in an error in state: 1395.
+## Ends in an error in state: 1399.
 ##
 ## pred -> CN_BLOCK LT . ctype GT [ LPAREN COMMA ]
 ##
@@ -2167,7 +2167,7 @@ parsing "pred": seen "CN_BLOCK LT", expecting "ctype GT"
 
 cn_statements: CN_UNPACK CN_OWNED LPAREN WHILE
 ##
-## Ends in an error in state: 1399.
+## Ends in an error in state: 1403.
 ##
 ## cn_statement -> CN_UNPACK pred LPAREN . cn_exprs_or_elipsis RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -3193,7 +3193,7 @@ cn_statements: CN_PACK CN_OWNED LPAREN CN_CONSTANT COMMA WHILE
 ##
 ## Ends in an error in state: 1131.
 ##
-## separated_nonempty_list(COMMA,expr) -> expr COMMA . separated_nonempty_list(COMMA,expr) [ RPAREN EOF ]
+## separated_nonempty_list(COMMA,expr) -> expr COMMA . separated_nonempty_list(COMMA,expr) [ SEMICOLON RPAREN EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## expr COMMA
@@ -4079,7 +4079,7 @@ parsing "unary_expr": seen "LPAREN base_type_explicit RPAREN", expecting "prim_e
 
 cn_statements: CN_UNPACK CN_OWNED LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1403.
+## Ends in an error in state: 1407.
 ##
 ## cn_statement -> CN_UNPACK pred LPAREN cn_exprs_or_elipsis RPAREN . SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -4091,7 +4091,7 @@ parsing "cn_statement": seen "CN_UNPACK pred LPAREN loption(separated_nonempty_l
 
 cn_statements: CN_UNFOLD UNAME VARIABLE WHILE
 ##
-## Ends in an error in state: 1407.
+## Ends in an error in state: 1411.
 ##
 ## cn_statement -> CN_UNFOLD UNAME VARIABLE . LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -4103,7 +4103,7 @@ parsing "cn_statement": seen "CN_UNFOLD UNAME VARIABLE", expecting "LPAREN lopti
 
 cn_statements: CN_UNFOLD UNAME VARIABLE LPAREN WHILE
 ##
-## Ends in an error in state: 1408.
+## Ends in an error in state: 1412.
 ##
 ## cn_statement -> CN_UNFOLD UNAME VARIABLE LPAREN . loption(separated_nonempty_list(COMMA,expr)) RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -4115,7 +4115,7 @@ parsing "cn_statement": seen "CN_UNFOLD UNAME VARIABLE LPAREN", expecting "lopti
 
 cn_statements: CN_UNFOLD UNAME VARIABLE LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1410.
+## Ends in an error in state: 1414.
 ##
 ## cn_statement -> CN_UNFOLD UNAME VARIABLE LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN . SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -4127,7 +4127,7 @@ parsing "cn_statement": seen "CN_UNFOLD UNAME VARIABLE LPAREN loption(separated_
 
 cn_statements: CN_UNFOLD UNAME TYPE WHILE
 ##
-## Ends in an error in state: 1412.
+## Ends in an error in state: 1416.
 ##
 ## cn_statement -> CN_UNFOLD UNAME TYPE . LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -4139,7 +4139,7 @@ parsing "cn_statement": seen "CN_UNFOLD UNAME TYPE", expecting "LPAREN loption(s
 
 cn_statements: CN_UNFOLD UNAME TYPE LPAREN WHILE
 ##
-## Ends in an error in state: 1413.
+## Ends in an error in state: 1417.
 ##
 ## cn_statement -> CN_UNFOLD UNAME TYPE LPAREN . loption(separated_nonempty_list(COMMA,expr)) RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -4151,7 +4151,7 @@ parsing "cn_statement": seen "CN_UNFOLD UNAME TYPE LPAREN", expecting "loption(s
 
 cn_statements: CN_UNFOLD UNAME TYPE LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1415.
+## Ends in an error in state: 1419.
 ##
 ## cn_statement -> CN_UNFOLD UNAME TYPE LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN . SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -4163,7 +4163,7 @@ parsing "cn_statement": seen "CN_UNFOLD UNAME TYPE LPAREN loption(separated_none
 
 cn_statements: CN_UNFOLD LNAME VARIABLE WHILE
 ##
-## Ends in an error in state: 1418.
+## Ends in an error in state: 1422.
 ##
 ## cn_statement -> CN_UNFOLD LNAME VARIABLE . LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -4175,7 +4175,7 @@ parsing "cn_statement": seen "CN_UNFOLD LNAME VARIABLE", expecting "LPAREN lopti
 
 cn_statements: CN_UNFOLD LNAME VARIABLE LPAREN WHILE
 ##
-## Ends in an error in state: 1419.
+## Ends in an error in state: 1423.
 ##
 ## cn_statement -> CN_UNFOLD LNAME VARIABLE LPAREN . loption(separated_nonempty_list(COMMA,expr)) RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -4187,7 +4187,7 @@ parsing "cn_statement": seen "CN_UNFOLD LNAME VARIABLE LPAREN", expecting "lopti
 
 cn_statements: CN_UNFOLD LNAME VARIABLE LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1421.
+## Ends in an error in state: 1425.
 ##
 ## cn_statement -> CN_UNFOLD LNAME VARIABLE LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN . SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -4199,7 +4199,7 @@ parsing "cn_statement": seen "CN_UNFOLD LNAME VARIABLE LPAREN loption(separated_
 
 cn_statements: CN_UNFOLD LNAME TYPE WHILE
 ##
-## Ends in an error in state: 1423.
+## Ends in an error in state: 1427.
 ##
 ## cn_statement -> CN_UNFOLD LNAME TYPE . LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -4211,7 +4211,7 @@ parsing "cn_statement": seen "CN_UNFOLD LNAME TYPE", expecting "LPAREN loption(s
 
 cn_statements: CN_UNFOLD LNAME TYPE LPAREN WHILE
 ##
-## Ends in an error in state: 1424.
+## Ends in an error in state: 1428.
 ##
 ## cn_statement -> CN_UNFOLD LNAME TYPE LPAREN . loption(separated_nonempty_list(COMMA,expr)) RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -4223,7 +4223,7 @@ parsing "cn_statement": seen "CN_UNFOLD LNAME TYPE LPAREN", expecting "loption(s
 
 cn_statements: CN_UNFOLD LNAME TYPE LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1426.
+## Ends in an error in state: 1430.
 ##
 ## cn_statement -> CN_UNFOLD LNAME TYPE LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN . SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -4235,7 +4235,7 @@ parsing "cn_statement": seen "CN_UNFOLD LNAME TYPE LPAREN loption(separated_none
 
 cn_statements: CN_SPLIT_CASE WHILE
 ##
-## Ends in an error in state: 1434.
+## Ends in an error in state: 1438.
 ##
 ## cn_statement -> CN_SPLIT_CASE . assert_expr SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -4247,7 +4247,7 @@ parsing "cn_statement": seen "CN_SPLIT_CASE", expecting "assert_expr SEMICOLON"
 
 cn_statements: CN_HAVE CN_EACH LPAREN CN_ALLOC_ID UNAME VARIABLE SEMICOLON WHILE
 ##
-## Ends in an error in state: 1440.
+## Ends in an error in state: 1444.
 ##
 ## assert_expr -> CN_EACH LPAREN base_type UNAME VARIABLE SEMICOLON . expr RPAREN LBRACE expr RBRACE [ SEMICOLON RPAREN ]
 ##
@@ -4259,7 +4259,7 @@ parsing "assert_expr": seen "CN_EACH LPAREN base_type UNAME VARIABLE SEMICOLON",
 
 cn_statements: CN_HAVE CN_EACH LPAREN CN_ALLOC_ID UNAME VARIABLE SEMICOLON CN_CONSTANT RPAREN WHILE
 ##
-## Ends in an error in state: 1442.
+## Ends in an error in state: 1446.
 ##
 ## assert_expr -> CN_EACH LPAREN base_type UNAME VARIABLE SEMICOLON expr RPAREN . LBRACE expr RBRACE [ SEMICOLON RPAREN ]
 ##
@@ -4271,7 +4271,7 @@ parsing "assert_expr": seen "CN_EACH LPAREN base_type UNAME VARIABLE SEMICOLON e
 
 cn_statements: CN_HAVE CN_EACH LPAREN CN_ALLOC_ID UNAME VARIABLE SEMICOLON CN_CONSTANT RPAREN LBRACE WHILE
 ##
-## Ends in an error in state: 1443.
+## Ends in an error in state: 1447.
 ##
 ## assert_expr -> CN_EACH LPAREN base_type UNAME VARIABLE SEMICOLON expr RPAREN LBRACE . expr RBRACE [ SEMICOLON RPAREN ]
 ##
@@ -4283,7 +4283,7 @@ parsing "assert_expr": seen "CN_EACH LPAREN base_type UNAME VARIABLE SEMICOLON e
 
 cn_statements: CN_HAVE CN_EACH LPAREN CN_ALLOC_ID UNAME TYPE SEMICOLON WHILE
 ##
-## Ends in an error in state: 1447.
+## Ends in an error in state: 1451.
 ##
 ## assert_expr -> CN_EACH LPAREN base_type UNAME TYPE SEMICOLON . expr RPAREN LBRACE expr RBRACE [ SEMICOLON RPAREN ]
 ##
@@ -4295,7 +4295,7 @@ parsing "assert_expr": seen "CN_EACH LPAREN base_type UNAME TYPE SEMICOLON", exp
 
 cn_statements: CN_HAVE CN_EACH LPAREN CN_ALLOC_ID UNAME TYPE SEMICOLON CN_CONSTANT RPAREN WHILE
 ##
-## Ends in an error in state: 1449.
+## Ends in an error in state: 1453.
 ##
 ## assert_expr -> CN_EACH LPAREN base_type UNAME TYPE SEMICOLON expr RPAREN . LBRACE expr RBRACE [ SEMICOLON RPAREN ]
 ##
@@ -4307,7 +4307,7 @@ parsing "assert_expr": seen "CN_EACH LPAREN base_type UNAME TYPE SEMICOLON expr 
 
 cn_statements: CN_HAVE CN_EACH LPAREN CN_ALLOC_ID UNAME TYPE SEMICOLON CN_CONSTANT RPAREN LBRACE WHILE
 ##
-## Ends in an error in state: 1450.
+## Ends in an error in state: 1454.
 ##
 ## assert_expr -> CN_EACH LPAREN base_type UNAME TYPE SEMICOLON expr RPAREN LBRACE . expr RBRACE [ SEMICOLON RPAREN ]
 ##
@@ -4319,7 +4319,7 @@ parsing "assert_expr": seen "CN_EACH LPAREN base_type UNAME TYPE SEMICOLON expr 
 
 cn_statements: CN_HAVE CN_EACH LPAREN CN_ALLOC_ID LNAME VARIABLE SEMICOLON WHILE
 ##
-## Ends in an error in state: 1455.
+## Ends in an error in state: 1459.
 ##
 ## assert_expr -> CN_EACH LPAREN base_type LNAME VARIABLE SEMICOLON . expr RPAREN LBRACE expr RBRACE [ SEMICOLON RPAREN ]
 ##
@@ -4331,7 +4331,7 @@ parsing "assert_expr": seen "CN_EACH LPAREN base_type LNAME VARIABLE SEMICOLON",
 
 cn_statements: CN_HAVE CN_EACH LPAREN CN_ALLOC_ID LNAME VARIABLE SEMICOLON CN_CONSTANT RPAREN WHILE
 ##
-## Ends in an error in state: 1457.
+## Ends in an error in state: 1461.
 ##
 ## assert_expr -> CN_EACH LPAREN base_type LNAME VARIABLE SEMICOLON expr RPAREN . LBRACE expr RBRACE [ SEMICOLON RPAREN ]
 ##
@@ -4343,7 +4343,7 @@ parsing "assert_expr": seen "CN_EACH LPAREN base_type LNAME VARIABLE SEMICOLON e
 
 cn_statements: CN_HAVE CN_EACH LPAREN CN_ALLOC_ID LNAME VARIABLE SEMICOLON CN_CONSTANT RPAREN LBRACE WHILE
 ##
-## Ends in an error in state: 1458.
+## Ends in an error in state: 1462.
 ##
 ## assert_expr -> CN_EACH LPAREN base_type LNAME VARIABLE SEMICOLON expr RPAREN LBRACE . expr RBRACE [ SEMICOLON RPAREN ]
 ##
@@ -4355,7 +4355,7 @@ parsing "assert_expr": seen "CN_EACH LPAREN base_type LNAME VARIABLE SEMICOLON e
 
 cn_statements: CN_HAVE CN_EACH LPAREN CN_ALLOC_ID LNAME TYPE SEMICOLON WHILE
 ##
-## Ends in an error in state: 1462.
+## Ends in an error in state: 1466.
 ##
 ## assert_expr -> CN_EACH LPAREN base_type LNAME TYPE SEMICOLON . expr RPAREN LBRACE expr RBRACE [ SEMICOLON RPAREN ]
 ##
@@ -4367,7 +4367,7 @@ parsing "assert_expr": seen "CN_EACH LPAREN base_type LNAME TYPE SEMICOLON", exp
 
 cn_statements: CN_HAVE CN_EACH LPAREN CN_ALLOC_ID LNAME TYPE SEMICOLON CN_CONSTANT RPAREN WHILE
 ##
-## Ends in an error in state: 1464.
+## Ends in an error in state: 1468.
 ##
 ## assert_expr -> CN_EACH LPAREN base_type LNAME TYPE SEMICOLON expr RPAREN . LBRACE expr RBRACE [ SEMICOLON RPAREN ]
 ##
@@ -4379,7 +4379,7 @@ parsing "assert_expr": seen "CN_EACH LPAREN base_type LNAME TYPE SEMICOLON expr 
 
 cn_statements: CN_HAVE CN_EACH LPAREN CN_ALLOC_ID LNAME TYPE SEMICOLON CN_CONSTANT RPAREN LBRACE WHILE
 ##
-## Ends in an error in state: 1465.
+## Ends in an error in state: 1469.
 ##
 ## assert_expr -> CN_EACH LPAREN base_type LNAME TYPE SEMICOLON expr RPAREN LBRACE . expr RBRACE [ SEMICOLON RPAREN ]
 ##
@@ -4391,7 +4391,7 @@ parsing "assert_expr": seen "CN_EACH LPAREN base_type LNAME TYPE SEMICOLON expr 
 
 cn_statements: CN_PRINT WHILE
 ##
-## Ends in an error in state: 1471.
+## Ends in an error in state: 1475.
 ##
 ## cn_statement -> CN_PRINT . LPAREN expr RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -4403,7 +4403,7 @@ parsing "cn_statement": seen "CN_PRINT", expecting "LPAREN expr RPAREN SEMICOLON
 
 cn_statements: CN_PRINT LPAREN WHILE
 ##
-## Ends in an error in state: 1472.
+## Ends in an error in state: 1476.
 ##
 ## cn_statement -> CN_PRINT LPAREN . expr RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -4415,7 +4415,7 @@ parsing "cn_statement": seen "CN_PRINT LPAREN", expecting "expr RPAREN SEMICOLON
 
 cn_statements: CN_PRINT LPAREN CN_CONSTANT RPAREN WHILE
 ##
-## Ends in an error in state: 1474.
+## Ends in an error in state: 1478.
 ##
 ## cn_statement -> CN_PRINT LPAREN expr RPAREN . SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -4427,7 +4427,7 @@ parsing "cn_statement": seen "CN_PRINT LPAREN expr RPAREN", expecting "SEMICOLON
 
 cn_statements: CN_PACK WHILE
 ##
-## Ends in an error in state: 1476.
+## Ends in an error in state: 1480.
 ##
 ## cn_statement -> CN_PACK . pred LPAREN cn_exprs_or_elipsis RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -4439,7 +4439,7 @@ parsing "cn_statement": seen "CN_PACK", expecting "pred LPAREN loption(separated
 
 cn_statements: CN_PACK CN_OWNED LPAREN WHILE
 ##
-## Ends in an error in state: 1478.
+## Ends in an error in state: 1482.
 ##
 ## cn_statement -> CN_PACK pred LPAREN . cn_exprs_or_elipsis RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -4451,7 +4451,7 @@ parsing "cn_statement": seen "CN_PACK pred LPAREN", expecting "loption(separated
 
 cn_statements: CN_PACK CN_OWNED LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1480.
+## Ends in an error in state: 1484.
 ##
 ## cn_statement -> CN_PACK pred LPAREN cn_exprs_or_elipsis RPAREN . SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -4463,7 +4463,7 @@ parsing "cn_statement": seen "CN_PACK pred LPAREN loption(separated_nonempty_lis
 
 cn_statements: CN_INSTANTIATE UNAME VARIABLE COMMA WHILE
 ##
-## Ends in an error in state: 1485.
+## Ends in an error in state: 1489.
 ##
 ## cn_statement -> CN_INSTANTIATE UNAME VARIABLE COMMA . expr SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -4475,7 +4475,7 @@ parsing "cn_statement": seen "CN_INSTANTIATE UNAME VARIABLE COMMA", expecting "e
 
 cn_statements: CN_INSTANTIATE UNAME TYPE COMMA WHILE
 ##
-## Ends in an error in state: 1489.
+## Ends in an error in state: 1493.
 ##
 ## cn_statement -> CN_INSTANTIATE UNAME TYPE COMMA . expr SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -4487,7 +4487,7 @@ parsing "cn_statement": seen "CN_INSTANTIATE UNAME TYPE COMMA", expecting "expr 
 
 cn_statements: CN_INSTANTIATE LNAME VARIABLE COMMA WHILE
 ##
-## Ends in an error in state: 1494.
+## Ends in an error in state: 1498.
 ##
 ## cn_statement -> CN_INSTANTIATE LNAME VARIABLE COMMA . expr SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -4499,7 +4499,7 @@ parsing "cn_statement": seen "CN_INSTANTIATE LNAME VARIABLE COMMA", expecting "e
 
 cn_statements: CN_INSTANTIATE LNAME TYPE COMMA WHILE
 ##
-## Ends in an error in state: 1498.
+## Ends in an error in state: 1502.
 ##
 ## cn_statement -> CN_INSTANTIATE LNAME TYPE COMMA . expr SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -4511,7 +4511,7 @@ parsing "cn_statement": seen "CN_INSTANTIATE LNAME TYPE COMMA", expecting "expr 
 
 cn_statements: CN_INSTANTIATE CN_GOOD LT BOOL GT COMMA WHILE
 ##
-## Ends in an error in state: 1504.
+## Ends in an error in state: 1508.
 ##
 ## cn_statement -> CN_INSTANTIATE cn_good COMMA . expr SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -4523,7 +4523,7 @@ parsing "cn_statement": seen "CN_INSTANTIATE cn_good COMMA", expecting "expr SEM
 
 cn_statements: CN_HAVE WHILE
 ##
-## Ends in an error in state: 1507.
+## Ends in an error in state: 1511.
 ##
 ## cn_statement -> CN_HAVE . assert_expr SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -4535,7 +4535,7 @@ parsing "cn_statement": seen "CN_HAVE", expecting "assert_expr SEMICOLON"
 
 cn_statements: CN_EXTRACT CN_OWNED COMMA WHILE
 ##
-## Ends in an error in state: 1520.
+## Ends in an error in state: 1524.
 ##
 ## cn_statement -> CN_EXTRACT pred COMMA . expr SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -4547,7 +4547,7 @@ parsing "cn_statement": seen "CN_EXTRACT pred COMMA", expecting "expr SEMICOLON"
 
 cn_statements: CN_APPLY UNAME VARIABLE WHILE
 ##
-## Ends in an error in state: 1527.
+## Ends in an error in state: 1531.
 ##
 ## cn_statement -> CN_APPLY UNAME VARIABLE . LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -4559,7 +4559,7 @@ parsing "cn_statement": seen "CN_APPLY UNAME VARIABLE", expecting "LPAREN loptio
 
 cn_statements: CN_APPLY UNAME VARIABLE LPAREN WHILE
 ##
-## Ends in an error in state: 1528.
+## Ends in an error in state: 1532.
 ##
 ## cn_statement -> CN_APPLY UNAME VARIABLE LPAREN . loption(separated_nonempty_list(COMMA,expr)) RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -4571,7 +4571,7 @@ parsing "cn_statement": seen "CN_APPLY UNAME VARIABLE LPAREN", expecting "loptio
 
 cn_statements: CN_APPLY UNAME VARIABLE LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1530.
+## Ends in an error in state: 1534.
 ##
 ## cn_statement -> CN_APPLY UNAME VARIABLE LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN . SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -4583,7 +4583,7 @@ parsing "cn_statement": seen "CN_APPLY UNAME VARIABLE LPAREN loption(separated_n
 
 cn_statements: CN_APPLY UNAME TYPE WHILE
 ##
-## Ends in an error in state: 1532.
+## Ends in an error in state: 1536.
 ##
 ## cn_statement -> CN_APPLY UNAME TYPE . LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -4595,7 +4595,7 @@ parsing "cn_statement": seen "CN_APPLY UNAME TYPE", expecting "LPAREN loption(se
 
 cn_statements: CN_APPLY UNAME TYPE LPAREN WHILE
 ##
-## Ends in an error in state: 1533.
+## Ends in an error in state: 1537.
 ##
 ## cn_statement -> CN_APPLY UNAME TYPE LPAREN . loption(separated_nonempty_list(COMMA,expr)) RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -4607,7 +4607,7 @@ parsing "cn_statement": seen "CN_APPLY UNAME TYPE LPAREN", expecting "loption(se
 
 cn_statements: CN_APPLY UNAME TYPE LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1535.
+## Ends in an error in state: 1539.
 ##
 ## cn_statement -> CN_APPLY UNAME TYPE LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN . SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -4619,7 +4619,7 @@ parsing "cn_statement": seen "CN_APPLY UNAME TYPE LPAREN loption(separated_nonem
 
 cn_statements: CN_APPLY LNAME VARIABLE WHILE
 ##
-## Ends in an error in state: 1538.
+## Ends in an error in state: 1542.
 ##
 ## cn_statement -> CN_APPLY LNAME VARIABLE . LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -4631,7 +4631,7 @@ parsing "cn_statement": seen "CN_APPLY LNAME VARIABLE", expecting "LPAREN loptio
 
 cn_statements: CN_APPLY LNAME VARIABLE LPAREN WHILE
 ##
-## Ends in an error in state: 1539.
+## Ends in an error in state: 1543.
 ##
 ## cn_statement -> CN_APPLY LNAME VARIABLE LPAREN . loption(separated_nonempty_list(COMMA,expr)) RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -4643,7 +4643,7 @@ parsing "cn_statement": seen "CN_APPLY LNAME VARIABLE LPAREN", expecting "loptio
 
 cn_statements: CN_APPLY LNAME VARIABLE LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1541.
+## Ends in an error in state: 1545.
 ##
 ## cn_statement -> CN_APPLY LNAME VARIABLE LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN . SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -4655,7 +4655,7 @@ parsing "cn_statement": seen "CN_APPLY LNAME VARIABLE LPAREN loption(separated_n
 
 cn_statements: CN_APPLY LNAME TYPE WHILE
 ##
-## Ends in an error in state: 1543.
+## Ends in an error in state: 1547.
 ##
 ## cn_statement -> CN_APPLY LNAME TYPE . LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -4667,7 +4667,7 @@ parsing "cn_statement": seen "CN_APPLY LNAME TYPE", expecting "LPAREN loption(se
 
 cn_statements: CN_APPLY LNAME TYPE LPAREN WHILE
 ##
-## Ends in an error in state: 1544.
+## Ends in an error in state: 1548.
 ##
 ## cn_statement -> CN_APPLY LNAME TYPE LPAREN . loption(separated_nonempty_list(COMMA,expr)) RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -4679,7 +4679,7 @@ parsing "cn_statement": seen "CN_APPLY LNAME TYPE LPAREN", expecting "loption(se
 
 cn_statements: CN_APPLY LNAME TYPE LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1546.
+## Ends in an error in state: 1550.
 ##
 ## cn_statement -> CN_APPLY LNAME TYPE LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN . SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -4691,7 +4691,7 @@ parsing "cn_statement": seen "CN_APPLY LNAME TYPE LPAREN loption(separated_nonem
 
 cn_statements: ASSERT WHILE
 ##
-## Ends in an error in state: 1548.
+## Ends in an error in state: 1552.
 ##
 ## cn_statement -> ASSERT . LPAREN assert_expr RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -4703,7 +4703,7 @@ parsing "cn_statement": seen "ASSERT", expecting "LPAREN assert_expr RPAREN SEMI
 
 cn_statements: ASSERT LPAREN WHILE
 ##
-## Ends in an error in state: 1549.
+## Ends in an error in state: 1553.
 ##
 ## cn_statement -> ASSERT LPAREN . assert_expr RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -4715,7 +4715,7 @@ parsing "cn_statement": seen "ASSERT LPAREN", expecting "assert_expr RPAREN SEMI
 
 cn_statements: ASSERT LPAREN CN_CONSTANT RPAREN WHILE
 ##
-## Ends in an error in state: 1551.
+## Ends in an error in state: 1555.
 ##
 ## cn_statement -> ASSERT LPAREN assert_expr RPAREN . SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -4727,7 +4727,7 @@ parsing "cn_statement": seen "ASSERT LPAREN assert_expr RPAREN", expecting "SEMI
 
 cn_toplevel: WHILE
 ##
-## Ends in an error in state: 1558.
+## Ends in an error in state: 1562.
 ##
 ## cn_toplevel' -> . cn_toplevel [ # ]
 ##
@@ -4739,7 +4739,7 @@ parsing "cn_toplevel'": expected "cn_toplevel"
 
 cn_toplevel: CN_TYPE_SYNONYM UNAME VARIABLE WHILE
 ##
-## Ends in an error in state: 1561.
+## Ends in an error in state: 1565.
 ##
 ## cn_type_synonym -> CN_TYPE_SYNONYM UNAME VARIABLE . EQ opt_paren(base_type) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -4751,7 +4751,7 @@ parsing "cn_type_synonym": seen "CN_TYPE_SYNONYM UNAME VARIABLE", expecting "EQ 
 
 cn_toplevel: CN_TYPE_SYNONYM UNAME VARIABLE EQ WHILE
 ##
-## Ends in an error in state: 1562.
+## Ends in an error in state: 1566.
 ##
 ## cn_type_synonym -> CN_TYPE_SYNONYM UNAME VARIABLE EQ . opt_paren(base_type) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -4763,7 +4763,7 @@ parsing "cn_type_synonym": seen "CN_TYPE_SYNONYM UNAME VARIABLE EQ", expecting "
 
 cn_toplevel: CN_PREDICATE LPAREN WHILE
 ##
-## Ends in an error in state: 1563.
+## Ends in an error in state: 1567.
 ##
 ## opt_paren(base_type) -> LPAREN . base_type RPAREN [ UNAME EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -4775,7 +4775,7 @@ parsing "opt_paren(base_type)": seen "LPAREN", expecting "base_type RPAREN"
 
 cn_toplevel: CN_PREDICATE LPAREN CN_ALLOC_ID WHILE
 ##
-## Ends in an error in state: 1564.
+## Ends in an error in state: 1568.
 ##
 ## opt_paren(base_type) -> LPAREN base_type . RPAREN [ UNAME EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -4787,7 +4787,7 @@ parsing "opt_paren(base_type)": seen "LPAREN base_type", expecting "RPAREN"
 
 cn_toplevel: CN_TYPE_SYNONYM UNAME TYPE WHILE
 ##
-## Ends in an error in state: 1568.
+## Ends in an error in state: 1572.
 ##
 ## cn_type_synonym -> CN_TYPE_SYNONYM UNAME TYPE . EQ opt_paren(base_type) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -4799,7 +4799,7 @@ parsing "cn_type_synonym": seen "CN_TYPE_SYNONYM UNAME TYPE", expecting "EQ opt_
 
 cn_toplevel: CN_TYPE_SYNONYM UNAME TYPE EQ WHILE
 ##
-## Ends in an error in state: 1569.
+## Ends in an error in state: 1573.
 ##
 ## cn_type_synonym -> CN_TYPE_SYNONYM UNAME TYPE EQ . opt_paren(base_type) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -4811,7 +4811,7 @@ parsing "cn_type_synonym": seen "CN_TYPE_SYNONYM UNAME TYPE EQ", expecting "opt_
 
 cn_toplevel: CN_TYPE_SYNONYM LNAME VARIABLE WHILE
 ##
-## Ends in an error in state: 1572.
+## Ends in an error in state: 1576.
 ##
 ## cn_type_synonym -> CN_TYPE_SYNONYM LNAME VARIABLE . EQ opt_paren(base_type) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -4823,7 +4823,7 @@ parsing "cn_type_synonym": seen "CN_TYPE_SYNONYM LNAME VARIABLE", expecting "EQ 
 
 cn_toplevel: CN_TYPE_SYNONYM LNAME VARIABLE EQ WHILE
 ##
-## Ends in an error in state: 1573.
+## Ends in an error in state: 1577.
 ##
 ## cn_type_synonym -> CN_TYPE_SYNONYM LNAME VARIABLE EQ . opt_paren(base_type) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -4835,7 +4835,7 @@ parsing "cn_type_synonym": seen "CN_TYPE_SYNONYM LNAME VARIABLE EQ", expecting "
 
 cn_toplevel: CN_TYPE_SYNONYM LNAME TYPE WHILE
 ##
-## Ends in an error in state: 1575.
+## Ends in an error in state: 1579.
 ##
 ## cn_type_synonym -> CN_TYPE_SYNONYM LNAME TYPE . EQ opt_paren(base_type) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -4847,7 +4847,7 @@ parsing "cn_type_synonym": seen "CN_TYPE_SYNONYM LNAME TYPE", expecting "EQ opt_
 
 cn_toplevel: CN_TYPE_SYNONYM LNAME TYPE EQ WHILE
 ##
-## Ends in an error in state: 1576.
+## Ends in an error in state: 1580.
 ##
 ## cn_type_synonym -> CN_TYPE_SYNONYM LNAME TYPE EQ . opt_paren(base_type) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -4859,7 +4859,7 @@ parsing "cn_type_synonym": seen "CN_TYPE_SYNONYM LNAME TYPE EQ", expecting "opt_
 
 cn_toplevel: CN_SPEC UNAME VARIABLE WHILE
 ##
-## Ends in an error in state: 1580.
+## Ends in an error in state: 1584.
 ##
 ## cn_fun_spec -> CN_SPEC UNAME VARIABLE . LPAREN cn_args RPAREN SEMICOLON function_spec [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -4871,7 +4871,7 @@ parsing "cn_fun_spec": seen "CN_SPEC UNAME VARIABLE", expecting "LPAREN cn_args 
 
 cn_toplevel: CN_SPEC UNAME VARIABLE LPAREN WHILE
 ##
-## Ends in an error in state: 1581.
+## Ends in an error in state: 1585.
 ##
 ## cn_fun_spec -> CN_SPEC UNAME VARIABLE LPAREN . cn_args RPAREN SEMICOLON function_spec [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -4883,7 +4883,7 @@ parsing "cn_fun_spec": seen "CN_SPEC UNAME VARIABLE LPAREN", expecting "cn_args 
 
 cn_toplevel: CN_SPEC UNAME VARIABLE LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1585.
+## Ends in an error in state: 1589.
 ##
 ## cn_fun_spec -> CN_SPEC UNAME VARIABLE LPAREN cn_args RPAREN . SEMICOLON function_spec [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -4895,7 +4895,7 @@ parsing "cn_fun_spec": seen "CN_SPEC UNAME VARIABLE LPAREN cn_args RPAREN", expe
 
 cn_toplevel: CN_SPEC UNAME VARIABLE LPAREN RPAREN SEMICOLON WHILE
 ##
-## Ends in an error in state: 1586.
+## Ends in an error in state: 1590.
 ##
 ## cn_fun_spec -> CN_SPEC UNAME VARIABLE LPAREN cn_args RPAREN SEMICOLON . function_spec [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -4907,7 +4907,7 @@ parsing "cn_fun_spec": seen "CN_SPEC UNAME VARIABLE LPAREN cn_args RPAREN SEMICO
 
 cn_toplevel: CN_SPEC UNAME VARIABLE LPAREN RPAREN SEMICOLON CN_REQUIRES WHILE
 ##
-## Ends in an error in state: 1605.
+## Ends in an error in state: 1609.
 ##
 ## requires_clauses -> CN_REQUIRES . option(ghost_binders) nonempty_list(condition) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_ENSURES CN_DATATYPE ]
 ##
@@ -4965,7 +4965,7 @@ parsing "cn_fun_spec": seen "CN_SPEC UNAME VARIABLE LPAREN cn_args RPAREN SEMICO
 
 cn_toplevel: CN_SPEC UNAME TYPE WHILE
 ##
-## Ends in an error in state: 1715.
+## Ends in an error in state: 1719.
 ##
 ## cn_fun_spec -> CN_SPEC UNAME TYPE . LPAREN cn_args RPAREN SEMICOLON function_spec [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -4977,7 +4977,7 @@ parsing "cn_fun_spec": seen "CN_SPEC UNAME TYPE", expecting "LPAREN cn_args RPAR
 
 cn_toplevel: CN_SPEC UNAME TYPE LPAREN WHILE
 ##
-## Ends in an error in state: 1716.
+## Ends in an error in state: 1720.
 ##
 ## cn_fun_spec -> CN_SPEC UNAME TYPE LPAREN . cn_args RPAREN SEMICOLON function_spec [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -4989,7 +4989,7 @@ parsing "cn_fun_spec": seen "CN_SPEC UNAME TYPE LPAREN", expecting "cn_args RPAR
 
 cn_toplevel: CN_SPEC UNAME TYPE LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1718.
+## Ends in an error in state: 1722.
 ##
 ## cn_fun_spec -> CN_SPEC UNAME TYPE LPAREN cn_args RPAREN . SEMICOLON function_spec [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -5001,7 +5001,7 @@ parsing "cn_fun_spec": seen "CN_SPEC UNAME TYPE LPAREN cn_args RPAREN", expectin
 
 cn_toplevel: CN_SPEC UNAME TYPE LPAREN RPAREN SEMICOLON WHILE
 ##
-## Ends in an error in state: 1719.
+## Ends in an error in state: 1723.
 ##
 ## cn_fun_spec -> CN_SPEC UNAME TYPE LPAREN cn_args RPAREN SEMICOLON . function_spec [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -5013,7 +5013,7 @@ parsing "cn_fun_spec": seen "CN_SPEC UNAME TYPE LPAREN cn_args RPAREN SEMICOLON"
 
 cn_toplevel: CN_SPEC LNAME VARIABLE WHILE
 ##
-## Ends in an error in state: 1722.
+## Ends in an error in state: 1726.
 ##
 ## cn_fun_spec -> CN_SPEC LNAME VARIABLE . LPAREN cn_args RPAREN SEMICOLON function_spec [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -5025,7 +5025,7 @@ parsing "cn_fun_spec": seen "CN_SPEC LNAME VARIABLE", expecting "LPAREN cn_args 
 
 cn_toplevel: CN_SPEC LNAME VARIABLE LPAREN WHILE
 ##
-## Ends in an error in state: 1723.
+## Ends in an error in state: 1727.
 ##
 ## cn_fun_spec -> CN_SPEC LNAME VARIABLE LPAREN . cn_args RPAREN SEMICOLON function_spec [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -5037,7 +5037,7 @@ parsing "cn_fun_spec": seen "CN_SPEC LNAME VARIABLE LPAREN", expecting "cn_args 
 
 cn_toplevel: CN_SPEC LNAME VARIABLE LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1725.
+## Ends in an error in state: 1729.
 ##
 ## cn_fun_spec -> CN_SPEC LNAME VARIABLE LPAREN cn_args RPAREN . SEMICOLON function_spec [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -5049,7 +5049,7 @@ parsing "cn_fun_spec": seen "CN_SPEC LNAME VARIABLE LPAREN cn_args RPAREN", expe
 
 cn_toplevel: CN_SPEC LNAME VARIABLE LPAREN RPAREN SEMICOLON WHILE
 ##
-## Ends in an error in state: 1726.
+## Ends in an error in state: 1730.
 ##
 ## cn_fun_spec -> CN_SPEC LNAME VARIABLE LPAREN cn_args RPAREN SEMICOLON . function_spec [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -5061,7 +5061,7 @@ parsing "cn_fun_spec": seen "CN_SPEC LNAME VARIABLE LPAREN cn_args RPAREN SEMICO
 
 cn_toplevel: CN_SPEC LNAME TYPE WHILE
 ##
-## Ends in an error in state: 1728.
+## Ends in an error in state: 1732.
 ##
 ## cn_fun_spec -> CN_SPEC LNAME TYPE . LPAREN cn_args RPAREN SEMICOLON function_spec [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -5073,7 +5073,7 @@ parsing "cn_fun_spec": seen "CN_SPEC LNAME TYPE", expecting "LPAREN cn_args RPAR
 
 cn_toplevel: CN_SPEC LNAME TYPE LPAREN WHILE
 ##
-## Ends in an error in state: 1729.
+## Ends in an error in state: 1733.
 ##
 ## cn_fun_spec -> CN_SPEC LNAME TYPE LPAREN . cn_args RPAREN SEMICOLON function_spec [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -5085,7 +5085,7 @@ parsing "cn_fun_spec": seen "CN_SPEC LNAME TYPE LPAREN", expecting "cn_args RPAR
 
 cn_toplevel: CN_SPEC LNAME TYPE LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1731.
+## Ends in an error in state: 1735.
 ##
 ## cn_fun_spec -> CN_SPEC LNAME TYPE LPAREN cn_args RPAREN . SEMICOLON function_spec [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -5097,7 +5097,7 @@ parsing "cn_fun_spec": seen "CN_SPEC LNAME TYPE LPAREN cn_args RPAREN", expectin
 
 cn_toplevel: CN_SPEC LNAME TYPE LPAREN RPAREN SEMICOLON WHILE
 ##
-## Ends in an error in state: 1732.
+## Ends in an error in state: 1736.
 ##
 ## cn_fun_spec -> CN_SPEC LNAME TYPE LPAREN cn_args RPAREN SEMICOLON . function_spec [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -5109,7 +5109,7 @@ parsing "cn_fun_spec": seen "CN_SPEC LNAME TYPE LPAREN cn_args RPAREN SEMICOLON"
 
 cn_toplevel: CN_PREDICATE WHILE
 ##
-## Ends in an error in state: 1734.
+## Ends in an error in state: 1738.
 ##
 ## cn_predicate -> CN_PREDICATE . cn_attrs cn_pred_output UNAME VARIABLE LPAREN cn_args RPAREN cn_option_pred_clauses [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -5121,7 +5121,7 @@ parsing "cn_predicate": seen "CN_PREDICATE", expecting "cn_attrs cn_pred_output 
 
 cn_toplevel: CN_FUNCTION LBRACK WHILE
 ##
-## Ends in an error in state: 1735.
+## Ends in an error in state: 1739.
 ##
 ## cn_attrs -> LBRACK . loption(separated_nonempty_list(COMMA,cn_variable)) RBRACK [ VOID UNAME STRUCT LPAREN LNAME LBRACE CN_TUPLE CN_SET CN_REAL CN_POINTER CN_MAP CN_LIST CN_INTEGER CN_DATATYPE CN_BOOL CN_BITS CN_ALLOC_ID ]
 ##
@@ -5133,7 +5133,7 @@ parsing "cn_attrs": seen "LBRACK", expecting "loption(separated_nonempty_list(CO
 
 cn_toplevel: CN_PREDICATE LBRACK RBRACK WHILE
 ##
-## Ends in an error in state: 1738.
+## Ends in an error in state: 1742.
 ##
 ## cn_predicate -> CN_PREDICATE cn_attrs . cn_pred_output UNAME VARIABLE LPAREN cn_args RPAREN cn_option_pred_clauses [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -5145,7 +5145,7 @@ parsing "cn_predicate": seen "CN_PREDICATE cn_attrs", expecting "cn_pred_output 
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID WHILE
 ##
-## Ends in an error in state: 1740.
+## Ends in an error in state: 1744.
 ##
 ## cn_predicate -> CN_PREDICATE cn_attrs cn_pred_output . UNAME VARIABLE LPAREN cn_args RPAREN cn_option_pred_clauses [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -5157,7 +5157,7 @@ parsing "cn_predicate": seen "CN_PREDICATE cn_attrs cn_pred_output", expecting "
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME WHILE
 ##
-## Ends in an error in state: 1741.
+## Ends in an error in state: 1745.
 ##
 ## cn_predicate -> CN_PREDICATE cn_attrs cn_pred_output UNAME . VARIABLE LPAREN cn_args RPAREN cn_option_pred_clauses [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -5169,7 +5169,7 @@ parsing "cn_predicate": seen "CN_PREDICATE cn_attrs cn_pred_output UNAME", expec
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE WHILE
 ##
-## Ends in an error in state: 1742.
+## Ends in an error in state: 1746.
 ##
 ## cn_predicate -> CN_PREDICATE cn_attrs cn_pred_output UNAME VARIABLE . LPAREN cn_args RPAREN cn_option_pred_clauses [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -5181,7 +5181,7 @@ parsing "cn_predicate": seen "CN_PREDICATE cn_attrs cn_pred_output UNAME VARIABL
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN WHILE
 ##
-## Ends in an error in state: 1743.
+## Ends in an error in state: 1747.
 ##
 ## cn_predicate -> CN_PREDICATE cn_attrs cn_pred_output UNAME VARIABLE LPAREN . cn_args RPAREN cn_option_pred_clauses [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -5193,7 +5193,7 @@ parsing "cn_predicate": seen "CN_PREDICATE cn_attrs cn_pred_output UNAME VARIABL
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1745.
+## Ends in an error in state: 1749.
 ##
 ## cn_predicate -> CN_PREDICATE cn_attrs cn_pred_output UNAME VARIABLE LPAREN cn_args RPAREN . cn_option_pred_clauses [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -5205,7 +5205,7 @@ parsing "cn_predicate": seen "CN_PREDICATE cn_attrs cn_pred_output UNAME VARIABL
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE WHILE
 ##
-## Ends in an error in state: 1746.
+## Ends in an error in state: 1750.
 ##
 ## cn_option_pred_clauses -> LBRACE . clauses RBRACE [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -5217,7 +5217,7 @@ parsing "cn_option_pred_clauses": seen "LBRACE", expecting "clauses RBRACE"
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE IF WHILE
 ##
-## Ends in an error in state: 1750.
+## Ends in an error in state: 1754.
 ##
 ## if_clauses -> IF . LPAREN expr RPAREN LBRACE clause SEMICOLON RBRACE ELSE if_clauses [ RBRACE ]
 ##
@@ -5229,7 +5229,7 @@ parsing "clauses": seen "IF", expecting "LPAREN expr RPAREN LBRACE clause SEMICO
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE IF LPAREN WHILE
 ##
-## Ends in an error in state: 1751.
+## Ends in an error in state: 1755.
 ##
 ## if_clauses -> IF LPAREN . expr RPAREN LBRACE clause SEMICOLON RBRACE ELSE if_clauses [ RBRACE ]
 ##
@@ -5241,7 +5241,7 @@ parsing "clauses": seen "IF LPAREN", expecting "expr RPAREN LBRACE clause SEMICO
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE IF LPAREN CN_CONSTANT RPAREN WHILE
 ##
-## Ends in an error in state: 1753.
+## Ends in an error in state: 1757.
 ##
 ## if_clauses -> IF LPAREN expr RPAREN . LBRACE clause SEMICOLON RBRACE ELSE if_clauses [ RBRACE ]
 ##
@@ -5253,7 +5253,7 @@ parsing "clauses": seen "IF LPAREN expr RPAREN", expecting "LBRACE clause SEMICO
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE IF LPAREN CN_CONSTANT RPAREN LBRACE WHILE
 ##
-## Ends in an error in state: 1754.
+## Ends in an error in state: 1758.
 ##
 ## if_clauses -> IF LPAREN expr RPAREN LBRACE . clause SEMICOLON RBRACE ELSE if_clauses [ RBRACE ]
 ##
@@ -5265,7 +5265,7 @@ parsing "clauses": seen "IF LPAREN expr RPAREN LBRACE", expecting "clause SEMICO
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_TAKE UNAME VARIABLE WHILE
 ##
-## Ends in an error in state: 1757.
+## Ends in an error in state: 1761.
 ##
 ## clause -> CN_TAKE UNAME VARIABLE . EQ resource SEMICOLON clause [ SEMICOLON ]
 ##
@@ -5277,7 +5277,7 @@ parsing "clause": seen "CN_TAKE UNAME VARIABLE", expecting "EQ resource SEMICOLO
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_TAKE UNAME VARIABLE EQ WHILE
 ##
-## Ends in an error in state: 1758.
+## Ends in an error in state: 1762.
 ##
 ## clause -> CN_TAKE UNAME VARIABLE EQ . resource SEMICOLON clause [ SEMICOLON ]
 ##
@@ -5289,7 +5289,7 @@ parsing "clause": seen "CN_TAKE UNAME VARIABLE EQ", expecting "resource SEMICOLO
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_TAKE UNAME VARIABLE EQ CN_OWNED LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1759.
+## Ends in an error in state: 1763.
 ##
 ## clause -> CN_TAKE UNAME VARIABLE EQ resource . SEMICOLON clause [ SEMICOLON ]
 ##
@@ -5301,7 +5301,7 @@ parsing "clause": seen "CN_TAKE UNAME VARIABLE EQ resource", expecting "SEMICOLO
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_TAKE UNAME VARIABLE EQ CN_OWNED LPAREN RPAREN SEMICOLON WHILE
 ##
-## Ends in an error in state: 1760.
+## Ends in an error in state: 1764.
 ##
 ## clause -> CN_TAKE UNAME VARIABLE EQ resource SEMICOLON . clause [ SEMICOLON ]
 ##
@@ -5313,7 +5313,7 @@ parsing "clause": seen "CN_TAKE UNAME VARIABLE EQ resource SEMICOLON", expecting
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_LET UNAME VARIABLE WHILE
 ##
-## Ends in an error in state: 1763.
+## Ends in an error in state: 1767.
 ##
 ## clause -> CN_LET UNAME VARIABLE . EQ expr SEMICOLON clause [ SEMICOLON ]
 ##
@@ -5325,7 +5325,7 @@ parsing "clause": seen "CN_LET UNAME VARIABLE", expecting "EQ expr SEMICOLON cla
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_LET UNAME VARIABLE EQ WHILE
 ##
-## Ends in an error in state: 1764.
+## Ends in an error in state: 1768.
 ##
 ## clause -> CN_LET UNAME VARIABLE EQ . expr SEMICOLON clause [ SEMICOLON ]
 ##
@@ -5337,7 +5337,7 @@ parsing "clause": seen "CN_LET UNAME VARIABLE EQ", expecting "expr SEMICOLON cla
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_LET UNAME VARIABLE EQ CN_CONSTANT SEMICOLON WHILE
 ##
-## Ends in an error in state: 1766.
+## Ends in an error in state: 1770.
 ##
 ## clause -> CN_LET UNAME VARIABLE EQ expr SEMICOLON . clause [ SEMICOLON ]
 ##
@@ -5349,7 +5349,7 @@ parsing "clause": seen "CN_LET UNAME VARIABLE EQ expr SEMICOLON", expecting "cla
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE ASSERT WHILE
 ##
-## Ends in an error in state: 1767.
+## Ends in an error in state: 1771.
 ##
 ## clause -> ASSERT . LPAREN assert_expr RPAREN SEMICOLON clause [ SEMICOLON ]
 ##
@@ -5361,7 +5361,7 @@ parsing "clause": seen "ASSERT", expecting "LPAREN assert_expr RPAREN SEMICOLON 
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE ASSERT LPAREN WHILE
 ##
-## Ends in an error in state: 1768.
+## Ends in an error in state: 1772.
 ##
 ## clause -> ASSERT LPAREN . assert_expr RPAREN SEMICOLON clause [ SEMICOLON ]
 ##
@@ -5373,7 +5373,7 @@ parsing "clause": seen "ASSERT LPAREN", expecting "assert_expr RPAREN SEMICOLON 
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE ASSERT LPAREN CN_CONSTANT RPAREN WHILE
 ##
-## Ends in an error in state: 1770.
+## Ends in an error in state: 1774.
 ##
 ## clause -> ASSERT LPAREN assert_expr RPAREN . SEMICOLON clause [ SEMICOLON ]
 ##
@@ -5385,7 +5385,7 @@ parsing "clause": seen "ASSERT LPAREN assert_expr RPAREN", expecting "SEMICOLON 
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE ASSERT LPAREN CN_CONSTANT RPAREN SEMICOLON WHILE
 ##
-## Ends in an error in state: 1771.
+## Ends in an error in state: 1775.
 ##
 ## clause -> ASSERT LPAREN assert_expr RPAREN SEMICOLON . clause [ SEMICOLON ]
 ##
@@ -5397,7 +5397,7 @@ parsing "clause": seen "ASSERT LPAREN assert_expr RPAREN SEMICOLON", expecting "
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_LET UNAME TYPE WHILE
 ##
-## Ends in an error in state: 1774.
+## Ends in an error in state: 1778.
 ##
 ## clause -> CN_LET UNAME TYPE . EQ expr SEMICOLON clause [ SEMICOLON ]
 ##
@@ -5409,7 +5409,7 @@ parsing "clause": seen "CN_LET UNAME TYPE", expecting "EQ expr SEMICOLON clause"
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_LET UNAME TYPE EQ WHILE
 ##
-## Ends in an error in state: 1775.
+## Ends in an error in state: 1779.
 ##
 ## clause -> CN_LET UNAME TYPE EQ . expr SEMICOLON clause [ SEMICOLON ]
 ##
@@ -5421,7 +5421,7 @@ parsing "clause": seen "CN_LET UNAME TYPE EQ", expecting "expr SEMICOLON clause"
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_LET UNAME TYPE EQ CN_CONSTANT SEMICOLON WHILE
 ##
-## Ends in an error in state: 1777.
+## Ends in an error in state: 1781.
 ##
 ## clause -> CN_LET UNAME TYPE EQ expr SEMICOLON . clause [ SEMICOLON ]
 ##
@@ -5433,7 +5433,7 @@ parsing "clause": seen "CN_LET UNAME TYPE EQ expr SEMICOLON", expecting "clause"
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_LET LNAME VARIABLE WHILE
 ##
-## Ends in an error in state: 1780.
+## Ends in an error in state: 1784.
 ##
 ## clause -> CN_LET LNAME VARIABLE . EQ expr SEMICOLON clause [ SEMICOLON ]
 ##
@@ -5445,7 +5445,7 @@ parsing "clause": seen "CN_LET LNAME VARIABLE", expecting "EQ expr SEMICOLON cla
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_LET LNAME VARIABLE EQ WHILE
 ##
-## Ends in an error in state: 1781.
+## Ends in an error in state: 1785.
 ##
 ## clause -> CN_LET LNAME VARIABLE EQ . expr SEMICOLON clause [ SEMICOLON ]
 ##
@@ -5457,7 +5457,7 @@ parsing "clause": seen "CN_LET LNAME VARIABLE EQ", expecting "expr SEMICOLON cla
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_LET LNAME VARIABLE EQ CN_CONSTANT SEMICOLON WHILE
 ##
-## Ends in an error in state: 1783.
+## Ends in an error in state: 1787.
 ##
 ## clause -> CN_LET LNAME VARIABLE EQ expr SEMICOLON . clause [ SEMICOLON ]
 ##
@@ -5469,7 +5469,7 @@ parsing "clause": seen "CN_LET LNAME VARIABLE EQ expr SEMICOLON", expecting "cla
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_LET LNAME TYPE WHILE
 ##
-## Ends in an error in state: 1785.
+## Ends in an error in state: 1789.
 ##
 ## clause -> CN_LET LNAME TYPE . EQ expr SEMICOLON clause [ SEMICOLON ]
 ##
@@ -5481,7 +5481,7 @@ parsing "clause": seen "CN_LET LNAME TYPE", expecting "EQ expr SEMICOLON clause"
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_LET LNAME TYPE EQ WHILE
 ##
-## Ends in an error in state: 1786.
+## Ends in an error in state: 1790.
 ##
 ## clause -> CN_LET LNAME TYPE EQ . expr SEMICOLON clause [ SEMICOLON ]
 ##
@@ -5493,7 +5493,7 @@ parsing "clause": seen "CN_LET LNAME TYPE EQ", expecting "expr SEMICOLON clause"
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_LET LNAME TYPE EQ CN_CONSTANT SEMICOLON WHILE
 ##
-## Ends in an error in state: 1788.
+## Ends in an error in state: 1792.
 ##
 ## clause -> CN_LET LNAME TYPE EQ expr SEMICOLON . clause [ SEMICOLON ]
 ##
@@ -5505,7 +5505,7 @@ parsing "clause": seen "CN_LET LNAME TYPE EQ expr SEMICOLON", expecting "clause"
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_TAKE UNAME TYPE WHILE
 ##
-## Ends in an error in state: 1791.
+## Ends in an error in state: 1795.
 ##
 ## clause -> CN_TAKE UNAME TYPE . EQ resource SEMICOLON clause [ SEMICOLON ]
 ##
@@ -5517,7 +5517,7 @@ parsing "clause": seen "CN_TAKE UNAME TYPE", expecting "EQ resource SEMICOLON cl
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_TAKE UNAME TYPE EQ WHILE
 ##
-## Ends in an error in state: 1792.
+## Ends in an error in state: 1796.
 ##
 ## clause -> CN_TAKE UNAME TYPE EQ . resource SEMICOLON clause [ SEMICOLON ]
 ##
@@ -5529,7 +5529,7 @@ parsing "clause": seen "CN_TAKE UNAME TYPE EQ", expecting "resource SEMICOLON cl
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_TAKE UNAME TYPE EQ CN_OWNED LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1793.
+## Ends in an error in state: 1797.
 ##
 ## clause -> CN_TAKE UNAME TYPE EQ resource . SEMICOLON clause [ SEMICOLON ]
 ##
@@ -5541,7 +5541,7 @@ parsing "clause": seen "CN_TAKE UNAME TYPE EQ resource", expecting "SEMICOLON cl
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_TAKE UNAME TYPE EQ CN_OWNED LPAREN RPAREN SEMICOLON WHILE
 ##
-## Ends in an error in state: 1794.
+## Ends in an error in state: 1798.
 ##
 ## clause -> CN_TAKE UNAME TYPE EQ resource SEMICOLON . clause [ SEMICOLON ]
 ##
@@ -5553,7 +5553,7 @@ parsing "clause": seen "CN_TAKE UNAME TYPE EQ resource SEMICOLON", expecting "cl
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_TAKE LNAME VARIABLE WHILE
 ##
-## Ends in an error in state: 1797.
+## Ends in an error in state: 1801.
 ##
 ## clause -> CN_TAKE LNAME VARIABLE . EQ resource SEMICOLON clause [ SEMICOLON ]
 ##
@@ -5565,7 +5565,7 @@ parsing "clause": seen "CN_TAKE LNAME VARIABLE", expecting "EQ resource SEMICOLO
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_TAKE LNAME VARIABLE EQ WHILE
 ##
-## Ends in an error in state: 1798.
+## Ends in an error in state: 1802.
 ##
 ## clause -> CN_TAKE LNAME VARIABLE EQ . resource SEMICOLON clause [ SEMICOLON ]
 ##
@@ -5577,7 +5577,7 @@ parsing "clause": seen "CN_TAKE LNAME VARIABLE EQ", expecting "resource SEMICOLO
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_TAKE LNAME VARIABLE EQ CN_OWNED LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1799.
+## Ends in an error in state: 1803.
 ##
 ## clause -> CN_TAKE LNAME VARIABLE EQ resource . SEMICOLON clause [ SEMICOLON ]
 ##
@@ -5589,7 +5589,7 @@ parsing "clause": seen "CN_TAKE LNAME VARIABLE EQ resource", expecting "SEMICOLO
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_TAKE LNAME VARIABLE EQ CN_OWNED LPAREN RPAREN SEMICOLON WHILE
 ##
-## Ends in an error in state: 1800.
+## Ends in an error in state: 1804.
 ##
 ## clause -> CN_TAKE LNAME VARIABLE EQ resource SEMICOLON . clause [ SEMICOLON ]
 ##
@@ -5601,7 +5601,7 @@ parsing "clause": seen "CN_TAKE LNAME VARIABLE EQ resource SEMICOLON", expecting
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_TAKE LNAME TYPE WHILE
 ##
-## Ends in an error in state: 1802.
+## Ends in an error in state: 1806.
 ##
 ## clause -> CN_TAKE LNAME TYPE . EQ resource SEMICOLON clause [ SEMICOLON ]
 ##
@@ -5613,7 +5613,7 @@ parsing "clause": seen "CN_TAKE LNAME TYPE", expecting "EQ resource SEMICOLON cl
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_TAKE LNAME TYPE EQ WHILE
 ##
-## Ends in an error in state: 1803.
+## Ends in an error in state: 1807.
 ##
 ## clause -> CN_TAKE LNAME TYPE EQ . resource SEMICOLON clause [ SEMICOLON ]
 ##
@@ -5625,7 +5625,7 @@ parsing "clause": seen "CN_TAKE LNAME TYPE EQ", expecting "resource SEMICOLON cl
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_TAKE LNAME TYPE EQ CN_OWNED LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1804.
+## Ends in an error in state: 1808.
 ##
 ## clause -> CN_TAKE LNAME TYPE EQ resource . SEMICOLON clause [ SEMICOLON ]
 ##
@@ -5637,7 +5637,7 @@ parsing "clause": seen "CN_TAKE LNAME TYPE EQ resource", expecting "SEMICOLON cl
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_TAKE LNAME TYPE EQ CN_OWNED LPAREN RPAREN SEMICOLON WHILE
 ##
-## Ends in an error in state: 1805.
+## Ends in an error in state: 1809.
 ##
 ## clause -> CN_TAKE LNAME TYPE EQ resource SEMICOLON . clause [ SEMICOLON ]
 ##
@@ -5649,7 +5649,7 @@ parsing "clause": seen "CN_TAKE LNAME TYPE EQ resource SEMICOLON", expecting "cl
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE IF LPAREN CN_CONSTANT RPAREN LBRACE RETURN SEMICOLON WHILE
 ##
-## Ends in an error in state: 1808.
+## Ends in an error in state: 1812.
 ##
 ## if_clauses -> IF LPAREN expr RPAREN LBRACE clause SEMICOLON . RBRACE ELSE if_clauses [ RBRACE ]
 ##
@@ -5661,7 +5661,7 @@ parsing "clauses": seen "IF LPAREN expr RPAREN LBRACE clause SEMICOLON", expecti
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE IF LPAREN CN_CONSTANT RPAREN LBRACE RETURN SEMICOLON RBRACE WHILE
 ##
-## Ends in an error in state: 1809.
+## Ends in an error in state: 1813.
 ##
 ## if_clauses -> IF LPAREN expr RPAREN LBRACE clause SEMICOLON RBRACE . ELSE if_clauses [ RBRACE ]
 ##
@@ -5673,7 +5673,7 @@ parsing "clauses": seen "IF LPAREN expr RPAREN LBRACE clause SEMICOLON RBRACE", 
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE IF LPAREN CN_CONSTANT RPAREN LBRACE RETURN SEMICOLON RBRACE ELSE WHILE
 ##
-## Ends in an error in state: 1810.
+## Ends in an error in state: 1814.
 ##
 ## if_clauses -> IF LPAREN expr RPAREN LBRACE clause SEMICOLON RBRACE ELSE . if_clauses [ RBRACE ]
 ##
@@ -5687,7 +5687,7 @@ parsing "clauses": seen "IF LPAREN expr RPAREN LBRACE clause SEMICOLON RBRACE EL
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE RETURN SEMICOLON WHILE
 ##
-## Ends in an error in state: 1817.
+## Ends in an error in state: 1821.
 ##
 ## cn_option_pred_clauses -> LBRACE clauses . RBRACE [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -5699,7 +5699,7 @@ parsing "cn_option_pred_clauses": seen "LBRACE clauses", expecting "RBRACE"
 
 cn_toplevel: CN_LEMMA UNAME VARIABLE WHILE
 ##
-## Ends in an error in state: 1822.
+## Ends in an error in state: 1826.
 ##
 ## cn_lemma -> CN_LEMMA UNAME VARIABLE . LPAREN cn_args RPAREN CN_REQUIRES nonempty_list(condition) CN_ENSURES nonempty_list(condition) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -5711,7 +5711,7 @@ parsing "cn_lemma": seen "CN_LEMMA UNAME VARIABLE", expecting "LPAREN cn_args RP
 
 cn_toplevel: CN_LEMMA UNAME VARIABLE LPAREN WHILE
 ##
-## Ends in an error in state: 1823.
+## Ends in an error in state: 1827.
 ##
 ## cn_lemma -> CN_LEMMA UNAME VARIABLE LPAREN . cn_args RPAREN CN_REQUIRES nonempty_list(condition) CN_ENSURES nonempty_list(condition) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -5723,7 +5723,7 @@ parsing "cn_lemma": seen "CN_LEMMA UNAME VARIABLE LPAREN", expecting "cn_args RP
 
 cn_toplevel: CN_LEMMA UNAME VARIABLE LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1825.
+## Ends in an error in state: 1829.
 ##
 ## cn_lemma -> CN_LEMMA UNAME VARIABLE LPAREN cn_args RPAREN . CN_REQUIRES nonempty_list(condition) CN_ENSURES nonempty_list(condition) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -5735,7 +5735,7 @@ parsing "cn_lemma": seen "CN_LEMMA UNAME VARIABLE LPAREN cn_args RPAREN", expect
 
 cn_toplevel: CN_LEMMA UNAME VARIABLE LPAREN RPAREN CN_REQUIRES WHILE
 ##
-## Ends in an error in state: 1826.
+## Ends in an error in state: 1830.
 ##
 ## cn_lemma -> CN_LEMMA UNAME VARIABLE LPAREN cn_args RPAREN CN_REQUIRES . nonempty_list(condition) CN_ENSURES nonempty_list(condition) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -5747,7 +5747,7 @@ parsing "cn_lemma": seen "CN_LEMMA UNAME VARIABLE LPAREN cn_args RPAREN CN_REQUI
 
 cn_toplevel: CN_LEMMA UNAME VARIABLE LPAREN RPAREN CN_REQUIRES CN_CONSTANT SEMICOLON CN_ENSURES WHILE
 ##
-## Ends in an error in state: 1828.
+## Ends in an error in state: 1832.
 ##
 ## cn_lemma -> CN_LEMMA UNAME VARIABLE LPAREN cn_args RPAREN CN_REQUIRES nonempty_list(condition) CN_ENSURES . nonempty_list(condition) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -5759,7 +5759,7 @@ parsing "cn_lemma": seen "CN_LEMMA UNAME VARIABLE LPAREN cn_args RPAREN CN_REQUI
 
 cn_toplevel: CN_LEMMA UNAME TYPE WHILE
 ##
-## Ends in an error in state: 1830.
+## Ends in an error in state: 1834.
 ##
 ## cn_lemma -> CN_LEMMA UNAME TYPE . LPAREN cn_args RPAREN CN_REQUIRES nonempty_list(condition) CN_ENSURES nonempty_list(condition) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -5771,7 +5771,7 @@ parsing "cn_lemma": seen "CN_LEMMA UNAME TYPE", expecting "LPAREN cn_args RPAREN
 
 cn_toplevel: CN_LEMMA UNAME TYPE LPAREN WHILE
 ##
-## Ends in an error in state: 1831.
+## Ends in an error in state: 1835.
 ##
 ## cn_lemma -> CN_LEMMA UNAME TYPE LPAREN . cn_args RPAREN CN_REQUIRES nonempty_list(condition) CN_ENSURES nonempty_list(condition) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -5783,7 +5783,7 @@ parsing "cn_lemma": seen "CN_LEMMA UNAME TYPE LPAREN", expecting "cn_args RPAREN
 
 cn_toplevel: CN_LEMMA UNAME TYPE LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1833.
+## Ends in an error in state: 1837.
 ##
 ## cn_lemma -> CN_LEMMA UNAME TYPE LPAREN cn_args RPAREN . CN_REQUIRES nonempty_list(condition) CN_ENSURES nonempty_list(condition) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -5795,7 +5795,7 @@ parsing "cn_lemma": seen "CN_LEMMA UNAME TYPE LPAREN cn_args RPAREN", expecting 
 
 cn_toplevel: CN_LEMMA UNAME TYPE LPAREN RPAREN CN_REQUIRES WHILE
 ##
-## Ends in an error in state: 1834.
+## Ends in an error in state: 1838.
 ##
 ## cn_lemma -> CN_LEMMA UNAME TYPE LPAREN cn_args RPAREN CN_REQUIRES . nonempty_list(condition) CN_ENSURES nonempty_list(condition) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -5807,7 +5807,7 @@ parsing "cn_lemma": seen "CN_LEMMA UNAME TYPE LPAREN cn_args RPAREN CN_REQUIRES"
 
 cn_toplevel: CN_LEMMA UNAME TYPE LPAREN RPAREN CN_REQUIRES CN_CONSTANT SEMICOLON CN_ENSURES WHILE
 ##
-## Ends in an error in state: 1836.
+## Ends in an error in state: 1840.
 ##
 ## cn_lemma -> CN_LEMMA UNAME TYPE LPAREN cn_args RPAREN CN_REQUIRES nonempty_list(condition) CN_ENSURES . nonempty_list(condition) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -5819,7 +5819,7 @@ parsing "cn_lemma": seen "CN_LEMMA UNAME TYPE LPAREN cn_args RPAREN CN_REQUIRES 
 
 cn_toplevel: CN_LEMMA LNAME VARIABLE WHILE
 ##
-## Ends in an error in state: 1839.
+## Ends in an error in state: 1843.
 ##
 ## cn_lemma -> CN_LEMMA LNAME VARIABLE . LPAREN cn_args RPAREN CN_REQUIRES nonempty_list(condition) CN_ENSURES nonempty_list(condition) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -5831,7 +5831,7 @@ parsing "cn_lemma": seen "CN_LEMMA LNAME VARIABLE", expecting "LPAREN cn_args RP
 
 cn_toplevel: CN_LEMMA LNAME VARIABLE LPAREN WHILE
 ##
-## Ends in an error in state: 1840.
+## Ends in an error in state: 1844.
 ##
 ## cn_lemma -> CN_LEMMA LNAME VARIABLE LPAREN . cn_args RPAREN CN_REQUIRES nonempty_list(condition) CN_ENSURES nonempty_list(condition) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -5843,7 +5843,7 @@ parsing "cn_lemma": seen "CN_LEMMA LNAME VARIABLE LPAREN", expecting "cn_args RP
 
 cn_toplevel: CN_LEMMA LNAME VARIABLE LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1842.
+## Ends in an error in state: 1846.
 ##
 ## cn_lemma -> CN_LEMMA LNAME VARIABLE LPAREN cn_args RPAREN . CN_REQUIRES nonempty_list(condition) CN_ENSURES nonempty_list(condition) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -5855,7 +5855,7 @@ parsing "cn_lemma": seen "CN_LEMMA LNAME VARIABLE LPAREN cn_args RPAREN", expect
 
 cn_toplevel: CN_LEMMA LNAME VARIABLE LPAREN RPAREN CN_REQUIRES WHILE
 ##
-## Ends in an error in state: 1843.
+## Ends in an error in state: 1847.
 ##
 ## cn_lemma -> CN_LEMMA LNAME VARIABLE LPAREN cn_args RPAREN CN_REQUIRES . nonempty_list(condition) CN_ENSURES nonempty_list(condition) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -5867,7 +5867,7 @@ parsing "cn_lemma": seen "CN_LEMMA LNAME VARIABLE LPAREN cn_args RPAREN CN_REQUI
 
 cn_toplevel: CN_LEMMA LNAME VARIABLE LPAREN RPAREN CN_REQUIRES CN_CONSTANT SEMICOLON CN_ENSURES WHILE
 ##
-## Ends in an error in state: 1845.
+## Ends in an error in state: 1849.
 ##
 ## cn_lemma -> CN_LEMMA LNAME VARIABLE LPAREN cn_args RPAREN CN_REQUIRES nonempty_list(condition) CN_ENSURES . nonempty_list(condition) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -5879,7 +5879,7 @@ parsing "cn_lemma": seen "CN_LEMMA LNAME VARIABLE LPAREN cn_args RPAREN CN_REQUI
 
 cn_toplevel: CN_LEMMA LNAME TYPE WHILE
 ##
-## Ends in an error in state: 1847.
+## Ends in an error in state: 1851.
 ##
 ## cn_lemma -> CN_LEMMA LNAME TYPE . LPAREN cn_args RPAREN CN_REQUIRES nonempty_list(condition) CN_ENSURES nonempty_list(condition) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -5891,7 +5891,7 @@ parsing "cn_lemma": seen "CN_LEMMA LNAME TYPE", expecting "LPAREN cn_args RPAREN
 
 cn_toplevel: CN_LEMMA LNAME TYPE LPAREN WHILE
 ##
-## Ends in an error in state: 1848.
+## Ends in an error in state: 1852.
 ##
 ## cn_lemma -> CN_LEMMA LNAME TYPE LPAREN . cn_args RPAREN CN_REQUIRES nonempty_list(condition) CN_ENSURES nonempty_list(condition) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -5903,7 +5903,7 @@ parsing "cn_lemma": seen "CN_LEMMA LNAME TYPE LPAREN", expecting "cn_args RPAREN
 
 cn_toplevel: CN_LEMMA LNAME TYPE LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1850.
+## Ends in an error in state: 1854.
 ##
 ## cn_lemma -> CN_LEMMA LNAME TYPE LPAREN cn_args RPAREN . CN_REQUIRES nonempty_list(condition) CN_ENSURES nonempty_list(condition) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -5915,7 +5915,7 @@ parsing "cn_lemma": seen "CN_LEMMA LNAME TYPE LPAREN cn_args RPAREN", expecting 
 
 cn_toplevel: CN_LEMMA LNAME TYPE LPAREN RPAREN CN_REQUIRES WHILE
 ##
-## Ends in an error in state: 1851.
+## Ends in an error in state: 1855.
 ##
 ## cn_lemma -> CN_LEMMA LNAME TYPE LPAREN cn_args RPAREN CN_REQUIRES . nonempty_list(condition) CN_ENSURES nonempty_list(condition) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -5927,7 +5927,7 @@ parsing "cn_lemma": seen "CN_LEMMA LNAME TYPE LPAREN cn_args RPAREN CN_REQUIRES"
 
 cn_toplevel: CN_LEMMA LNAME TYPE LPAREN RPAREN CN_REQUIRES CN_CONSTANT SEMICOLON CN_ENSURES WHILE
 ##
-## Ends in an error in state: 1853.
+## Ends in an error in state: 1857.
 ##
 ## cn_lemma -> CN_LEMMA LNAME TYPE LPAREN cn_args RPAREN CN_REQUIRES nonempty_list(condition) CN_ENSURES . nonempty_list(condition) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -5939,7 +5939,7 @@ parsing "cn_lemma": seen "CN_LEMMA LNAME TYPE LPAREN cn_args RPAREN CN_REQUIRES 
 
 cn_toplevel: CN_FUNCTION LPAREN CN_ALLOC_ID RPAREN UNAME VARIABLE WHILE
 ##
-## Ends in an error in state: 1861.
+## Ends in an error in state: 1865.
 ##
 ## cn_function -> CN_FUNCTION cn_attrs LPAREN base_type RPAREN UNAME VARIABLE . LPAREN cn_args RPAREN cn_option_func_body [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -5951,7 +5951,7 @@ parsing "cn_function": seen "CN_FUNCTION cn_attrs LPAREN base_type RPAREN UNAME 
 
 cn_toplevel: CN_FUNCTION LPAREN CN_ALLOC_ID RPAREN UNAME VARIABLE LPAREN WHILE
 ##
-## Ends in an error in state: 1862.
+## Ends in an error in state: 1866.
 ##
 ## cn_function -> CN_FUNCTION cn_attrs LPAREN base_type RPAREN UNAME VARIABLE LPAREN . cn_args RPAREN cn_option_func_body [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -5963,7 +5963,7 @@ parsing "cn_function": seen "CN_FUNCTION cn_attrs LPAREN base_type RPAREN UNAME 
 
 cn_toplevel: CN_FUNCTION LPAREN CN_ALLOC_ID RPAREN UNAME VARIABLE LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1864.
+## Ends in an error in state: 1868.
 ##
 ## cn_function -> CN_FUNCTION cn_attrs LPAREN base_type RPAREN UNAME VARIABLE LPAREN cn_args RPAREN . cn_option_func_body [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -5975,7 +5975,7 @@ parsing "cn_function": seen "CN_FUNCTION cn_attrs LPAREN base_type RPAREN UNAME 
 
 cn_toplevel: CN_FUNCTION LPAREN CN_ALLOC_ID RPAREN LNAME TYPE LPAREN RPAREN LBRACE WHILE
 ##
-## Ends in an error in state: 1865.
+## Ends in an error in state: 1869.
 ##
 ## cn_option_func_body -> LBRACE . expr RBRACE [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -5987,7 +5987,7 @@ parsing "cn_option_func_body": seen "LBRACE", expecting "expr RBRACE"
 
 cn_toplevel: CN_FUNCTION LPAREN CN_ALLOC_ID RPAREN UNAME TYPE WHILE
 ##
-## Ends in an error in state: 1869.
+## Ends in an error in state: 1873.
 ##
 ## cn_function -> CN_FUNCTION cn_attrs LPAREN base_type RPAREN UNAME TYPE . LPAREN cn_args RPAREN cn_option_func_body [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -5999,7 +5999,7 @@ parsing "cn_function": seen "CN_FUNCTION cn_attrs LPAREN base_type RPAREN UNAME 
 
 cn_toplevel: CN_FUNCTION LPAREN CN_ALLOC_ID RPAREN UNAME TYPE LPAREN WHILE
 ##
-## Ends in an error in state: 1870.
+## Ends in an error in state: 1874.
 ##
 ## cn_function -> CN_FUNCTION cn_attrs LPAREN base_type RPAREN UNAME TYPE LPAREN . cn_args RPAREN cn_option_func_body [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -6011,7 +6011,7 @@ parsing "cn_function": seen "CN_FUNCTION cn_attrs LPAREN base_type RPAREN UNAME 
 
 cn_toplevel: CN_FUNCTION LPAREN CN_ALLOC_ID RPAREN UNAME TYPE LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1872.
+## Ends in an error in state: 1876.
 ##
 ## cn_function -> CN_FUNCTION cn_attrs LPAREN base_type RPAREN UNAME TYPE LPAREN cn_args RPAREN . cn_option_func_body [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -6023,7 +6023,7 @@ parsing "cn_function": seen "CN_FUNCTION cn_attrs LPAREN base_type RPAREN UNAME 
 
 cn_toplevel: CN_FUNCTION LPAREN CN_ALLOC_ID RPAREN LNAME VARIABLE WHILE
 ##
-## Ends in an error in state: 1875.
+## Ends in an error in state: 1879.
 ##
 ## cn_function -> CN_FUNCTION cn_attrs LPAREN base_type RPAREN LNAME VARIABLE . LPAREN cn_args RPAREN cn_option_func_body [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -6035,7 +6035,7 @@ parsing "cn_function": seen "CN_FUNCTION cn_attrs LPAREN base_type RPAREN LNAME 
 
 cn_toplevel: CN_FUNCTION LPAREN CN_ALLOC_ID RPAREN LNAME VARIABLE LPAREN WHILE
 ##
-## Ends in an error in state: 1876.
+## Ends in an error in state: 1880.
 ##
 ## cn_function -> CN_FUNCTION cn_attrs LPAREN base_type RPAREN LNAME VARIABLE LPAREN . cn_args RPAREN cn_option_func_body [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -6047,7 +6047,7 @@ parsing "cn_function": seen "CN_FUNCTION cn_attrs LPAREN base_type RPAREN LNAME 
 
 cn_toplevel: CN_FUNCTION LPAREN CN_ALLOC_ID RPAREN LNAME VARIABLE LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1878.
+## Ends in an error in state: 1882.
 ##
 ## cn_function -> CN_FUNCTION cn_attrs LPAREN base_type RPAREN LNAME VARIABLE LPAREN cn_args RPAREN . cn_option_func_body [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -6059,7 +6059,7 @@ parsing "cn_function": seen "CN_FUNCTION cn_attrs LPAREN base_type RPAREN LNAME 
 
 cn_toplevel: CN_FUNCTION LPAREN CN_ALLOC_ID RPAREN LNAME TYPE WHILE
 ##
-## Ends in an error in state: 1880.
+## Ends in an error in state: 1884.
 ##
 ## cn_function -> CN_FUNCTION cn_attrs LPAREN base_type RPAREN LNAME TYPE . LPAREN cn_args RPAREN cn_option_func_body [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -6071,7 +6071,7 @@ parsing "cn_function": seen "CN_FUNCTION cn_attrs LPAREN base_type RPAREN LNAME 
 
 cn_toplevel: CN_FUNCTION LPAREN CN_ALLOC_ID RPAREN LNAME TYPE LPAREN WHILE
 ##
-## Ends in an error in state: 1881.
+## Ends in an error in state: 1885.
 ##
 ## cn_function -> CN_FUNCTION cn_attrs LPAREN base_type RPAREN LNAME TYPE LPAREN . cn_args RPAREN cn_option_func_body [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -6083,7 +6083,7 @@ parsing "cn_function": seen "CN_FUNCTION cn_attrs LPAREN base_type RPAREN LNAME 
 
 cn_toplevel: CN_FUNCTION LPAREN CN_ALLOC_ID RPAREN LNAME TYPE LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1883.
+## Ends in an error in state: 1887.
 ##
 ## cn_function -> CN_FUNCTION cn_attrs LPAREN base_type RPAREN LNAME TYPE LPAREN cn_args RPAREN . cn_option_func_body [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -6095,7 +6095,7 @@ parsing "cn_function": seen "CN_FUNCTION cn_attrs LPAREN base_type RPAREN LNAME 
 
 cn_toplevel: CN_DATATYPE UNAME VARIABLE WHILE
 ##
-## Ends in an error in state: 1887.
+## Ends in an error in state: 1891.
 ##
 ## cn_datatype -> CN_DATATYPE UNAME VARIABLE . LBRACE cn_cons_cases RBRACE [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -6107,7 +6107,7 @@ parsing "cn_datatype": seen "CN_DATATYPE UNAME VARIABLE", expecting "LBRACE cn_c
 
 cn_toplevel: CN_DATATYPE UNAME VARIABLE LBRACE WHILE
 ##
-## Ends in an error in state: 1888.
+## Ends in an error in state: 1892.
 ##
 ## cn_datatype -> CN_DATATYPE UNAME VARIABLE LBRACE . cn_cons_cases RBRACE [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -6119,7 +6119,7 @@ parsing "cn_datatype": seen "CN_DATATYPE UNAME VARIABLE LBRACE", expecting "cn_c
 
 cn_toplevel: CN_DATATYPE LNAME TYPE LBRACE UNAME VARIABLE WHILE
 ##
-## Ends in an error in state: 1890.
+## Ends in an error in state: 1894.
 ##
 ## cn_cons_case -> UNAME VARIABLE . LBRACE cn_args RBRACE [ RBRACE COMMA ]
 ##
@@ -6131,7 +6131,7 @@ parsing "cn_cons_case": seen "UNAME VARIABLE", expecting "LBRACE cn_args RBRACE"
 
 cn_toplevel: CN_DATATYPE LNAME TYPE LBRACE UNAME VARIABLE LBRACE WHILE
 ##
-## Ends in an error in state: 1891.
+## Ends in an error in state: 1895.
 ##
 ## cn_cons_case -> UNAME VARIABLE LBRACE . cn_args RBRACE [ RBRACE COMMA ]
 ##
@@ -6143,7 +6143,7 @@ parsing "cn_cons_case": seen "UNAME VARIABLE LBRACE", expecting "cn_args RBRACE"
 
 cn_toplevel: CN_DATATYPE LNAME TYPE LBRACE UNAME TYPE WHILE
 ##
-## Ends in an error in state: 1894.
+## Ends in an error in state: 1898.
 ##
 ## cn_cons_case -> UNAME TYPE . LBRACE cn_args RBRACE [ RBRACE COMMA ]
 ##
@@ -6155,7 +6155,7 @@ parsing "cn_cons_case": seen "UNAME TYPE", expecting "LBRACE cn_args RBRACE"
 
 cn_toplevel: CN_DATATYPE LNAME TYPE LBRACE UNAME TYPE LBRACE WHILE
 ##
-## Ends in an error in state: 1895.
+## Ends in an error in state: 1899.
 ##
 ## cn_cons_case -> UNAME TYPE LBRACE . cn_args RBRACE [ RBRACE COMMA ]
 ##
@@ -6167,7 +6167,7 @@ parsing "cn_cons_case": seen "UNAME TYPE LBRACE", expecting "cn_args RBRACE"
 
 cn_toplevel: CN_DATATYPE LNAME TYPE LBRACE LNAME VARIABLE WHILE
 ##
-## Ends in an error in state: 1899.
+## Ends in an error in state: 1903.
 ##
 ## cn_cons_case -> LNAME VARIABLE . LBRACE cn_args RBRACE [ RBRACE COMMA ]
 ##
@@ -6179,7 +6179,7 @@ parsing "cn_cons_case": seen "LNAME VARIABLE", expecting "LBRACE cn_args RBRACE"
 
 cn_toplevel: CN_DATATYPE LNAME TYPE LBRACE LNAME VARIABLE LBRACE WHILE
 ##
-## Ends in an error in state: 1900.
+## Ends in an error in state: 1904.
 ##
 ## cn_cons_case -> LNAME VARIABLE LBRACE . cn_args RBRACE [ RBRACE COMMA ]
 ##
@@ -6191,7 +6191,7 @@ parsing "cn_cons_case": seen "LNAME VARIABLE LBRACE", expecting "cn_args RBRACE"
 
 cn_toplevel: CN_DATATYPE LNAME TYPE LBRACE LNAME TYPE WHILE
 ##
-## Ends in an error in state: 1903.
+## Ends in an error in state: 1907.
 ##
 ## cn_cons_case -> LNAME TYPE . LBRACE cn_args RBRACE [ RBRACE COMMA ]
 ##
@@ -6203,7 +6203,7 @@ parsing "cn_cons_case": seen "LNAME TYPE", expecting "LBRACE cn_args RBRACE"
 
 cn_toplevel: CN_DATATYPE LNAME TYPE LBRACE LNAME TYPE LBRACE WHILE
 ##
-## Ends in an error in state: 1904.
+## Ends in an error in state: 1908.
 ##
 ## cn_cons_case -> LNAME TYPE LBRACE . cn_args RBRACE [ RBRACE COMMA ]
 ##
@@ -6215,7 +6215,7 @@ parsing "cn_cons_case": seen "LNAME TYPE LBRACE", expecting "cn_args RBRACE"
 
 cn_toplevel: CN_DATATYPE LNAME TYPE LBRACE LNAME TYPE LBRACE RBRACE COMMA WHILE
 ##
-## Ends in an error in state: 1912.
+## Ends in an error in state: 1916.
 ##
 ## separated_nonempty_list(COMMA,cn_cons_case) -> cn_cons_case COMMA . separated_nonempty_list(COMMA,cn_cons_case) [ RBRACE ]
 ##
@@ -6227,7 +6227,7 @@ parsing "separated_nonempty_list(COMMA,cn_cons_case)": seen "cn_cons_case COMMA"
 
 cn_toplevel: CN_DATATYPE UNAME TYPE WHILE
 ##
-## Ends in an error in state: 1914.
+## Ends in an error in state: 1918.
 ##
 ## cn_datatype -> CN_DATATYPE UNAME TYPE . LBRACE cn_cons_cases RBRACE [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -6239,7 +6239,7 @@ parsing "cn_datatype": seen "CN_DATATYPE UNAME TYPE", expecting "LBRACE cn_cons_
 
 cn_toplevel: CN_DATATYPE UNAME TYPE LBRACE WHILE
 ##
-## Ends in an error in state: 1915.
+## Ends in an error in state: 1919.
 ##
 ## cn_datatype -> CN_DATATYPE UNAME TYPE LBRACE . cn_cons_cases RBRACE [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -6251,7 +6251,7 @@ parsing "cn_datatype": seen "CN_DATATYPE UNAME TYPE LBRACE", expecting "cn_cons_
 
 cn_toplevel: CN_DATATYPE LNAME VARIABLE WHILE
 ##
-## Ends in an error in state: 1919.
+## Ends in an error in state: 1923.
 ##
 ## cn_datatype -> CN_DATATYPE LNAME VARIABLE . LBRACE cn_cons_cases RBRACE [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -6263,7 +6263,7 @@ parsing "cn_datatype": seen "CN_DATATYPE LNAME VARIABLE", expecting "LBRACE cn_c
 
 cn_toplevel: CN_DATATYPE LNAME VARIABLE LBRACE WHILE
 ##
-## Ends in an error in state: 1920.
+## Ends in an error in state: 1924.
 ##
 ## cn_datatype -> CN_DATATYPE LNAME VARIABLE LBRACE . cn_cons_cases RBRACE [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -6275,7 +6275,7 @@ parsing "cn_datatype": seen "CN_DATATYPE LNAME VARIABLE LBRACE", expecting "cn_c
 
 cn_toplevel: CN_DATATYPE LNAME TYPE WHILE
 ##
-## Ends in an error in state: 1923.
+## Ends in an error in state: 1927.
 ##
 ## cn_datatype -> CN_DATATYPE LNAME TYPE . LBRACE cn_cons_cases RBRACE [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -6287,7 +6287,7 @@ parsing "cn_datatype": seen "CN_DATATYPE LNAME TYPE", expecting "LBRACE cn_cons_
 
 cn_toplevel: CN_DATATYPE LNAME TYPE LBRACE WHILE
 ##
-## Ends in an error in state: 1924.
+## Ends in an error in state: 1928.
 ##
 ## cn_datatype -> CN_DATATYPE LNAME TYPE LBRACE . cn_cons_cases RBRACE [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -6299,7 +6299,7 @@ parsing "cn_datatype": seen "CN_DATATYPE LNAME TYPE LBRACE", expecting "cn_cons_
 
 cn_toplevel: CN_DATATYPE LNAME TYPE LBRACE RBRACE WHILE
 ##
-## Ends in an error in state: 1930.
+## Ends in an error in state: 1934.
 ##
 ## list(cn_toplevel_elem) -> cn_toplevel_elem . list(cn_toplevel_elem) [ EOF ]
 ##
@@ -6321,7 +6321,7 @@ parsing "list(cn_toplevel_elem)": seen "cn_toplevel_elem", expecting "list(cn_to
 
 loop_spec: WHILE
 ##
-## Ends in an error in state: 1942.
+## Ends in an error in state: 1946.
 ##
 ## loop_spec' -> . loop_spec [ # ]
 ##
@@ -6333,7 +6333,7 @@ parsing "loop_spec'": expected "loop_spec"
 
 loop_spec: CN_INV WHILE
 ##
-## Ends in an error in state: 1943.
+## Ends in an error in state: 1947.
 ##
 ## loop_spec -> CN_INV . nonempty_list(condition) EOF [ # ]
 ##
@@ -6345,7 +6345,7 @@ parsing "loop_spec": seen "CN_INV", expecting "nonempty_list(condition) EOF"
 
 translation_unit: WHILE
 ##
-## Ends in an error in state: 1947.
+## Ends in an error in state: 1951.
 ##
 ## translation_unit' -> . translation_unit [ # ]
 ##
@@ -6588,7 +6588,7 @@ parsing "add_expr": seen "add_expr PIPE", expecting "mul_expr"
 
 cn_statements: CN_TO_BYTES WHILE
 ##
-## Ends in an error in state: 1428.
+## Ends in an error in state: 1432.
 ##
 ## cn_statement -> CN_TO_BYTES . pred LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -6600,7 +6600,7 @@ parsing "cn_statement": seen "CN_TO_BYTES", expecting "pred LPAREN loption(separ
 
 cn_statements: CN_TO_BYTES CN_BLOCK LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1432.
+## Ends in an error in state: 1436.
 ##
 ## cn_statement -> CN_TO_BYTES pred LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN . SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -6612,7 +6612,7 @@ parsing "cn_statement": seen "CN_TO_BYTES pred LPAREN loption(separated_nonempty
 
 cn_statements: CN_FROM_BYTES WHILE
 ##
-## Ends in an error in state: 1510.
+## Ends in an error in state: 1514.
 ##
 ## cn_statement -> CN_FROM_BYTES . pred LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -6624,7 +6624,7 @@ parsing "cn_statement": seen "CN_FROM_BYTES", expecting "pred LPAREN loption(sep
 
 cn_statements: CN_FROM_BYTES CN_BLOCK LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1514.
+## Ends in an error in state: 1518.
 ##
 ## cn_statement -> CN_FROM_BYTES pred LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN . SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -6649,7 +6649,7 @@ parsing "cn_statement": seen "CN_FROM_BYTES pred LPAREN loption(separated_nonemp
 
 cn_statements: CN_TO_BYTES CN_BLOCK LPAREN WHILE
 ##
-## Ends in an error in state: 1430.
+## Ends in an error in state: 1434.
 ##
 ## cn_statement -> CN_TO_BYTES pred LPAREN . loption(separated_nonempty_list(COMMA,expr)) RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -6661,7 +6661,7 @@ parsing "cn_statement": seen "CN_TO_BYTES pred LPAREN", expecting "loption(separ
 
 cn_statements: CN_FROM_BYTES CN_BLOCK LPAREN WHILE
 ##
-## Ends in an error in state: 1512.
+## Ends in an error in state: 1516.
 ##
 ## cn_statement -> CN_FROM_BYTES pred LPAREN . loption(separated_nonempty_list(COMMA,expr)) RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -6714,7 +6714,7 @@ parsing "cn_statement": seen "CN_FROM_BYTES pred LPAREN", expecting "loption(sep
 
 loop_spec: CN_INV CN_TAKE UNAME VARIABLE WHILE
 ##
-## Ends in an error in state: 1612.
+## Ends in an error in state: 1616.
 ##
 ## condition -> CN_TAKE UNAME VARIABLE . EQ resource SEMICOLON [ UNAME TILDE STRUCT STAR SIZEOF RETURN OFFSETOF MINUS LPAREN LNAME LBRACK LBRACE IF EOF DEFAULT CONSTANT CN_TYPE_SYNONYM CN_TRUE CN_TAKE CN_SPEC CN_PREDICATE CN_NULL CN_MEMBER_SHIFT CN_MATCH CN_LET CN_LEMMA CN_GOOD CN_FUNCTION CN_FALSE CN_ENSURES CN_EACH CN_DATATYPE CN_CONSTANT CN_ARRAY_SHIFT BANG AMPERSAND ]
 ##
@@ -6726,7 +6726,7 @@ parsing "condition": seen "CN_TAKE UNAME VARIABLE", expecting "EQ resource SEMIC
 
 loop_spec: CN_INV CN_TAKE UNAME VARIABLE EQ WHILE
 ##
-## Ends in an error in state: 1613.
+## Ends in an error in state: 1617.
 ##
 ## condition -> CN_TAKE UNAME VARIABLE EQ . resource SEMICOLON [ UNAME TILDE STRUCT STAR SIZEOF RETURN OFFSETOF MINUS LPAREN LNAME LBRACK LBRACE IF EOF DEFAULT CONSTANT CN_TYPE_SYNONYM CN_TRUE CN_TAKE CN_SPEC CN_PREDICATE CN_NULL CN_MEMBER_SHIFT CN_MATCH CN_LET CN_LEMMA CN_GOOD CN_FUNCTION CN_FALSE CN_ENSURES CN_EACH CN_DATATYPE CN_CONSTANT CN_ARRAY_SHIFT BANG AMPERSAND ]
 ##
@@ -6738,7 +6738,7 @@ parsing "condition": seen "CN_TAKE UNAME VARIABLE EQ", expecting "resource SEMIC
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID UNAME VARIABLE WHILE
 ##
-## Ends in an error in state: 1618.
+## Ends in an error in state: 1622.
 ##
 ## resource -> CN_EACH LPAREN base_type UNAME VARIABLE . SEMICOLON expr RPAREN LBRACE pred LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN RBRACE [ SEMICOLON ]
 ##
@@ -6750,7 +6750,7 @@ parsing "resource": seen "CN_EACH LPAREN base_type UNAME VARIABLE", expecting "S
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID UNAME VARIABLE SEMICOLON WHILE
 ##
-## Ends in an error in state: 1619.
+## Ends in an error in state: 1623.
 ##
 ## resource -> CN_EACH LPAREN base_type UNAME VARIABLE SEMICOLON . expr RPAREN LBRACE pred LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN RBRACE [ SEMICOLON ]
 ##
@@ -6762,7 +6762,7 @@ parsing "resource": seen "CN_EACH LPAREN base_type UNAME VARIABLE SEMICOLON", ex
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID UNAME VARIABLE SEMICOLON CN_CONSTANT RPAREN WHILE
 ##
-## Ends in an error in state: 1621.
+## Ends in an error in state: 1625.
 ##
 ## resource -> CN_EACH LPAREN base_type UNAME VARIABLE SEMICOLON expr RPAREN . LBRACE pred LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN RBRACE [ SEMICOLON ]
 ##
@@ -6774,7 +6774,7 @@ parsing "resource": seen "CN_EACH LPAREN base_type UNAME VARIABLE SEMICOLON expr
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID UNAME VARIABLE SEMICOLON CN_CONSTANT RPAREN LBRACE WHILE
 ##
-## Ends in an error in state: 1622.
+## Ends in an error in state: 1626.
 ##
 ## resource -> CN_EACH LPAREN base_type UNAME VARIABLE SEMICOLON expr RPAREN LBRACE . pred LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN RBRACE [ SEMICOLON ]
 ##
@@ -6786,7 +6786,7 @@ parsing "resource": seen "CN_EACH LPAREN base_type UNAME VARIABLE SEMICOLON expr
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID UNAME VARIABLE SEMICOLON CN_CONSTANT RPAREN LBRACE CN_BLOCK LPAREN WHILE
 ##
-## Ends in an error in state: 1624.
+## Ends in an error in state: 1628.
 ##
 ## resource -> CN_EACH LPAREN base_type UNAME VARIABLE SEMICOLON expr RPAREN LBRACE pred LPAREN . loption(separated_nonempty_list(COMMA,expr)) RPAREN RBRACE [ SEMICOLON ]
 ##
@@ -6798,7 +6798,7 @@ parsing "resource": seen "CN_EACH LPAREN base_type UNAME VARIABLE SEMICOLON expr
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID UNAME VARIABLE SEMICOLON CN_CONSTANT RPAREN LBRACE CN_BLOCK LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1626.
+## Ends in an error in state: 1630.
 ##
 ## resource -> CN_EACH LPAREN base_type UNAME VARIABLE SEMICOLON expr RPAREN LBRACE pred LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN . RBRACE [ SEMICOLON ]
 ##
@@ -6810,7 +6810,7 @@ parsing "resource": seen "CN_EACH LPAREN base_type UNAME VARIABLE SEMICOLON expr
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID UNAME TYPE WHILE
 ##
-## Ends in an error in state: 1628.
+## Ends in an error in state: 1632.
 ##
 ## resource -> CN_EACH LPAREN base_type UNAME TYPE . SEMICOLON expr RPAREN LBRACE pred LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN RBRACE [ SEMICOLON ]
 ##
@@ -6822,7 +6822,7 @@ parsing "resource": seen "CN_EACH LPAREN base_type UNAME TYPE", expecting "SEMIC
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID UNAME TYPE SEMICOLON WHILE
 ##
-## Ends in an error in state: 1629.
+## Ends in an error in state: 1633.
 ##
 ## resource -> CN_EACH LPAREN base_type UNAME TYPE SEMICOLON . expr RPAREN LBRACE pred LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN RBRACE [ SEMICOLON ]
 ##
@@ -6834,7 +6834,7 @@ parsing "resource": seen "CN_EACH LPAREN base_type UNAME TYPE SEMICOLON", expect
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID UNAME TYPE SEMICOLON CN_CONSTANT RPAREN WHILE
 ##
-## Ends in an error in state: 1631.
+## Ends in an error in state: 1635.
 ##
 ## resource -> CN_EACH LPAREN base_type UNAME TYPE SEMICOLON expr RPAREN . LBRACE pred LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN RBRACE [ SEMICOLON ]
 ##
@@ -6846,7 +6846,7 @@ parsing "resource": seen "CN_EACH LPAREN base_type UNAME TYPE SEMICOLON expr RPA
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID UNAME TYPE SEMICOLON CN_CONSTANT RPAREN LBRACE WHILE
 ##
-## Ends in an error in state: 1632.
+## Ends in an error in state: 1636.
 ##
 ## resource -> CN_EACH LPAREN base_type UNAME TYPE SEMICOLON expr RPAREN LBRACE . pred LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN RBRACE [ SEMICOLON ]
 ##
@@ -6858,7 +6858,7 @@ parsing "resource": seen "CN_EACH LPAREN base_type UNAME TYPE SEMICOLON expr RPA
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID UNAME TYPE SEMICOLON CN_CONSTANT RPAREN LBRACE CN_BLOCK LPAREN WHILE
 ##
-## Ends in an error in state: 1634.
+## Ends in an error in state: 1638.
 ##
 ## resource -> CN_EACH LPAREN base_type UNAME TYPE SEMICOLON expr RPAREN LBRACE pred LPAREN . loption(separated_nonempty_list(COMMA,expr)) RPAREN RBRACE [ SEMICOLON ]
 ##
@@ -6870,7 +6870,7 @@ parsing "resource": seen "CN_EACH LPAREN base_type UNAME TYPE SEMICOLON expr RPA
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID UNAME TYPE SEMICOLON CN_CONSTANT RPAREN LBRACE CN_BLOCK LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1636.
+## Ends in an error in state: 1640.
 ##
 ## resource -> CN_EACH LPAREN base_type UNAME TYPE SEMICOLON expr RPAREN LBRACE pred LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN . RBRACE [ SEMICOLON ]
 ##
@@ -6882,7 +6882,7 @@ parsing "resource": seen "CN_EACH LPAREN base_type UNAME TYPE SEMICOLON expr RPA
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID LNAME VARIABLE WHILE
 ##
-## Ends in an error in state: 1639.
+## Ends in an error in state: 1643.
 ##
 ## resource -> CN_EACH LPAREN base_type LNAME VARIABLE . SEMICOLON expr RPAREN LBRACE pred LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN RBRACE [ SEMICOLON ]
 ##
@@ -6894,7 +6894,7 @@ parsing "resource": seen "CN_EACH LPAREN base_type LNAME VARIABLE", expecting "S
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID LNAME VARIABLE SEMICOLON WHILE
 ##
-## Ends in an error in state: 1640.
+## Ends in an error in state: 1644.
 ##
 ## resource -> CN_EACH LPAREN base_type LNAME VARIABLE SEMICOLON . expr RPAREN LBRACE pred LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN RBRACE [ SEMICOLON ]
 ##
@@ -6906,7 +6906,7 @@ parsing "resource": seen "CN_EACH LPAREN base_type LNAME VARIABLE SEMICOLON", ex
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID LNAME VARIABLE SEMICOLON CN_CONSTANT RPAREN WHILE
 ##
-## Ends in an error in state: 1642.
+## Ends in an error in state: 1646.
 ##
 ## resource -> CN_EACH LPAREN base_type LNAME VARIABLE SEMICOLON expr RPAREN . LBRACE pred LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN RBRACE [ SEMICOLON ]
 ##
@@ -6918,7 +6918,7 @@ parsing "resource": seen "CN_EACH LPAREN base_type LNAME VARIABLE SEMICOLON expr
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID LNAME VARIABLE SEMICOLON CN_CONSTANT RPAREN LBRACE WHILE
 ##
-## Ends in an error in state: 1643.
+## Ends in an error in state: 1647.
 ##
 ## resource -> CN_EACH LPAREN base_type LNAME VARIABLE SEMICOLON expr RPAREN LBRACE . pred LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN RBRACE [ SEMICOLON ]
 ##
@@ -6930,7 +6930,7 @@ parsing "resource": seen "CN_EACH LPAREN base_type LNAME VARIABLE SEMICOLON expr
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID LNAME VARIABLE SEMICOLON CN_CONSTANT RPAREN LBRACE CN_BLOCK LPAREN WHILE
 ##
-## Ends in an error in state: 1645.
+## Ends in an error in state: 1649.
 ##
 ## resource -> CN_EACH LPAREN base_type LNAME VARIABLE SEMICOLON expr RPAREN LBRACE pred LPAREN . loption(separated_nonempty_list(COMMA,expr)) RPAREN RBRACE [ SEMICOLON ]
 ##
@@ -6942,7 +6942,7 @@ parsing "resource": seen "CN_EACH LPAREN base_type LNAME VARIABLE SEMICOLON expr
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID LNAME VARIABLE SEMICOLON CN_CONSTANT RPAREN LBRACE CN_BLOCK LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1647.
+## Ends in an error in state: 1651.
 ##
 ## resource -> CN_EACH LPAREN base_type LNAME VARIABLE SEMICOLON expr RPAREN LBRACE pred LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN . RBRACE [ SEMICOLON ]
 ##
@@ -6954,7 +6954,7 @@ parsing "resource": seen "CN_EACH LPAREN base_type LNAME VARIABLE SEMICOLON expr
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID LNAME TYPE WHILE
 ##
-## Ends in an error in state: 1649.
+## Ends in an error in state: 1653.
 ##
 ## resource -> CN_EACH LPAREN base_type LNAME TYPE . SEMICOLON expr RPAREN LBRACE pred LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN RBRACE [ SEMICOLON ]
 ##
@@ -6966,7 +6966,7 @@ parsing "resource": seen "CN_EACH LPAREN base_type LNAME TYPE", expecting "SEMIC
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID LNAME TYPE SEMICOLON WHILE
 ##
-## Ends in an error in state: 1650.
+## Ends in an error in state: 1654.
 ##
 ## resource -> CN_EACH LPAREN base_type LNAME TYPE SEMICOLON . expr RPAREN LBRACE pred LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN RBRACE [ SEMICOLON ]
 ##
@@ -6978,7 +6978,7 @@ parsing "resource": seen "CN_EACH LPAREN base_type LNAME TYPE SEMICOLON", expect
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID LNAME TYPE SEMICOLON CN_CONSTANT RPAREN WHILE
 ##
-## Ends in an error in state: 1652.
+## Ends in an error in state: 1656.
 ##
 ## resource -> CN_EACH LPAREN base_type LNAME TYPE SEMICOLON expr RPAREN . LBRACE pred LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN RBRACE [ SEMICOLON ]
 ##
@@ -6990,7 +6990,7 @@ parsing "resource": seen "CN_EACH LPAREN base_type LNAME TYPE SEMICOLON expr RPA
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID LNAME TYPE SEMICOLON CN_CONSTANT RPAREN LBRACE WHILE
 ##
-## Ends in an error in state: 1653.
+## Ends in an error in state: 1657.
 ##
 ## resource -> CN_EACH LPAREN base_type LNAME TYPE SEMICOLON expr RPAREN LBRACE . pred LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN RBRACE [ SEMICOLON ]
 ##
@@ -7002,7 +7002,7 @@ parsing "resource": seen "CN_EACH LPAREN base_type LNAME TYPE SEMICOLON expr RPA
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID LNAME TYPE SEMICOLON CN_CONSTANT RPAREN LBRACE CN_BLOCK LPAREN WHILE
 ##
-## Ends in an error in state: 1655.
+## Ends in an error in state: 1659.
 ##
 ## resource -> CN_EACH LPAREN base_type LNAME TYPE SEMICOLON expr RPAREN LBRACE pred LPAREN . loption(separated_nonempty_list(COMMA,expr)) RPAREN RBRACE [ SEMICOLON ]
 ##
@@ -7014,7 +7014,7 @@ parsing "resource": seen "CN_EACH LPAREN base_type LNAME TYPE SEMICOLON expr RPA
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID LNAME TYPE SEMICOLON CN_CONSTANT RPAREN LBRACE CN_BLOCK LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1657.
+## Ends in an error in state: 1661.
 ##
 ## resource -> CN_EACH LPAREN base_type LNAME TYPE SEMICOLON expr RPAREN LBRACE pred LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN . RBRACE [ SEMICOLON ]
 ##
@@ -7026,7 +7026,7 @@ parsing "resource": seen "CN_EACH LPAREN base_type LNAME TYPE SEMICOLON expr RPA
 
 loop_spec: CN_INV CN_TAKE UNAME VARIABLE EQ CN_BLOCK LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1659.
+## Ends in an error in state: 1663.
 ##
 ## condition -> CN_TAKE UNAME VARIABLE EQ resource . SEMICOLON [ UNAME TILDE STRUCT STAR SIZEOF RETURN OFFSETOF MINUS LPAREN LNAME LBRACK LBRACE IF EOF DEFAULT CONSTANT CN_TYPE_SYNONYM CN_TRUE CN_TAKE CN_SPEC CN_PREDICATE CN_NULL CN_MEMBER_SHIFT CN_MATCH CN_LET CN_LEMMA CN_GOOD CN_FUNCTION CN_FALSE CN_ENSURES CN_EACH CN_DATATYPE CN_CONSTANT CN_ARRAY_SHIFT BANG AMPERSAND ]
 ##
@@ -7038,7 +7038,7 @@ parsing "condition": seen "CN_TAKE UNAME VARIABLE EQ resource", expecting "SEMIC
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_BLOCK LPAREN WHILE
 ##
-## Ends in an error in state: 1662.
+## Ends in an error in state: 1666.
 ##
 ## resource -> pred LPAREN . loption(separated_nonempty_list(COMMA,expr)) RPAREN [ SEMICOLON ]
 ##
@@ -7050,7 +7050,7 @@ parsing "resource": seen "pred LPAREN", expecting "loption(separated_nonempty_li
 
 loop_spec: CN_INV CN_TAKE UNAME TYPE WHILE
 ##
-## Ends in an error in state: 1665.
+## Ends in an error in state: 1669.
 ##
 ## condition -> CN_TAKE UNAME TYPE . EQ resource SEMICOLON [ UNAME TILDE STRUCT STAR SIZEOF RETURN OFFSETOF MINUS LPAREN LNAME LBRACK LBRACE IF EOF DEFAULT CONSTANT CN_TYPE_SYNONYM CN_TRUE CN_TAKE CN_SPEC CN_PREDICATE CN_NULL CN_MEMBER_SHIFT CN_MATCH CN_LET CN_LEMMA CN_GOOD CN_FUNCTION CN_FALSE CN_ENSURES CN_EACH CN_DATATYPE CN_CONSTANT CN_ARRAY_SHIFT BANG AMPERSAND ]
 ##
@@ -7062,7 +7062,7 @@ parsing "condition": seen "CN_TAKE UNAME TYPE", expecting "EQ resource SEMICOLON
 
 loop_spec: CN_INV CN_TAKE UNAME TYPE EQ WHILE
 ##
-## Ends in an error in state: 1666.
+## Ends in an error in state: 1670.
 ##
 ## condition -> CN_TAKE UNAME TYPE EQ . resource SEMICOLON [ UNAME TILDE STRUCT STAR SIZEOF RETURN OFFSETOF MINUS LPAREN LNAME LBRACK LBRACE IF EOF DEFAULT CONSTANT CN_TYPE_SYNONYM CN_TRUE CN_TAKE CN_SPEC CN_PREDICATE CN_NULL CN_MEMBER_SHIFT CN_MATCH CN_LET CN_LEMMA CN_GOOD CN_FUNCTION CN_FALSE CN_ENSURES CN_EACH CN_DATATYPE CN_CONSTANT CN_ARRAY_SHIFT BANG AMPERSAND ]
 ##
@@ -7074,7 +7074,7 @@ parsing "condition": seen "CN_TAKE UNAME TYPE EQ", expecting "resource SEMICOLON
 
 loop_spec: CN_INV CN_TAKE UNAME TYPE EQ CN_BLOCK LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1667.
+## Ends in an error in state: 1671.
 ##
 ## condition -> CN_TAKE UNAME TYPE EQ resource . SEMICOLON [ UNAME TILDE STRUCT STAR SIZEOF RETURN OFFSETOF MINUS LPAREN LNAME LBRACK LBRACE IF EOF DEFAULT CONSTANT CN_TYPE_SYNONYM CN_TRUE CN_TAKE CN_SPEC CN_PREDICATE CN_NULL CN_MEMBER_SHIFT CN_MATCH CN_LET CN_LEMMA CN_GOOD CN_FUNCTION CN_FALSE CN_ENSURES CN_EACH CN_DATATYPE CN_CONSTANT CN_ARRAY_SHIFT BANG AMPERSAND ]
 ##
@@ -7086,7 +7086,7 @@ parsing "condition": seen "CN_TAKE UNAME TYPE EQ resource", expecting "SEMICOLON
 
 loop_spec: CN_INV CN_TAKE LNAME VARIABLE WHILE
 ##
-## Ends in an error in state: 1670.
+## Ends in an error in state: 1674.
 ##
 ## condition -> CN_TAKE LNAME VARIABLE . EQ resource SEMICOLON [ UNAME TILDE STRUCT STAR SIZEOF RETURN OFFSETOF MINUS LPAREN LNAME LBRACK LBRACE IF EOF DEFAULT CONSTANT CN_TYPE_SYNONYM CN_TRUE CN_TAKE CN_SPEC CN_PREDICATE CN_NULL CN_MEMBER_SHIFT CN_MATCH CN_LET CN_LEMMA CN_GOOD CN_FUNCTION CN_FALSE CN_ENSURES CN_EACH CN_DATATYPE CN_CONSTANT CN_ARRAY_SHIFT BANG AMPERSAND ]
 ##
@@ -7098,7 +7098,7 @@ parsing "condition": seen "CN_TAKE LNAME VARIABLE", expecting "EQ resource SEMIC
 
 loop_spec: CN_INV CN_TAKE LNAME VARIABLE EQ WHILE
 ##
-## Ends in an error in state: 1671.
+## Ends in an error in state: 1675.
 ##
 ## condition -> CN_TAKE LNAME VARIABLE EQ . resource SEMICOLON [ UNAME TILDE STRUCT STAR SIZEOF RETURN OFFSETOF MINUS LPAREN LNAME LBRACK LBRACE IF EOF DEFAULT CONSTANT CN_TYPE_SYNONYM CN_TRUE CN_TAKE CN_SPEC CN_PREDICATE CN_NULL CN_MEMBER_SHIFT CN_MATCH CN_LET CN_LEMMA CN_GOOD CN_FUNCTION CN_FALSE CN_ENSURES CN_EACH CN_DATATYPE CN_CONSTANT CN_ARRAY_SHIFT BANG AMPERSAND ]
 ##
@@ -7110,7 +7110,7 @@ parsing "condition": seen "CN_TAKE LNAME VARIABLE EQ", expecting "resource SEMIC
 
 loop_spec: CN_INV CN_TAKE LNAME VARIABLE EQ CN_BLOCK LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1672.
+## Ends in an error in state: 1676.
 ##
 ## condition -> CN_TAKE LNAME VARIABLE EQ resource . SEMICOLON [ UNAME TILDE STRUCT STAR SIZEOF RETURN OFFSETOF MINUS LPAREN LNAME LBRACK LBRACE IF EOF DEFAULT CONSTANT CN_TYPE_SYNONYM CN_TRUE CN_TAKE CN_SPEC CN_PREDICATE CN_NULL CN_MEMBER_SHIFT CN_MATCH CN_LET CN_LEMMA CN_GOOD CN_FUNCTION CN_FALSE CN_ENSURES CN_EACH CN_DATATYPE CN_CONSTANT CN_ARRAY_SHIFT BANG AMPERSAND ]
 ##
@@ -7122,7 +7122,7 @@ parsing "condition": seen "CN_TAKE LNAME VARIABLE EQ resource", expecting "SEMIC
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE WHILE
 ##
-## Ends in an error in state: 1674.
+## Ends in an error in state: 1678.
 ##
 ## condition -> CN_TAKE LNAME TYPE . EQ resource SEMICOLON [ UNAME TILDE STRUCT STAR SIZEOF RETURN OFFSETOF MINUS LPAREN LNAME LBRACK LBRACE IF EOF DEFAULT CONSTANT CN_TYPE_SYNONYM CN_TRUE CN_TAKE CN_SPEC CN_PREDICATE CN_NULL CN_MEMBER_SHIFT CN_MATCH CN_LET CN_LEMMA CN_GOOD CN_FUNCTION CN_FALSE CN_ENSURES CN_EACH CN_DATATYPE CN_CONSTANT CN_ARRAY_SHIFT BANG AMPERSAND ]
 ##
@@ -7134,7 +7134,7 @@ parsing "condition": seen "CN_TAKE LNAME TYPE", expecting "EQ resource SEMICOLON
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE EQ WHILE
 ##
-## Ends in an error in state: 1675.
+## Ends in an error in state: 1679.
 ##
 ## condition -> CN_TAKE LNAME TYPE EQ . resource SEMICOLON [ UNAME TILDE STRUCT STAR SIZEOF RETURN OFFSETOF MINUS LPAREN LNAME LBRACK LBRACE IF EOF DEFAULT CONSTANT CN_TYPE_SYNONYM CN_TRUE CN_TAKE CN_SPEC CN_PREDICATE CN_NULL CN_MEMBER_SHIFT CN_MATCH CN_LET CN_LEMMA CN_GOOD CN_FUNCTION CN_FALSE CN_ENSURES CN_EACH CN_DATATYPE CN_CONSTANT CN_ARRAY_SHIFT BANG AMPERSAND ]
 ##
@@ -7146,7 +7146,7 @@ parsing "condition": seen "CN_TAKE LNAME TYPE EQ", expecting "resource SEMICOLON
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_BLOCK LPAREN RPAREN WHILE
 ##
-## Ends in an error in state: 1676.
+## Ends in an error in state: 1680.
 ##
 ## condition -> CN_TAKE LNAME TYPE EQ resource . SEMICOLON [ UNAME TILDE STRUCT STAR SIZEOF RETURN OFFSETOF MINUS LPAREN LNAME LBRACK LBRACE IF EOF DEFAULT CONSTANT CN_TYPE_SYNONYM CN_TRUE CN_TAKE CN_SPEC CN_PREDICATE CN_NULL CN_MEMBER_SHIFT CN_MATCH CN_LET CN_LEMMA CN_GOOD CN_FUNCTION CN_FALSE CN_ENSURES CN_EACH CN_DATATYPE CN_CONSTANT CN_ARRAY_SHIFT BANG AMPERSAND ]
 ##
@@ -7158,7 +7158,7 @@ parsing "condition": seen "CN_TAKE LNAME TYPE EQ resource", expecting "SEMICOLON
 
 loop_spec: CN_INV CN_LET UNAME VARIABLE WHILE
 ##
-## Ends in an error in state: 1680.
+## Ends in an error in state: 1684.
 ##
 ## condition -> CN_LET UNAME VARIABLE . EQ expr SEMICOLON [ UNAME TILDE STRUCT STAR SIZEOF RETURN OFFSETOF MINUS LPAREN LNAME LBRACK LBRACE IF EOF DEFAULT CONSTANT CN_TYPE_SYNONYM CN_TRUE CN_TAKE CN_SPEC CN_PREDICATE CN_NULL CN_MEMBER_SHIFT CN_MATCH CN_LET CN_LEMMA CN_GOOD CN_FUNCTION CN_FALSE CN_ENSURES CN_EACH CN_DATATYPE CN_CONSTANT CN_ARRAY_SHIFT BANG AMPERSAND ]
 ##
@@ -7170,7 +7170,7 @@ parsing "condition": seen "CN_LET UNAME VARIABLE", expecting "EQ expr SEMICOLON"
 
 loop_spec: CN_INV CN_LET UNAME VARIABLE EQ WHILE
 ##
-## Ends in an error in state: 1681.
+## Ends in an error in state: 1685.
 ##
 ## condition -> CN_LET UNAME VARIABLE EQ . expr SEMICOLON [ UNAME TILDE STRUCT STAR SIZEOF RETURN OFFSETOF MINUS LPAREN LNAME LBRACK LBRACE IF EOF DEFAULT CONSTANT CN_TYPE_SYNONYM CN_TRUE CN_TAKE CN_SPEC CN_PREDICATE CN_NULL CN_MEMBER_SHIFT CN_MATCH CN_LET CN_LEMMA CN_GOOD CN_FUNCTION CN_FALSE CN_ENSURES CN_EACH CN_DATATYPE CN_CONSTANT CN_ARRAY_SHIFT BANG AMPERSAND ]
 ##
@@ -7182,7 +7182,7 @@ parsing "condition": seen "CN_LET UNAME VARIABLE EQ", expecting "expr SEMICOLON"
 
 loop_spec: CN_INV CN_LET UNAME TYPE WHILE
 ##
-## Ends in an error in state: 1684.
+## Ends in an error in state: 1688.
 ##
 ## condition -> CN_LET UNAME TYPE . EQ expr SEMICOLON [ UNAME TILDE STRUCT STAR SIZEOF RETURN OFFSETOF MINUS LPAREN LNAME LBRACK LBRACE IF EOF DEFAULT CONSTANT CN_TYPE_SYNONYM CN_TRUE CN_TAKE CN_SPEC CN_PREDICATE CN_NULL CN_MEMBER_SHIFT CN_MATCH CN_LET CN_LEMMA CN_GOOD CN_FUNCTION CN_FALSE CN_ENSURES CN_EACH CN_DATATYPE CN_CONSTANT CN_ARRAY_SHIFT BANG AMPERSAND ]
 ##
@@ -7194,7 +7194,7 @@ parsing "condition": seen "CN_LET UNAME TYPE", expecting "EQ expr SEMICOLON"
 
 loop_spec: CN_INV CN_LET UNAME TYPE EQ WHILE
 ##
-## Ends in an error in state: 1685.
+## Ends in an error in state: 1689.
 ##
 ## condition -> CN_LET UNAME TYPE EQ . expr SEMICOLON [ UNAME TILDE STRUCT STAR SIZEOF RETURN OFFSETOF MINUS LPAREN LNAME LBRACK LBRACE IF EOF DEFAULT CONSTANT CN_TYPE_SYNONYM CN_TRUE CN_TAKE CN_SPEC CN_PREDICATE CN_NULL CN_MEMBER_SHIFT CN_MATCH CN_LET CN_LEMMA CN_GOOD CN_FUNCTION CN_FALSE CN_ENSURES CN_EACH CN_DATATYPE CN_CONSTANT CN_ARRAY_SHIFT BANG AMPERSAND ]
 ##
@@ -7206,7 +7206,7 @@ parsing "condition": seen "CN_LET UNAME TYPE EQ", expecting "expr SEMICOLON"
 
 loop_spec: CN_INV CN_LET LNAME VARIABLE WHILE
 ##
-## Ends in an error in state: 1689.
+## Ends in an error in state: 1693.
 ##
 ## condition -> CN_LET LNAME VARIABLE . EQ expr SEMICOLON [ UNAME TILDE STRUCT STAR SIZEOF RETURN OFFSETOF MINUS LPAREN LNAME LBRACK LBRACE IF EOF DEFAULT CONSTANT CN_TYPE_SYNONYM CN_TRUE CN_TAKE CN_SPEC CN_PREDICATE CN_NULL CN_MEMBER_SHIFT CN_MATCH CN_LET CN_LEMMA CN_GOOD CN_FUNCTION CN_FALSE CN_ENSURES CN_EACH CN_DATATYPE CN_CONSTANT CN_ARRAY_SHIFT BANG AMPERSAND ]
 ##
@@ -7218,7 +7218,7 @@ parsing "condition": seen "CN_LET LNAME VARIABLE", expecting "EQ expr SEMICOLON"
 
 loop_spec: CN_INV CN_LET LNAME VARIABLE EQ WHILE
 ##
-## Ends in an error in state: 1690.
+## Ends in an error in state: 1694.
 ##
 ## condition -> CN_LET LNAME VARIABLE EQ . expr SEMICOLON [ UNAME TILDE STRUCT STAR SIZEOF RETURN OFFSETOF MINUS LPAREN LNAME LBRACK LBRACE IF EOF DEFAULT CONSTANT CN_TYPE_SYNONYM CN_TRUE CN_TAKE CN_SPEC CN_PREDICATE CN_NULL CN_MEMBER_SHIFT CN_MATCH CN_LET CN_LEMMA CN_GOOD CN_FUNCTION CN_FALSE CN_ENSURES CN_EACH CN_DATATYPE CN_CONSTANT CN_ARRAY_SHIFT BANG AMPERSAND ]
 ##
@@ -7230,7 +7230,7 @@ parsing "condition": seen "CN_LET LNAME VARIABLE EQ", expecting "expr SEMICOLON"
 
 loop_spec: CN_INV CN_LET LNAME TYPE WHILE
 ##
-## Ends in an error in state: 1693.
+## Ends in an error in state: 1697.
 ##
 ## condition -> CN_LET LNAME TYPE . EQ expr SEMICOLON [ UNAME TILDE STRUCT STAR SIZEOF RETURN OFFSETOF MINUS LPAREN LNAME LBRACK LBRACE IF EOF DEFAULT CONSTANT CN_TYPE_SYNONYM CN_TRUE CN_TAKE CN_SPEC CN_PREDICATE CN_NULL CN_MEMBER_SHIFT CN_MATCH CN_LET CN_LEMMA CN_GOOD CN_FUNCTION CN_FALSE CN_ENSURES CN_EACH CN_DATATYPE CN_CONSTANT CN_ARRAY_SHIFT BANG AMPERSAND ]
 ##
@@ -7242,7 +7242,7 @@ parsing "condition": seen "CN_LET LNAME TYPE", expecting "EQ expr SEMICOLON"
 
 loop_spec: CN_INV CN_LET LNAME TYPE EQ WHILE
 ##
-## Ends in an error in state: 1694.
+## Ends in an error in state: 1698.
 ##
 ## condition -> CN_LET LNAME TYPE EQ . expr SEMICOLON [ UNAME TILDE STRUCT STAR SIZEOF RETURN OFFSETOF MINUS LPAREN LNAME LBRACK LBRACE IF EOF DEFAULT CONSTANT CN_TYPE_SYNONYM CN_TRUE CN_TAKE CN_SPEC CN_PREDICATE CN_NULL CN_MEMBER_SHIFT CN_MATCH CN_LET CN_LEMMA CN_GOOD CN_FUNCTION CN_FALSE CN_ENSURES CN_EACH CN_DATATYPE CN_CONSTANT CN_ARRAY_SHIFT BANG AMPERSAND ]
 ##
@@ -7329,7 +7329,7 @@ parsing "compound_statement": seen "LBRACE", expecting "option(block_item_list) 
 
 translation_unit: BOOL LNAME TYPE CERB_MAGIC WHILE
 ##
-## Ends in an error in state: 1953.
+## Ends in an error in state: 1957.
 ##
 ## function_definition -> function_definition1 option(declaration_list) magic_comment_list . compound_statement boption(SEMICOLON) [ VOLATILE VOID UNSIGNED UNION UNAME TYPEOF TYPEDEF THREAD_LOCAL STRUCT STATIC_ASSERT STATIC SIGNED SHORT RESTRICT REGISTER NORETURN LONG LNAME LBRACK_LBRACK INT INLINE FLOAT EXTERN EOF ENUM DOUBLE CONST COMPLEX CHAR CERB_MAGIC BOOL AUTO ATOMIC ALIGNAS ]
 ##
@@ -7349,7 +7349,7 @@ parsing "function_definition": seen "function_definition1 option(declaration_lis
 
 translation_unit: BOOL LNAME TYPE CERB_MAGIC LBRACE RBRACE WHILE
 ##
-## Ends in an error in state: 1954.
+## Ends in an error in state: 1958.
 ##
 ## function_definition -> function_definition1 option(declaration_list) magic_comment_list compound_statement . boption(SEMICOLON) [ VOLATILE VOID UNSIGNED UNION UNAME TYPEOF TYPEDEF THREAD_LOCAL STRUCT STATIC_ASSERT STATIC SIGNED SHORT RESTRICT REGISTER NORETURN LONG LNAME LBRACK_LBRACK INT INLINE FLOAT EXTERN EOF ENUM DOUBLE CONST COMPLEX CHAR CERB_MAGIC BOOL AUTO ATOMIC ALIGNAS ]
 ##
@@ -7375,7 +7375,7 @@ parsing "function_definition": seen "function_definition1 option(declaration_lis
 
 fundef_spec: WHILE
 ##
-## Ends in an error in state: 1938.
+## Ends in an error in state: 1942.
 ##
 ## fundef_spec' -> . fundef_spec [ # ]
 ##
@@ -7387,7 +7387,7 @@ parsing "fundef_spec'": expected "fundef_spec"
 
 fundef_spec: CN_TRUSTED WHILE
 ##
-## Ends in an error in state: 1587.
+## Ends in an error in state: 1591.
 ##
 ## option(__anonymous_0) -> CN_TRUSTED . SEMICOLON [ EOF CN_TYPE_SYNONYM CN_SPEC CN_REQUIRES CN_PREDICATE CN_LIFT_FUNCTION CN_LEMMA CN_FUNCTION CN_ENSURES CN_DATATYPE CN_ACCESSES ]
 ##
@@ -7399,7 +7399,7 @@ parsing "option(trusted)": seen "CN_TRUSTED", expecting "SEMICOLON"
 
 fundef_spec: CN_TRUSTED SEMICOLON WHILE
 ##
-## Ends in an error in state: 1589.
+## Ends in an error in state: 1593.
 ##
 ## function_spec -> option(__anonymous_0) . option(accesses_or_function) option(requires_clauses) option(ensures_clauses) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -7412,7 +7412,7 @@ parsing "fundef_spec": seen "option(trusted)", expecting "option(accesses_or_fun
 
 fundef_spec: CN_ACCESSES WHILE
 ##
-## Ends in an error in state: 1601.
+## Ends in an error in state: 1605.
 ##
 ## accesses -> CN_ACCESSES . separated_nonempty_list(COMMA,cn_variable) SEMICOLON [ EOF CN_TYPE_SYNONYM CN_SPEC CN_REQUIRES CN_PREDICATE CN_LEMMA CN_FUNCTION CN_ENSURES CN_DATATYPE CN_ACCESSES ]
 ##
@@ -7424,7 +7424,7 @@ parsing "accesses": seen "CN_ACCESSES", expecting "separated_nonempty_list(COMMA
 
 fundef_spec: CN_ACCESSES UNAME TYPE SEMICOLON WHILE
 ##
-## Ends in an error in state: 1712.
+## Ends in an error in state: 1716.
 ##
 ## nonempty_list(accesses) -> accesses . [ EOF CN_TYPE_SYNONYM CN_SPEC CN_REQUIRES CN_PREDICATE CN_LEMMA CN_FUNCTION CN_ENSURES CN_DATATYPE ]
 ## nonempty_list(accesses) -> accesses . nonempty_list(accesses) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_REQUIRES CN_PREDICATE CN_LEMMA CN_FUNCTION CN_ENSURES CN_DATATYPE ]
@@ -7437,7 +7437,7 @@ I've seen an 'accesses' list, and I'm expecting requires/ensures clauses now.
 
 fundef_spec: CN_LIFT_FUNCTION UNAME VARIABLE WHILE
 ##
-## Ends in an error in state: 1592.
+## Ends in an error in state: 1596.
 ##
 ## accesses_or_function -> CN_LIFT_FUNCTION UNAME VARIABLE . SEMICOLON [ EOF CN_TYPE_SYNONYM CN_SPEC CN_REQUIRES CN_PREDICATE CN_LEMMA CN_FUNCTION CN_ENSURES CN_DATATYPE ]
 ##
@@ -7449,7 +7449,7 @@ parsing "accesses_or_function": seen "CN_LIFT_FUNCTION UNAME VARIABLE", expectin
 
 fundef_spec: CN_LIFT_FUNCTION UNAME TYPE WHILE
 ##
-## Ends in an error in state: 1594.
+## Ends in an error in state: 1598.
 ##
 ## accesses_or_function -> CN_LIFT_FUNCTION UNAME TYPE . SEMICOLON [ EOF CN_TYPE_SYNONYM CN_SPEC CN_REQUIRES CN_PREDICATE CN_LEMMA CN_FUNCTION CN_ENSURES CN_DATATYPE ]
 ##
@@ -7461,7 +7461,7 @@ parsing "accesses_or_function": seen "CN_LIFT_FUNCTION UNAME TYPE", expecting "S
 
 fundef_spec: CN_LIFT_FUNCTION LNAME VARIABLE WHILE
 ##
-## Ends in an error in state: 1597.
+## Ends in an error in state: 1601.
 ##
 ## accesses_or_function -> CN_LIFT_FUNCTION LNAME VARIABLE . SEMICOLON [ EOF CN_TYPE_SYNONYM CN_SPEC CN_REQUIRES CN_PREDICATE CN_LEMMA CN_FUNCTION CN_ENSURES CN_DATATYPE ]
 ##
@@ -7473,7 +7473,7 @@ parsing "accesses_or_function": seen "CN_LIFT_FUNCTION LNAME VARIABLE", expectin
 
 fundef_spec: CN_LIFT_FUNCTION LNAME TYPE WHILE
 ##
-## Ends in an error in state: 1599.
+## Ends in an error in state: 1603.
 ##
 ## accesses_or_function -> CN_LIFT_FUNCTION LNAME TYPE . SEMICOLON [ EOF CN_TYPE_SYNONYM CN_SPEC CN_REQUIRES CN_PREDICATE CN_LEMMA CN_FUNCTION CN_ENSURES CN_DATATYPE ]
 ##
@@ -7485,7 +7485,7 @@ parsing "accesses_or_function": seen "CN_LIFT_FUNCTION LNAME TYPE", expecting "S
 
 fundef_spec: CN_LIFT_FUNCTION LNAME TYPE SEMICOLON WHILE
 ##
-## Ends in an error in state: 1604.
+## Ends in an error in state: 1608.
 ##
 ## function_spec -> option(__anonymous_0) option(accesses_or_function) . option(requires_clauses) option(ensures_clauses) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -7564,7 +7564,7 @@ parsing "iteration_statement": seen "FOR LPAREN declaration option(expression) S
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE IF LPAREN CN_CONSTANT RPAREN LBRACE RETURN SEMICOLON RBRACE ELSE LBRACE WHILE
 ##
-## Ends in an error in state: 1749.
+## Ends in an error in state: 1753.
 ##
 ## if_clauses -> LBRACE . clauses RBRACE [ RBRACE ]
 ##
@@ -7578,7 +7578,7 @@ parsing "clauses": seen "IF LPAREN expr RPAREN LBRACE clause SEMICOLON RBRACE EL
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE IF LPAREN CN_CONSTANT RPAREN LBRACE RETURN SEMICOLON RBRACE ELSE LBRACE RETURN SEMICOLON WHILE
 ##
-## Ends in an error in state: 1813.
+## Ends in an error in state: 1817.
 ##
 ## if_clauses -> LBRACE clauses . RBRACE [ RBRACE ]
 ##
@@ -7616,7 +7616,7 @@ parsing "postfix_expression": seen "postfix_expression LPAREN option(argument_ex
 
 fundef_spec: CN_ENSURES WHILE
 ##
-## Ends in an error in state: 1705.
+## Ends in an error in state: 1709.
 ##
 ## ensures_clauses -> CN_ENSURES . option(ghost_binders) nonempty_list(condition) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -7630,7 +7630,7 @@ parsing "ensures_clauses": seen "CN_ENSURES", expecting "cn_args SEMICOLON nonem
 
 fundef_spec: CN_REQUIRES CN_GHOST WHILE
 ##
-## Ends in an error in state: 1606.
+## Ends in an error in state: 1610.
 ##
 ## ghost_binders -> CN_GHOST . cn_args SEMICOLON [ UNAME TILDE STRUCT STAR SIZEOF RETURN OFFSETOF MINUS LPAREN LNAME LBRACK LBRACE IF DEFAULT CONSTANT CN_TRUE CN_TAKE CN_NULL CN_MEMBER_SHIFT CN_MATCH CN_LET CN_GOOD CN_FALSE CN_EACH CN_CONSTANT CN_ARRAY_SHIFT BANG AMPERSAND ]
 ##
@@ -7642,7 +7642,7 @@ parsing "ghost": seen "CN_GHOST", expecting "cn_args SEMICOLON"
 
 fundef_spec: CN_REQUIRES CN_GHOST SEMICOLON WHILE
 ##
-## Ends in an error in state: 1609.
+## Ends in an error in state: 1613.
 ##
 ## requires_clauses -> CN_REQUIRES option(ghost_binders) . nonempty_list(condition) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_ENSURES CN_DATATYPE ]
 ##
@@ -7654,7 +7654,7 @@ parsing "requires_clauses": seen "CN_REQUIRES option(ghost)", expecting "nonempt
 
 fundef_spec: CN_ENSURES CN_GHOST SEMICOLON WHILE
 ##
-## Ends in an error in state: 1706.
+## Ends in an error in state: 1710.
 ##
 ## ensures_clauses -> CN_ENSURES option(ghost_binders) . nonempty_list(condition) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -7877,6 +7877,30 @@ cn_ghost_args: WHILE
 ##
 
 parsing "cn_ghost_args'": expected "cn_ghost_args"
+
+cn_statements: CN_UNPACK CN_BLOCK LPAREN ELLIPSIS WHILE
+##
+## Ends in an error in state: 1406.
+##
+## cn_statement -> CN_UNPACK pred LPAREN cn_exprs_or_elipsis . RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
+##
+## The known suffix of the stack is as follows:
+## CN_UNPACK pred LPAREN cn_exprs_or_elipsis
+##
+
+parsing "cn_statement": seen "CN_UNPACK pred LPAREN cn_exprs_or_elipsis", expecting "RPAREN SEMICOLON"
+
+cn_statements: CN_PACK CN_BLOCK LPAREN ELLIPSIS WHILE
+##
+## Ends in an error in state: 1483.
+##
+## cn_statement -> CN_PACK pred LPAREN cn_exprs_or_elipsis . RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
+##
+## The known suffix of the stack is as follows:
+## CN_PACK pred LPAREN cn_exprs_or_elipsis
+##
+
+parsing "cn_statement": seen "CN_PACK pred LPAREN cn_exprs_or_elipsis", expecting "RPAREN SEMICOLON"
 
 cn_ghost_args: UNAME WHILE
 ##
@@ -14366,8 +14390,8 @@ cn_ghost_args: CN_CONSTANT RBRACE
 ##
 ## Ends in an error in state: 1130.
 ##
-## separated_nonempty_list(COMMA,expr) -> expr . [ RPAREN EOF ]
-## separated_nonempty_list(COMMA,expr) -> expr . COMMA separated_nonempty_list(COMMA,expr) [ RPAREN EOF ]
+## separated_nonempty_list(COMMA,expr) -> expr . [ SEMICOLON RPAREN EOF ]
+## separated_nonempty_list(COMMA,expr) -> expr . COMMA separated_nonempty_list(COMMA,expr) [ SEMICOLON RPAREN EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## expr
@@ -15879,7 +15903,7 @@ cn_ghost_args: CN_CONSTANT RPAREN
 ##
 ## Ends in an error in state: 1365.
 ##
-## cn_ghost_args -> loption(separated_nonempty_list(COMMA,expr)) . EOF [ # ]
+## cn_ghost_args -> loption(separated_nonempty_list(COMMA,expr)) . option(cn_ghost_args_out) EOF [ # ]
 ##
 ## The known suffix of the stack is as follows:
 ## loption(separated_nonempty_list(COMMA,expr))
@@ -15904,14 +15928,26 @@ cn_ghost_args: CN_CONSTANT RPAREN
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
+cn_ghost_args: SEMICOLON WHILE
+##
+## Ends in an error in state: 1366.
+##
+## cn_ghost_args_out -> SEMICOLON . loption(separated_nonempty_list(COMMA,cn_variable)) [ EOF ]
+##
+## The known suffix of the stack is as follows:
+## SEMICOLON
+##
+
+parsing "cn_ghost_args_out": seen "SEMICOLON", expecting "loption(separated_nonempty_list(COMMA,cn_variable))"
+
 cn_statements: INLINE UNAME WHILE
 ##
-## Ends in an error in state: 1370.
+## Ends in an error in state: 1367.
 ##
-## separated_nonempty_list(COMMA,cn_variable) -> UNAME . VARIABLE [ SEMICOLON RBRACK ]
-## separated_nonempty_list(COMMA,cn_variable) -> UNAME . TYPE [ SEMICOLON RBRACK ]
-## separated_nonempty_list(COMMA,cn_variable) -> UNAME . VARIABLE COMMA separated_nonempty_list(COMMA,cn_variable) [ SEMICOLON RBRACK ]
-## separated_nonempty_list(COMMA,cn_variable) -> UNAME . TYPE COMMA separated_nonempty_list(COMMA,cn_variable) [ SEMICOLON RBRACK ]
+## separated_nonempty_list(COMMA,cn_variable) -> UNAME . VARIABLE [ SEMICOLON RBRACK EOF ]
+## separated_nonempty_list(COMMA,cn_variable) -> UNAME . TYPE [ SEMICOLON RBRACK EOF ]
+## separated_nonempty_list(COMMA,cn_variable) -> UNAME . VARIABLE COMMA separated_nonempty_list(COMMA,cn_variable) [ SEMICOLON RBRACK EOF ]
+## separated_nonempty_list(COMMA,cn_variable) -> UNAME . TYPE COMMA separated_nonempty_list(COMMA,cn_variable) [ SEMICOLON RBRACK EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## UNAME
@@ -15921,10 +15957,10 @@ cn_statements: INLINE UNAME WHILE
 
 cn_statements: INLINE UNAME VARIABLE WHILE
 ##
-## Ends in an error in state: 1371.
+## Ends in an error in state: 1368.
 ##
-## separated_nonempty_list(COMMA,cn_variable) -> UNAME VARIABLE . [ SEMICOLON RBRACK ]
-## separated_nonempty_list(COMMA,cn_variable) -> UNAME VARIABLE . COMMA separated_nonempty_list(COMMA,cn_variable) [ SEMICOLON RBRACK ]
+## separated_nonempty_list(COMMA,cn_variable) -> UNAME VARIABLE . [ SEMICOLON RBRACK EOF ]
+## separated_nonempty_list(COMMA,cn_variable) -> UNAME VARIABLE . COMMA separated_nonempty_list(COMMA,cn_variable) [ SEMICOLON RBRACK EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## UNAME VARIABLE
@@ -15934,12 +15970,12 @@ cn_statements: INLINE UNAME VARIABLE WHILE
 
 cn_statements: INLINE LNAME WHILE
 ##
-## Ends in an error in state: 1373.
+## Ends in an error in state: 1370.
 ##
-## separated_nonempty_list(COMMA,cn_variable) -> LNAME . VARIABLE [ SEMICOLON RBRACK ]
-## separated_nonempty_list(COMMA,cn_variable) -> LNAME . TYPE [ SEMICOLON RBRACK ]
-## separated_nonempty_list(COMMA,cn_variable) -> LNAME . VARIABLE COMMA separated_nonempty_list(COMMA,cn_variable) [ SEMICOLON RBRACK ]
-## separated_nonempty_list(COMMA,cn_variable) -> LNAME . TYPE COMMA separated_nonempty_list(COMMA,cn_variable) [ SEMICOLON RBRACK ]
+## separated_nonempty_list(COMMA,cn_variable) -> LNAME . VARIABLE [ SEMICOLON RBRACK EOF ]
+## separated_nonempty_list(COMMA,cn_variable) -> LNAME . TYPE [ SEMICOLON RBRACK EOF ]
+## separated_nonempty_list(COMMA,cn_variable) -> LNAME . VARIABLE COMMA separated_nonempty_list(COMMA,cn_variable) [ SEMICOLON RBRACK EOF ]
+## separated_nonempty_list(COMMA,cn_variable) -> LNAME . TYPE COMMA separated_nonempty_list(COMMA,cn_variable) [ SEMICOLON RBRACK EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## LNAME
@@ -15949,10 +15985,10 @@ cn_statements: INLINE LNAME WHILE
 
 cn_statements: INLINE LNAME VARIABLE WHILE
 ##
-## Ends in an error in state: 1374.
+## Ends in an error in state: 1371.
 ##
-## separated_nonempty_list(COMMA,cn_variable) -> LNAME VARIABLE . [ SEMICOLON RBRACK ]
-## separated_nonempty_list(COMMA,cn_variable) -> LNAME VARIABLE . COMMA separated_nonempty_list(COMMA,cn_variable) [ SEMICOLON RBRACK ]
+## separated_nonempty_list(COMMA,cn_variable) -> LNAME VARIABLE . [ SEMICOLON RBRACK EOF ]
+## separated_nonempty_list(COMMA,cn_variable) -> LNAME VARIABLE . COMMA separated_nonempty_list(COMMA,cn_variable) [ SEMICOLON RBRACK EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## LNAME VARIABLE
@@ -15962,10 +15998,10 @@ cn_statements: INLINE LNAME VARIABLE WHILE
 
 cn_statements: INLINE LNAME TYPE WHILE
 ##
-## Ends in an error in state: 1377.
+## Ends in an error in state: 1374.
 ##
-## separated_nonempty_list(COMMA,cn_variable) -> LNAME TYPE . [ SEMICOLON RBRACK ]
-## separated_nonempty_list(COMMA,cn_variable) -> LNAME TYPE . COMMA separated_nonempty_list(COMMA,cn_variable) [ SEMICOLON RBRACK ]
+## separated_nonempty_list(COMMA,cn_variable) -> LNAME TYPE . [ SEMICOLON RBRACK EOF ]
+## separated_nonempty_list(COMMA,cn_variable) -> LNAME TYPE . COMMA separated_nonempty_list(COMMA,cn_variable) [ SEMICOLON RBRACK EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## LNAME TYPE
@@ -15975,10 +16011,10 @@ cn_statements: INLINE LNAME TYPE WHILE
 
 cn_statements: INLINE UNAME TYPE WHILE
 ##
-## Ends in an error in state: 1381.
+## Ends in an error in state: 1378.
 ##
-## separated_nonempty_list(COMMA,cn_variable) -> UNAME TYPE . [ SEMICOLON RBRACK ]
-## separated_nonempty_list(COMMA,cn_variable) -> UNAME TYPE . COMMA separated_nonempty_list(COMMA,cn_variable) [ SEMICOLON RBRACK ]
+## separated_nonempty_list(COMMA,cn_variable) -> UNAME TYPE . [ SEMICOLON RBRACK EOF ]
+## separated_nonempty_list(COMMA,cn_variable) -> UNAME TYPE . COMMA separated_nonempty_list(COMMA,cn_variable) [ SEMICOLON RBRACK EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## UNAME TYPE
@@ -15986,9 +16022,30 @@ cn_statements: INLINE UNAME TYPE WHILE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
+cn_ghost_args: SEMICOLON UNAME TYPE SEMICOLON
+##
+## Ends in an error in state: 1383.
+##
+## cn_ghost_args -> loption(separated_nonempty_list(COMMA,expr)) option(cn_ghost_args_out) . EOF [ # ]
+##
+## The known suffix of the stack is as follows:
+## loption(separated_nonempty_list(COMMA,expr)) option(cn_ghost_args_out)
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 1378, spurious reduction of production separated_nonempty_list(COMMA,cn_variable) -> UNAME TYPE
+## In state 1381, spurious reduction of production loption(separated_nonempty_list(COMMA,cn_variable)) -> separated_nonempty_list(COMMA,cn_variable)
+## In state 1382, spurious reduction of production cn_ghost_args_out -> SEMICOLON loption(separated_nonempty_list(COMMA,cn_variable))
+## In state 1385, spurious reduction of production option(cn_ghost_args_out) -> cn_ghost_args_out
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
 cn_statements: INLINE UNAME TYPE RBRACK
 ##
-## Ends in an error in state: 1385.
+## Ends in an error in state: 1389.
 ##
 ## cn_statement -> INLINE loption(separated_nonempty_list(COMMA,cn_variable)) . SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -15999,15 +16056,15 @@ cn_statements: INLINE UNAME TYPE RBRACK
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1381, spurious reduction of production separated_nonempty_list(COMMA,cn_variable) -> UNAME TYPE
-## In state 1384, spurious reduction of production loption(separated_nonempty_list(COMMA,cn_variable)) -> separated_nonempty_list(COMMA,cn_variable)
+## In state 1378, spurious reduction of production separated_nonempty_list(COMMA,cn_variable) -> UNAME TYPE
+## In state 1381, spurious reduction of production loption(separated_nonempty_list(COMMA,cn_variable)) -> separated_nonempty_list(COMMA,cn_variable)
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 cn_statements: CN_EXTRACT CN_OWNED WHILE
 ##
-## Ends in an error in state: 1390.
+## Ends in an error in state: 1394.
 ##
 ## pred -> CN_OWNED . LT ctype GT [ LPAREN COMMA ]
 ## pred -> CN_OWNED . [ LPAREN COMMA ]
@@ -16020,7 +16077,7 @@ cn_statements: CN_EXTRACT CN_OWNED WHILE
 
 cn_statements: CN_EXTRACT CN_OWNED LT BOOL COLON
 ##
-## Ends in an error in state: 1392.
+## Ends in an error in state: 1396.
 ##
 ## pred -> CN_OWNED LT ctype . GT [ LPAREN COMMA ]
 ##
@@ -16044,7 +16101,7 @@ cn_statements: CN_EXTRACT CN_OWNED LT BOOL COLON
 
 cn_statements: CN_EXTRACT CN_BLOCK LT BOOL COLON
 ##
-## Ends in an error in state: 1396.
+## Ends in an error in state: 1400.
 ##
 ## pred -> CN_BLOCK LT ctype . GT [ LPAREN COMMA ]
 ##
@@ -16068,7 +16125,7 @@ cn_statements: CN_EXTRACT CN_BLOCK LT BOOL COLON
 
 cn_statements: CN_UNPACK CN_BLOCK COMMA
 ##
-## Ends in an error in state: 1398.
+## Ends in an error in state: 1402.
 ##
 ## cn_statement -> CN_UNPACK pred . LPAREN cn_exprs_or_elipsis RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -16079,26 +16136,14 @@ cn_statements: CN_UNPACK CN_BLOCK COMMA
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1394, spurious reduction of production pred -> CN_BLOCK
+## In state 1398, spurious reduction of production pred -> CN_BLOCK
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-cn_statements: CN_UNPACK CN_BLOCK LPAREN ELLIPSIS WHILE
-##
-## Ends in an error in state: 1402.
-##
-## cn_statement -> CN_UNPACK pred LPAREN cn_exprs_or_elipsis . RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
-##
-## The known suffix of the stack is as follows:
-## CN_UNPACK pred LPAREN cn_exprs_or_elipsis
-##
-
-parsing "cn_statement": seen "CN_UNPACK pred LPAREN cn_exprs_or_elipsis", expecting "RPAREN SEMICOLON"
-
 cn_statements: CN_UNFOLD WHILE
 ##
-## Ends in an error in state: 1405.
+## Ends in an error in state: 1409.
 ##
 ## cn_statement -> CN_UNFOLD . UNAME VARIABLE LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ## cn_statement -> CN_UNFOLD . LNAME VARIABLE LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
@@ -16113,7 +16158,7 @@ cn_statements: CN_UNFOLD WHILE
 
 cn_statements: CN_UNFOLD UNAME WHILE
 ##
-## Ends in an error in state: 1406.
+## Ends in an error in state: 1410.
 ##
 ## cn_statement -> CN_UNFOLD UNAME . VARIABLE LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ## cn_statement -> CN_UNFOLD UNAME . TYPE LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
@@ -16126,7 +16171,7 @@ cn_statements: CN_UNFOLD UNAME WHILE
 
 cn_statements: CN_UNFOLD UNAME VARIABLE LPAREN CN_CONSTANT EOF
 ##
-## Ends in an error in state: 1409.
+## Ends in an error in state: 1413.
 ##
 ## cn_statement -> CN_UNFOLD UNAME VARIABLE LPAREN loption(separated_nonempty_list(COMMA,expr)) . RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -16155,7 +16200,7 @@ cn_statements: CN_UNFOLD UNAME VARIABLE LPAREN CN_CONSTANT EOF
 
 cn_statements: CN_UNFOLD UNAME TYPE LPAREN CN_CONSTANT EOF
 ##
-## Ends in an error in state: 1414.
+## Ends in an error in state: 1418.
 ##
 ## cn_statement -> CN_UNFOLD UNAME TYPE LPAREN loption(separated_nonempty_list(COMMA,expr)) . RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -16184,7 +16229,7 @@ cn_statements: CN_UNFOLD UNAME TYPE LPAREN CN_CONSTANT EOF
 
 cn_statements: CN_UNFOLD LNAME WHILE
 ##
-## Ends in an error in state: 1417.
+## Ends in an error in state: 1421.
 ##
 ## cn_statement -> CN_UNFOLD LNAME . VARIABLE LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ## cn_statement -> CN_UNFOLD LNAME . TYPE LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
@@ -16197,7 +16242,7 @@ cn_statements: CN_UNFOLD LNAME WHILE
 
 cn_statements: CN_UNFOLD LNAME VARIABLE LPAREN CN_CONSTANT EOF
 ##
-## Ends in an error in state: 1420.
+## Ends in an error in state: 1424.
 ##
 ## cn_statement -> CN_UNFOLD LNAME VARIABLE LPAREN loption(separated_nonempty_list(COMMA,expr)) . RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -16226,7 +16271,7 @@ cn_statements: CN_UNFOLD LNAME VARIABLE LPAREN CN_CONSTANT EOF
 
 cn_statements: CN_UNFOLD LNAME TYPE LPAREN CN_CONSTANT EOF
 ##
-## Ends in an error in state: 1425.
+## Ends in an error in state: 1429.
 ##
 ## cn_statement -> CN_UNFOLD LNAME TYPE LPAREN loption(separated_nonempty_list(COMMA,expr)) . RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -16255,7 +16300,7 @@ cn_statements: CN_UNFOLD LNAME TYPE LPAREN CN_CONSTANT EOF
 
 cn_statements: CN_TO_BYTES CN_BLOCK COMMA
 ##
-## Ends in an error in state: 1429.
+## Ends in an error in state: 1433.
 ##
 ## cn_statement -> CN_TO_BYTES pred . LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -16266,14 +16311,14 @@ cn_statements: CN_TO_BYTES CN_BLOCK COMMA
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1394, spurious reduction of production pred -> CN_BLOCK
+## In state 1398, spurious reduction of production pred -> CN_BLOCK
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 cn_statements: CN_TO_BYTES CN_BLOCK LPAREN CN_CONSTANT EOF
 ##
-## Ends in an error in state: 1431.
+## Ends in an error in state: 1435.
 ##
 ## cn_statement -> CN_TO_BYTES pred LPAREN loption(separated_nonempty_list(COMMA,expr)) . RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -16302,7 +16347,7 @@ cn_statements: CN_TO_BYTES CN_BLOCK LPAREN CN_CONSTANT EOF
 
 cn_statements: CN_HAVE CN_EACH WHILE
 ##
-## Ends in an error in state: 1435.
+## Ends in an error in state: 1439.
 ##
 ## assert_expr -> CN_EACH . LPAREN base_type UNAME VARIABLE SEMICOLON expr RPAREN LBRACE expr RBRACE [ SEMICOLON RPAREN ]
 ## assert_expr -> CN_EACH . LPAREN base_type LNAME VARIABLE SEMICOLON expr RPAREN LBRACE expr RBRACE [ SEMICOLON RPAREN ]
@@ -16321,7 +16366,7 @@ cn_statements: CN_HAVE CN_EACH WHILE
 
 cn_statements: CN_HAVE CN_EACH LPAREN WHILE
 ##
-## Ends in an error in state: 1436.
+## Ends in an error in state: 1440.
 ##
 ## assert_expr -> CN_EACH LPAREN . base_type UNAME VARIABLE SEMICOLON expr RPAREN LBRACE expr RBRACE [ SEMICOLON RPAREN ]
 ## assert_expr -> CN_EACH LPAREN . base_type LNAME VARIABLE SEMICOLON expr RPAREN LBRACE expr RBRACE [ SEMICOLON RPAREN ]
@@ -16340,7 +16385,7 @@ cn_statements: CN_HAVE CN_EACH LPAREN WHILE
 
 cn_statements: CN_HAVE CN_EACH LPAREN CN_ALLOC_ID WHILE
 ##
-## Ends in an error in state: 1437.
+## Ends in an error in state: 1441.
 ##
 ## assert_expr -> CN_EACH LPAREN base_type . UNAME VARIABLE SEMICOLON expr RPAREN LBRACE expr RBRACE [ SEMICOLON RPAREN ]
 ## assert_expr -> CN_EACH LPAREN base_type . LNAME VARIABLE SEMICOLON expr RPAREN LBRACE expr RBRACE [ SEMICOLON RPAREN ]
@@ -16359,7 +16404,7 @@ cn_statements: CN_HAVE CN_EACH LPAREN CN_ALLOC_ID WHILE
 
 cn_statements: CN_HAVE CN_EACH LPAREN CN_ALLOC_ID UNAME WHILE
 ##
-## Ends in an error in state: 1438.
+## Ends in an error in state: 1442.
 ##
 ## assert_expr -> CN_EACH LPAREN base_type UNAME . VARIABLE SEMICOLON expr RPAREN LBRACE expr RBRACE [ SEMICOLON RPAREN ]
 ## assert_expr -> CN_EACH LPAREN base_type UNAME . TYPE SEMICOLON expr RPAREN LBRACE expr RBRACE [ SEMICOLON RPAREN ]
@@ -16374,7 +16419,7 @@ cn_statements: CN_HAVE CN_EACH LPAREN CN_ALLOC_ID UNAME WHILE
 
 cn_statements: CN_HAVE CN_EACH LPAREN CN_ALLOC_ID UNAME VARIABLE WHILE
 ##
-## Ends in an error in state: 1439.
+## Ends in an error in state: 1443.
 ##
 ## assert_expr -> CN_EACH LPAREN base_type UNAME VARIABLE . SEMICOLON expr RPAREN LBRACE expr RBRACE [ SEMICOLON RPAREN ]
 ## expr_without_let -> CN_EACH LPAREN base_type UNAME VARIABLE . COLON int_range SEMICOLON expr RPAREN [ SEMICOLON RPAREN ]
@@ -16387,7 +16432,7 @@ cn_statements: CN_HAVE CN_EACH LPAREN CN_ALLOC_ID UNAME VARIABLE WHILE
 
 cn_statements: CN_HAVE CN_EACH LPAREN CN_ALLOC_ID UNAME VARIABLE SEMICOLON CN_CONSTANT EOF
 ##
-## Ends in an error in state: 1441.
+## Ends in an error in state: 1445.
 ##
 ## assert_expr -> CN_EACH LPAREN base_type UNAME VARIABLE SEMICOLON expr . RPAREN LBRACE expr RBRACE [ SEMICOLON RPAREN ]
 ##
@@ -16414,7 +16459,7 @@ cn_statements: CN_HAVE CN_EACH LPAREN CN_ALLOC_ID UNAME VARIABLE SEMICOLON CN_CO
 
 cn_statements: CN_HAVE CN_EACH LPAREN CN_ALLOC_ID UNAME VARIABLE SEMICOLON CN_CONSTANT RPAREN LBRACE CN_CONSTANT RPAREN
 ##
-## Ends in an error in state: 1444.
+## Ends in an error in state: 1448.
 ##
 ## assert_expr -> CN_EACH LPAREN base_type UNAME VARIABLE SEMICOLON expr RPAREN LBRACE expr . RBRACE [ SEMICOLON RPAREN ]
 ##
@@ -16441,7 +16486,7 @@ cn_statements: CN_HAVE CN_EACH LPAREN CN_ALLOC_ID UNAME VARIABLE SEMICOLON CN_CO
 
 cn_statements: CN_HAVE CN_EACH LPAREN CN_ALLOC_ID UNAME TYPE WHILE
 ##
-## Ends in an error in state: 1446.
+## Ends in an error in state: 1450.
 ##
 ## assert_expr -> CN_EACH LPAREN base_type UNAME TYPE . SEMICOLON expr RPAREN LBRACE expr RBRACE [ SEMICOLON RPAREN ]
 ## expr_without_let -> CN_EACH LPAREN base_type UNAME TYPE . COLON int_range SEMICOLON expr RPAREN [ SEMICOLON RPAREN ]
@@ -16454,7 +16499,7 @@ cn_statements: CN_HAVE CN_EACH LPAREN CN_ALLOC_ID UNAME TYPE WHILE
 
 cn_statements: CN_HAVE CN_EACH LPAREN CN_ALLOC_ID UNAME TYPE SEMICOLON CN_CONSTANT EOF
 ##
-## Ends in an error in state: 1448.
+## Ends in an error in state: 1452.
 ##
 ## assert_expr -> CN_EACH LPAREN base_type UNAME TYPE SEMICOLON expr . RPAREN LBRACE expr RBRACE [ SEMICOLON RPAREN ]
 ##
@@ -16481,7 +16526,7 @@ cn_statements: CN_HAVE CN_EACH LPAREN CN_ALLOC_ID UNAME TYPE SEMICOLON CN_CONSTA
 
 cn_statements: CN_HAVE CN_EACH LPAREN CN_ALLOC_ID UNAME TYPE SEMICOLON CN_CONSTANT RPAREN LBRACE CN_CONSTANT RPAREN
 ##
-## Ends in an error in state: 1451.
+## Ends in an error in state: 1455.
 ##
 ## assert_expr -> CN_EACH LPAREN base_type UNAME TYPE SEMICOLON expr RPAREN LBRACE expr . RBRACE [ SEMICOLON RPAREN ]
 ##
@@ -16508,7 +16553,7 @@ cn_statements: CN_HAVE CN_EACH LPAREN CN_ALLOC_ID UNAME TYPE SEMICOLON CN_CONSTA
 
 cn_statements: CN_HAVE CN_EACH LPAREN CN_ALLOC_ID LNAME WHILE
 ##
-## Ends in an error in state: 1453.
+## Ends in an error in state: 1457.
 ##
 ## assert_expr -> CN_EACH LPAREN base_type LNAME . VARIABLE SEMICOLON expr RPAREN LBRACE expr RBRACE [ SEMICOLON RPAREN ]
 ## assert_expr -> CN_EACH LPAREN base_type LNAME . TYPE SEMICOLON expr RPAREN LBRACE expr RBRACE [ SEMICOLON RPAREN ]
@@ -16523,7 +16568,7 @@ cn_statements: CN_HAVE CN_EACH LPAREN CN_ALLOC_ID LNAME WHILE
 
 cn_statements: CN_HAVE CN_EACH LPAREN CN_ALLOC_ID LNAME VARIABLE WHILE
 ##
-## Ends in an error in state: 1454.
+## Ends in an error in state: 1458.
 ##
 ## assert_expr -> CN_EACH LPAREN base_type LNAME VARIABLE . SEMICOLON expr RPAREN LBRACE expr RBRACE [ SEMICOLON RPAREN ]
 ## expr_without_let -> CN_EACH LPAREN base_type LNAME VARIABLE . COLON int_range SEMICOLON expr RPAREN [ SEMICOLON RPAREN ]
@@ -16536,7 +16581,7 @@ cn_statements: CN_HAVE CN_EACH LPAREN CN_ALLOC_ID LNAME VARIABLE WHILE
 
 cn_statements: CN_HAVE CN_EACH LPAREN CN_ALLOC_ID LNAME VARIABLE SEMICOLON CN_CONSTANT EOF
 ##
-## Ends in an error in state: 1456.
+## Ends in an error in state: 1460.
 ##
 ## assert_expr -> CN_EACH LPAREN base_type LNAME VARIABLE SEMICOLON expr . RPAREN LBRACE expr RBRACE [ SEMICOLON RPAREN ]
 ##
@@ -16563,7 +16608,7 @@ cn_statements: CN_HAVE CN_EACH LPAREN CN_ALLOC_ID LNAME VARIABLE SEMICOLON CN_CO
 
 cn_statements: CN_HAVE CN_EACH LPAREN CN_ALLOC_ID LNAME VARIABLE SEMICOLON CN_CONSTANT RPAREN LBRACE CN_CONSTANT RPAREN
 ##
-## Ends in an error in state: 1459.
+## Ends in an error in state: 1463.
 ##
 ## assert_expr -> CN_EACH LPAREN base_type LNAME VARIABLE SEMICOLON expr RPAREN LBRACE expr . RBRACE [ SEMICOLON RPAREN ]
 ##
@@ -16590,7 +16635,7 @@ cn_statements: CN_HAVE CN_EACH LPAREN CN_ALLOC_ID LNAME VARIABLE SEMICOLON CN_CO
 
 cn_statements: CN_HAVE CN_EACH LPAREN CN_ALLOC_ID LNAME TYPE WHILE
 ##
-## Ends in an error in state: 1461.
+## Ends in an error in state: 1465.
 ##
 ## assert_expr -> CN_EACH LPAREN base_type LNAME TYPE . SEMICOLON expr RPAREN LBRACE expr RBRACE [ SEMICOLON RPAREN ]
 ## expr_without_let -> CN_EACH LPAREN base_type LNAME TYPE . COLON int_range SEMICOLON expr RPAREN [ SEMICOLON RPAREN ]
@@ -16603,7 +16648,7 @@ cn_statements: CN_HAVE CN_EACH LPAREN CN_ALLOC_ID LNAME TYPE WHILE
 
 cn_statements: CN_HAVE CN_EACH LPAREN CN_ALLOC_ID LNAME TYPE SEMICOLON CN_CONSTANT EOF
 ##
-## Ends in an error in state: 1463.
+## Ends in an error in state: 1467.
 ##
 ## assert_expr -> CN_EACH LPAREN base_type LNAME TYPE SEMICOLON expr . RPAREN LBRACE expr RBRACE [ SEMICOLON RPAREN ]
 ##
@@ -16630,7 +16675,7 @@ cn_statements: CN_HAVE CN_EACH LPAREN CN_ALLOC_ID LNAME TYPE SEMICOLON CN_CONSTA
 
 cn_statements: CN_HAVE CN_EACH LPAREN CN_ALLOC_ID LNAME TYPE SEMICOLON CN_CONSTANT RPAREN LBRACE CN_CONSTANT RPAREN
 ##
-## Ends in an error in state: 1466.
+## Ends in an error in state: 1470.
 ##
 ## assert_expr -> CN_EACH LPAREN base_type LNAME TYPE SEMICOLON expr RPAREN LBRACE expr . RBRACE [ SEMICOLON RPAREN ]
 ##
@@ -16657,7 +16702,7 @@ cn_statements: CN_HAVE CN_EACH LPAREN CN_ALLOC_ID LNAME TYPE SEMICOLON CN_CONSTA
 
 cn_statements: CN_SPLIT_CASE CN_CONSTANT RPAREN
 ##
-## Ends in an error in state: 1469.
+## Ends in an error in state: 1473.
 ##
 ## cn_statement -> CN_SPLIT_CASE assert_expr . SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -16677,14 +16722,14 @@ cn_statements: CN_SPLIT_CASE CN_CONSTANT RPAREN
 ## In state 1114, spurious reduction of production bool_or_expr -> bool_implies_expr
 ## In state 1081, spurious reduction of production list_expr -> bool_or_expr
 ## In state 1076, spurious reduction of production expr_without_let -> list_expr
-## In state 1468, spurious reduction of production assert_expr -> expr_without_let
+## In state 1472, spurious reduction of production assert_expr -> expr_without_let
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 cn_statements: CN_PRINT LPAREN CN_CONSTANT EOF
 ##
-## Ends in an error in state: 1473.
+## Ends in an error in state: 1477.
 ##
 ## cn_statement -> CN_PRINT LPAREN expr . RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -16711,7 +16756,7 @@ cn_statements: CN_PRINT LPAREN CN_CONSTANT EOF
 
 cn_statements: CN_PACK CN_BLOCK COMMA
 ##
-## Ends in an error in state: 1477.
+## Ends in an error in state: 1481.
 ##
 ## cn_statement -> CN_PACK pred . LPAREN cn_exprs_or_elipsis RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -16722,26 +16767,14 @@ cn_statements: CN_PACK CN_BLOCK COMMA
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1394, spurious reduction of production pred -> CN_BLOCK
+## In state 1398, spurious reduction of production pred -> CN_BLOCK
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-cn_statements: CN_PACK CN_BLOCK LPAREN ELLIPSIS WHILE
-##
-## Ends in an error in state: 1479.
-##
-## cn_statement -> CN_PACK pred LPAREN cn_exprs_or_elipsis . RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
-##
-## The known suffix of the stack is as follows:
-## CN_PACK pred LPAREN cn_exprs_or_elipsis
-##
-
-parsing "cn_statement": seen "CN_PACK pred LPAREN cn_exprs_or_elipsis", expecting "RPAREN SEMICOLON"
-
 cn_statements: CN_INSTANTIATE WHILE
 ##
-## Ends in an error in state: 1482.
+## Ends in an error in state: 1486.
 ##
 ## cn_statement -> CN_INSTANTIATE . expr SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ## cn_statement -> CN_INSTANTIATE . UNAME VARIABLE COMMA expr SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
@@ -16758,7 +16791,7 @@ cn_statements: CN_INSTANTIATE WHILE
 
 cn_statements: CN_INSTANTIATE UNAME WHILE
 ##
-## Ends in an error in state: 1483.
+## Ends in an error in state: 1487.
 ##
 ## cn_statement -> CN_INSTANTIATE UNAME . VARIABLE COMMA expr SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ## cn_statement -> CN_INSTANTIATE UNAME . TYPE COMMA expr SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
@@ -16777,7 +16810,7 @@ cn_statements: CN_INSTANTIATE UNAME WHILE
 
 cn_statements: CN_INSTANTIATE UNAME VARIABLE WHILE
 ##
-## Ends in an error in state: 1484.
+## Ends in an error in state: 1488.
 ##
 ## cn_statement -> CN_INSTANTIATE UNAME VARIABLE . COMMA expr SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ## prim_expr -> UNAME VARIABLE . [ STAR SLASH SEMICOLON QUESTION PLUS PIPE_PIPE PIPE PERCENT MINUS_GT MINUS LT_EQ LT LBRACK GT_EQ GT EQ_EQ DOT CN_IMPLIES CARET BANG_EQ AMPERSAND_AMPERSAND AMPERSAND ]
@@ -16792,7 +16825,7 @@ cn_statements: CN_INSTANTIATE UNAME VARIABLE WHILE
 
 cn_statements: CN_INSTANTIATE UNAME VARIABLE COMMA CN_CONSTANT RPAREN
 ##
-## Ends in an error in state: 1486.
+## Ends in an error in state: 1490.
 ##
 ## cn_statement -> CN_INSTANTIATE UNAME VARIABLE COMMA expr . SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -16819,7 +16852,7 @@ cn_statements: CN_INSTANTIATE UNAME VARIABLE COMMA CN_CONSTANT RPAREN
 
 cn_statements: CN_INSTANTIATE UNAME TYPE WHILE
 ##
-## Ends in an error in state: 1488.
+## Ends in an error in state: 1492.
 ##
 ## cn_statement -> CN_INSTANTIATE UNAME TYPE . COMMA expr SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ## prim_expr -> UNAME TYPE . [ STAR SLASH SEMICOLON QUESTION PLUS PIPE_PIPE PIPE PERCENT MINUS_GT MINUS LT_EQ LT LBRACK GT_EQ GT EQ_EQ DOT CN_IMPLIES CARET BANG_EQ AMPERSAND_AMPERSAND AMPERSAND ]
@@ -16834,7 +16867,7 @@ cn_statements: CN_INSTANTIATE UNAME TYPE WHILE
 
 cn_statements: CN_INSTANTIATE UNAME TYPE COMMA CN_CONSTANT RPAREN
 ##
-## Ends in an error in state: 1490.
+## Ends in an error in state: 1494.
 ##
 ## cn_statement -> CN_INSTANTIATE UNAME TYPE COMMA expr . SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -16861,7 +16894,7 @@ cn_statements: CN_INSTANTIATE UNAME TYPE COMMA CN_CONSTANT RPAREN
 
 cn_statements: CN_INSTANTIATE LNAME WHILE
 ##
-## Ends in an error in state: 1492.
+## Ends in an error in state: 1496.
 ##
 ## cn_statement -> CN_INSTANTIATE LNAME . VARIABLE COMMA expr SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ## cn_statement -> CN_INSTANTIATE LNAME . TYPE COMMA expr SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
@@ -16880,7 +16913,7 @@ cn_statements: CN_INSTANTIATE LNAME WHILE
 
 cn_statements: CN_INSTANTIATE LNAME VARIABLE WHILE
 ##
-## Ends in an error in state: 1493.
+## Ends in an error in state: 1497.
 ##
 ## cn_statement -> CN_INSTANTIATE LNAME VARIABLE . COMMA expr SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ## prim_expr -> LNAME VARIABLE . [ STAR SLASH SEMICOLON QUESTION PLUS PIPE_PIPE PIPE PERCENT MINUS_GT MINUS LT_EQ LT LBRACK GT_EQ GT EQ_EQ DOT CN_IMPLIES CARET BANG_EQ AMPERSAND_AMPERSAND AMPERSAND ]
@@ -16895,7 +16928,7 @@ cn_statements: CN_INSTANTIATE LNAME VARIABLE WHILE
 
 cn_statements: CN_INSTANTIATE LNAME VARIABLE COMMA CN_CONSTANT RPAREN
 ##
-## Ends in an error in state: 1495.
+## Ends in an error in state: 1499.
 ##
 ## cn_statement -> CN_INSTANTIATE LNAME VARIABLE COMMA expr . SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -16922,7 +16955,7 @@ cn_statements: CN_INSTANTIATE LNAME VARIABLE COMMA CN_CONSTANT RPAREN
 
 cn_statements: CN_INSTANTIATE LNAME TYPE WHILE
 ##
-## Ends in an error in state: 1497.
+## Ends in an error in state: 1501.
 ##
 ## cn_statement -> CN_INSTANTIATE LNAME TYPE . COMMA expr SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ## prim_expr -> LNAME TYPE . [ STAR SLASH SEMICOLON QUESTION PLUS PIPE_PIPE PIPE PERCENT MINUS_GT MINUS LT_EQ LT LBRACK GT_EQ GT EQ_EQ DOT CN_IMPLIES CARET BANG_EQ AMPERSAND_AMPERSAND AMPERSAND ]
@@ -16937,7 +16970,7 @@ cn_statements: CN_INSTANTIATE LNAME TYPE WHILE
 
 cn_statements: CN_INSTANTIATE LNAME TYPE COMMA CN_CONSTANT RPAREN
 ##
-## Ends in an error in state: 1499.
+## Ends in an error in state: 1503.
 ##
 ## cn_statement -> CN_INSTANTIATE LNAME TYPE COMMA expr . SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -16964,7 +16997,7 @@ cn_statements: CN_INSTANTIATE LNAME TYPE COMMA CN_CONSTANT RPAREN
 
 cn_statements: CN_INSTANTIATE CN_CONSTANT RPAREN
 ##
-## Ends in an error in state: 1501.
+## Ends in an error in state: 1505.
 ##
 ## cn_statement -> CN_INSTANTIATE expr . SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -16991,7 +17024,7 @@ cn_statements: CN_INSTANTIATE CN_CONSTANT RPAREN
 
 cn_statements: CN_INSTANTIATE CN_GOOD LT BOOL GT WHILE
 ##
-## Ends in an error in state: 1503.
+## Ends in an error in state: 1507.
 ##
 ## cn_statement -> CN_INSTANTIATE cn_good . COMMA expr SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ## prim_expr -> cn_good . LPAREN expr RPAREN [ STAR SLASH SEMICOLON QUESTION PLUS PIPE_PIPE PIPE PERCENT MINUS_GT MINUS LT_EQ LT LBRACK GT_EQ GT EQ_EQ DOT CN_IMPLIES CARET BANG_EQ AMPERSAND_AMPERSAND AMPERSAND ]
@@ -17004,7 +17037,7 @@ cn_statements: CN_INSTANTIATE CN_GOOD LT BOOL GT WHILE
 
 cn_statements: CN_INSTANTIATE CN_GOOD LT BOOL GT COMMA CN_CONSTANT RPAREN
 ##
-## Ends in an error in state: 1505.
+## Ends in an error in state: 1509.
 ##
 ## cn_statement -> CN_INSTANTIATE cn_good COMMA expr . SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -17031,7 +17064,7 @@ cn_statements: CN_INSTANTIATE CN_GOOD LT BOOL GT COMMA CN_CONSTANT RPAREN
 
 cn_statements: CN_HAVE CN_CONSTANT RPAREN
 ##
-## Ends in an error in state: 1508.
+## Ends in an error in state: 1512.
 ##
 ## cn_statement -> CN_HAVE assert_expr . SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -17051,14 +17084,14 @@ cn_statements: CN_HAVE CN_CONSTANT RPAREN
 ## In state 1114, spurious reduction of production bool_or_expr -> bool_implies_expr
 ## In state 1081, spurious reduction of production list_expr -> bool_or_expr
 ## In state 1076, spurious reduction of production expr_without_let -> list_expr
-## In state 1468, spurious reduction of production assert_expr -> expr_without_let
+## In state 1472, spurious reduction of production assert_expr -> expr_without_let
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 cn_statements: CN_FROM_BYTES CN_BLOCK COMMA
 ##
-## Ends in an error in state: 1511.
+## Ends in an error in state: 1515.
 ##
 ## cn_statement -> CN_FROM_BYTES pred . LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -17069,14 +17102,14 @@ cn_statements: CN_FROM_BYTES CN_BLOCK COMMA
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1394, spurious reduction of production pred -> CN_BLOCK
+## In state 1398, spurious reduction of production pred -> CN_BLOCK
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 cn_statements: CN_FROM_BYTES CN_BLOCK LPAREN CN_CONSTANT EOF
 ##
-## Ends in an error in state: 1513.
+## Ends in an error in state: 1517.
 ##
 ## cn_statement -> CN_FROM_BYTES pred LPAREN loption(separated_nonempty_list(COMMA,expr)) . RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -17105,7 +17138,7 @@ cn_statements: CN_FROM_BYTES CN_BLOCK LPAREN CN_CONSTANT EOF
 
 cn_statements: CN_EXTRACT WHILE
 ##
-## Ends in an error in state: 1516.
+## Ends in an error in state: 1520.
 ##
 ## cn_statement -> CN_EXTRACT . expr SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ## cn_statement -> CN_EXTRACT . pred COMMA expr SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
@@ -17118,7 +17151,7 @@ cn_statements: CN_EXTRACT WHILE
 
 cn_statements: CN_EXTRACT UNAME WHILE
 ##
-## Ends in an error in state: 1517.
+## Ends in an error in state: 1521.
 ##
 ## pred -> UNAME . VARIABLE [ COMMA ]
 ## prim_expr -> UNAME . VARIABLE [ STAR SLASH SEMICOLON QUESTION PLUS PIPE_PIPE PIPE PERCENT MINUS_GT MINUS LT_EQ LT LBRACK GT_EQ GT EQ_EQ DOT CN_IMPLIES CARET BANG_EQ AMPERSAND_AMPERSAND AMPERSAND ]
@@ -17136,7 +17169,7 @@ cn_statements: CN_EXTRACT UNAME WHILE
 
 cn_statements: CN_EXTRACT UNAME VARIABLE WHILE
 ##
-## Ends in an error in state: 1518.
+## Ends in an error in state: 1522.
 ##
 ## pred -> UNAME VARIABLE . [ COMMA ]
 ## prim_expr -> UNAME VARIABLE . [ STAR SLASH SEMICOLON QUESTION PLUS PIPE_PIPE PIPE PERCENT MINUS_GT MINUS LT_EQ LT LBRACK GT_EQ GT EQ_EQ DOT CN_IMPLIES CARET BANG_EQ AMPERSAND_AMPERSAND AMPERSAND ]
@@ -17151,7 +17184,7 @@ cn_statements: CN_EXTRACT UNAME VARIABLE WHILE
 
 cn_statements: CN_EXTRACT CN_BLOCK LPAREN
 ##
-## Ends in an error in state: 1519.
+## Ends in an error in state: 1523.
 ##
 ## cn_statement -> CN_EXTRACT pred . COMMA expr SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -17162,14 +17195,14 @@ cn_statements: CN_EXTRACT CN_BLOCK LPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1394, spurious reduction of production pred -> CN_BLOCK
+## In state 1398, spurious reduction of production pred -> CN_BLOCK
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 cn_statements: CN_EXTRACT CN_BLOCK COMMA CN_CONSTANT RPAREN
 ##
-## Ends in an error in state: 1521.
+## Ends in an error in state: 1525.
 ##
 ## cn_statement -> CN_EXTRACT pred COMMA expr . SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -17196,7 +17229,7 @@ cn_statements: CN_EXTRACT CN_BLOCK COMMA CN_CONSTANT RPAREN
 
 cn_statements: CN_EXTRACT CN_CONSTANT RPAREN
 ##
-## Ends in an error in state: 1523.
+## Ends in an error in state: 1527.
 ##
 ## cn_statement -> CN_EXTRACT expr . SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -17223,7 +17256,7 @@ cn_statements: CN_EXTRACT CN_CONSTANT RPAREN
 
 cn_statements: CN_APPLY WHILE
 ##
-## Ends in an error in state: 1525.
+## Ends in an error in state: 1529.
 ##
 ## cn_statement -> CN_APPLY . UNAME VARIABLE LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ## cn_statement -> CN_APPLY . LNAME VARIABLE LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
@@ -17238,7 +17271,7 @@ cn_statements: CN_APPLY WHILE
 
 cn_statements: CN_APPLY UNAME WHILE
 ##
-## Ends in an error in state: 1526.
+## Ends in an error in state: 1530.
 ##
 ## cn_statement -> CN_APPLY UNAME . VARIABLE LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ## cn_statement -> CN_APPLY UNAME . TYPE LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
@@ -17251,7 +17284,7 @@ cn_statements: CN_APPLY UNAME WHILE
 
 cn_statements: CN_APPLY UNAME VARIABLE LPAREN CN_CONSTANT EOF
 ##
-## Ends in an error in state: 1529.
+## Ends in an error in state: 1533.
 ##
 ## cn_statement -> CN_APPLY UNAME VARIABLE LPAREN loption(separated_nonempty_list(COMMA,expr)) . RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -17280,7 +17313,7 @@ cn_statements: CN_APPLY UNAME VARIABLE LPAREN CN_CONSTANT EOF
 
 cn_statements: CN_APPLY UNAME TYPE LPAREN CN_CONSTANT EOF
 ##
-## Ends in an error in state: 1534.
+## Ends in an error in state: 1538.
 ##
 ## cn_statement -> CN_APPLY UNAME TYPE LPAREN loption(separated_nonempty_list(COMMA,expr)) . RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -17309,7 +17342,7 @@ cn_statements: CN_APPLY UNAME TYPE LPAREN CN_CONSTANT EOF
 
 cn_statements: CN_APPLY LNAME WHILE
 ##
-## Ends in an error in state: 1537.
+## Ends in an error in state: 1541.
 ##
 ## cn_statement -> CN_APPLY LNAME . VARIABLE LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ## cn_statement -> CN_APPLY LNAME . TYPE LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
@@ -17322,7 +17355,7 @@ cn_statements: CN_APPLY LNAME WHILE
 
 cn_statements: CN_APPLY LNAME VARIABLE LPAREN CN_CONSTANT EOF
 ##
-## Ends in an error in state: 1540.
+## Ends in an error in state: 1544.
 ##
 ## cn_statement -> CN_APPLY LNAME VARIABLE LPAREN loption(separated_nonempty_list(COMMA,expr)) . RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -17351,7 +17384,7 @@ cn_statements: CN_APPLY LNAME VARIABLE LPAREN CN_CONSTANT EOF
 
 cn_statements: CN_APPLY LNAME TYPE LPAREN CN_CONSTANT EOF
 ##
-## Ends in an error in state: 1545.
+## Ends in an error in state: 1549.
 ##
 ## cn_statement -> CN_APPLY LNAME TYPE LPAREN loption(separated_nonempty_list(COMMA,expr)) . RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -17380,7 +17413,7 @@ cn_statements: CN_APPLY LNAME TYPE LPAREN CN_CONSTANT EOF
 
 cn_statements: ASSERT LPAREN CN_CONSTANT EOF
 ##
-## Ends in an error in state: 1550.
+## Ends in an error in state: 1554.
 ##
 ## cn_statement -> ASSERT LPAREN assert_expr . RPAREN SEMICOLON [ INLINE EOF CN_UNPACK CN_UNFOLD CN_TO_BYTES CN_SPLIT_CASE CN_PRINT CN_PACK CN_INSTANTIATE CN_HAVE CN_FROM_BYTES CN_EXTRACT CN_APPLY ASSERT ]
 ##
@@ -17400,14 +17433,14 @@ cn_statements: ASSERT LPAREN CN_CONSTANT EOF
 ## In state 1114, spurious reduction of production bool_or_expr -> bool_implies_expr
 ## In state 1081, spurious reduction of production list_expr -> bool_or_expr
 ## In state 1076, spurious reduction of production expr_without_let -> list_expr
-## In state 1468, spurious reduction of production assert_expr -> expr_without_let
+## In state 1472, spurious reduction of production assert_expr -> expr_without_let
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 cn_statements: INLINE SEMICOLON WHILE
 ##
-## Ends in an error in state: 1556.
+## Ends in an error in state: 1560.
 ##
 ## nonempty_list(cn_statement) -> cn_statement . [ EOF ]
 ## nonempty_list(cn_statement) -> cn_statement . nonempty_list(cn_statement) [ EOF ]
@@ -17420,7 +17453,7 @@ cn_statements: INLINE SEMICOLON WHILE
 
 cn_toplevel: CN_TYPE_SYNONYM WHILE
 ##
-## Ends in an error in state: 1559.
+## Ends in an error in state: 1563.
 ##
 ## cn_type_synonym -> CN_TYPE_SYNONYM . UNAME VARIABLE EQ opt_paren(base_type) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ## cn_type_synonym -> CN_TYPE_SYNONYM . LNAME VARIABLE EQ opt_paren(base_type) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
@@ -17435,7 +17468,7 @@ cn_toplevel: CN_TYPE_SYNONYM WHILE
 
 cn_toplevel: CN_TYPE_SYNONYM UNAME WHILE
 ##
-## Ends in an error in state: 1560.
+## Ends in an error in state: 1564.
 ##
 ## cn_type_synonym -> CN_TYPE_SYNONYM UNAME . VARIABLE EQ opt_paren(base_type) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ## cn_type_synonym -> CN_TYPE_SYNONYM UNAME . TYPE EQ opt_paren(base_type) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
@@ -17448,7 +17481,7 @@ cn_toplevel: CN_TYPE_SYNONYM UNAME WHILE
 
 cn_toplevel: CN_TYPE_SYNONYM LNAME WHILE
 ##
-## Ends in an error in state: 1571.
+## Ends in an error in state: 1575.
 ##
 ## cn_type_synonym -> CN_TYPE_SYNONYM LNAME . VARIABLE EQ opt_paren(base_type) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ## cn_type_synonym -> CN_TYPE_SYNONYM LNAME . TYPE EQ opt_paren(base_type) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
@@ -17461,7 +17494,7 @@ cn_toplevel: CN_TYPE_SYNONYM LNAME WHILE
 
 cn_toplevel: CN_SPEC WHILE
 ##
-## Ends in an error in state: 1578.
+## Ends in an error in state: 1582.
 ##
 ## cn_fun_spec -> CN_SPEC . UNAME VARIABLE LPAREN cn_args RPAREN SEMICOLON function_spec [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ## cn_fun_spec -> CN_SPEC . LNAME VARIABLE LPAREN cn_args RPAREN SEMICOLON function_spec [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
@@ -17476,7 +17509,7 @@ cn_toplevel: CN_SPEC WHILE
 
 cn_toplevel: CN_SPEC UNAME WHILE
 ##
-## Ends in an error in state: 1579.
+## Ends in an error in state: 1583.
 ##
 ## cn_fun_spec -> CN_SPEC UNAME . VARIABLE LPAREN cn_args RPAREN SEMICOLON function_spec [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ## cn_fun_spec -> CN_SPEC UNAME . TYPE LPAREN cn_args RPAREN SEMICOLON function_spec [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
@@ -17489,7 +17522,7 @@ cn_toplevel: CN_SPEC UNAME WHILE
 
 cn_toplevel: CN_SPEC UNAME VARIABLE LPAREN CN_ALLOC_ID LNAME TYPE RBRACE
 ##
-## Ends in an error in state: 1584.
+## Ends in an error in state: 1588.
 ##
 ## cn_fun_spec -> CN_SPEC UNAME VARIABLE LPAREN cn_args . RPAREN SEMICOLON function_spec [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -17501,15 +17534,15 @@ cn_toplevel: CN_SPEC UNAME VARIABLE LPAREN CN_ALLOC_ID LNAME TYPE RBRACE
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 997, spurious reduction of production separated_nonempty_list(COMMA,base_type_cn_variable) -> base_type LNAME TYPE
-## In state 1582, spurious reduction of production loption(separated_nonempty_list(COMMA,base_type_cn_variable)) -> separated_nonempty_list(COMMA,base_type_cn_variable)
-## In state 1583, spurious reduction of production cn_args -> loption(separated_nonempty_list(COMMA,base_type_cn_variable))
+## In state 1586, spurious reduction of production loption(separated_nonempty_list(COMMA,base_type_cn_variable)) -> separated_nonempty_list(COMMA,base_type_cn_variable)
+## In state 1587, spurious reduction of production cn_args -> loption(separated_nonempty_list(COMMA,base_type_cn_variable))
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 fundef_spec: CN_LIFT_FUNCTION WHILE
 ##
-## Ends in an error in state: 1590.
+## Ends in an error in state: 1594.
 ##
 ## accesses_or_function -> CN_LIFT_FUNCTION . UNAME VARIABLE SEMICOLON [ EOF CN_TYPE_SYNONYM CN_SPEC CN_REQUIRES CN_PREDICATE CN_LEMMA CN_FUNCTION CN_ENSURES CN_DATATYPE ]
 ## accesses_or_function -> CN_LIFT_FUNCTION . LNAME VARIABLE SEMICOLON [ EOF CN_TYPE_SYNONYM CN_SPEC CN_REQUIRES CN_PREDICATE CN_LEMMA CN_FUNCTION CN_ENSURES CN_DATATYPE ]
@@ -17524,7 +17557,7 @@ fundef_spec: CN_LIFT_FUNCTION WHILE
 
 fundef_spec: CN_LIFT_FUNCTION UNAME WHILE
 ##
-## Ends in an error in state: 1591.
+## Ends in an error in state: 1595.
 ##
 ## accesses_or_function -> CN_LIFT_FUNCTION UNAME . VARIABLE SEMICOLON [ EOF CN_TYPE_SYNONYM CN_SPEC CN_REQUIRES CN_PREDICATE CN_LEMMA CN_FUNCTION CN_ENSURES CN_DATATYPE ]
 ## accesses_or_function -> CN_LIFT_FUNCTION UNAME . TYPE SEMICOLON [ EOF CN_TYPE_SYNONYM CN_SPEC CN_REQUIRES CN_PREDICATE CN_LEMMA CN_FUNCTION CN_ENSURES CN_DATATYPE ]
@@ -17537,7 +17570,7 @@ fundef_spec: CN_LIFT_FUNCTION UNAME WHILE
 
 fundef_spec: CN_LIFT_FUNCTION LNAME WHILE
 ##
-## Ends in an error in state: 1596.
+## Ends in an error in state: 1600.
 ##
 ## accesses_or_function -> CN_LIFT_FUNCTION LNAME . VARIABLE SEMICOLON [ EOF CN_TYPE_SYNONYM CN_SPEC CN_REQUIRES CN_PREDICATE CN_LEMMA CN_FUNCTION CN_ENSURES CN_DATATYPE ]
 ## accesses_or_function -> CN_LIFT_FUNCTION LNAME . TYPE SEMICOLON [ EOF CN_TYPE_SYNONYM CN_SPEC CN_REQUIRES CN_PREDICATE CN_LEMMA CN_FUNCTION CN_ENSURES CN_DATATYPE ]
@@ -17550,7 +17583,7 @@ fundef_spec: CN_LIFT_FUNCTION LNAME WHILE
 
 fundef_spec: CN_ACCESSES UNAME TYPE RBRACK
 ##
-## Ends in an error in state: 1602.
+## Ends in an error in state: 1606.
 ##
 ## accesses -> CN_ACCESSES separated_nonempty_list(COMMA,cn_variable) . SEMICOLON [ EOF CN_TYPE_SYNONYM CN_SPEC CN_REQUIRES CN_PREDICATE CN_LEMMA CN_FUNCTION CN_ENSURES CN_DATATYPE CN_ACCESSES ]
 ##
@@ -17561,14 +17594,14 @@ fundef_spec: CN_ACCESSES UNAME TYPE RBRACK
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1381, spurious reduction of production separated_nonempty_list(COMMA,cn_variable) -> UNAME TYPE
+## In state 1378, spurious reduction of production separated_nonempty_list(COMMA,cn_variable) -> UNAME TYPE
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 fundef_spec: CN_REQUIRES CN_GHOST CN_ALLOC_ID LNAME TYPE RBRACE
 ##
-## Ends in an error in state: 1607.
+## Ends in an error in state: 1611.
 ##
 ## ghost_binders -> CN_GHOST cn_args . SEMICOLON [ UNAME TILDE STRUCT STAR SIZEOF RETURN OFFSETOF MINUS LPAREN LNAME LBRACK LBRACE IF DEFAULT CONSTANT CN_TRUE CN_TAKE CN_NULL CN_MEMBER_SHIFT CN_MATCH CN_LET CN_GOOD CN_FALSE CN_EACH CN_CONSTANT CN_ARRAY_SHIFT BANG AMPERSAND ]
 ##
@@ -17580,15 +17613,15 @@ fundef_spec: CN_REQUIRES CN_GHOST CN_ALLOC_ID LNAME TYPE RBRACE
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 997, spurious reduction of production separated_nonempty_list(COMMA,base_type_cn_variable) -> base_type LNAME TYPE
-## In state 1582, spurious reduction of production loption(separated_nonempty_list(COMMA,base_type_cn_variable)) -> separated_nonempty_list(COMMA,base_type_cn_variable)
-## In state 1583, spurious reduction of production cn_args -> loption(separated_nonempty_list(COMMA,base_type_cn_variable))
+## In state 1586, spurious reduction of production loption(separated_nonempty_list(COMMA,base_type_cn_variable)) -> separated_nonempty_list(COMMA,base_type_cn_variable)
+## In state 1587, spurious reduction of production cn_args -> loption(separated_nonempty_list(COMMA,base_type_cn_variable))
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 loop_spec: CN_INV CN_TAKE WHILE
 ##
-## Ends in an error in state: 1610.
+## Ends in an error in state: 1614.
 ##
 ## condition -> CN_TAKE . UNAME VARIABLE EQ resource SEMICOLON [ UNAME TILDE STRUCT STAR SIZEOF RETURN OFFSETOF MINUS LPAREN LNAME LBRACK LBRACE IF EOF DEFAULT CONSTANT CN_TYPE_SYNONYM CN_TRUE CN_TAKE CN_SPEC CN_PREDICATE CN_NULL CN_MEMBER_SHIFT CN_MATCH CN_LET CN_LEMMA CN_GOOD CN_FUNCTION CN_FALSE CN_ENSURES CN_EACH CN_DATATYPE CN_CONSTANT CN_ARRAY_SHIFT BANG AMPERSAND ]
 ## condition -> CN_TAKE . LNAME VARIABLE EQ resource SEMICOLON [ UNAME TILDE STRUCT STAR SIZEOF RETURN OFFSETOF MINUS LPAREN LNAME LBRACK LBRACE IF EOF DEFAULT CONSTANT CN_TYPE_SYNONYM CN_TRUE CN_TAKE CN_SPEC CN_PREDICATE CN_NULL CN_MEMBER_SHIFT CN_MATCH CN_LET CN_LEMMA CN_GOOD CN_FUNCTION CN_FALSE CN_ENSURES CN_EACH CN_DATATYPE CN_CONSTANT CN_ARRAY_SHIFT BANG AMPERSAND ]
@@ -17603,7 +17636,7 @@ loop_spec: CN_INV CN_TAKE WHILE
 
 loop_spec: CN_INV CN_TAKE UNAME WHILE
 ##
-## Ends in an error in state: 1611.
+## Ends in an error in state: 1615.
 ##
 ## condition -> CN_TAKE UNAME . VARIABLE EQ resource SEMICOLON [ UNAME TILDE STRUCT STAR SIZEOF RETURN OFFSETOF MINUS LPAREN LNAME LBRACK LBRACE IF EOF DEFAULT CONSTANT CN_TYPE_SYNONYM CN_TRUE CN_TAKE CN_SPEC CN_PREDICATE CN_NULL CN_MEMBER_SHIFT CN_MATCH CN_LET CN_LEMMA CN_GOOD CN_FUNCTION CN_FALSE CN_ENSURES CN_EACH CN_DATATYPE CN_CONSTANT CN_ARRAY_SHIFT BANG AMPERSAND ]
 ## condition -> CN_TAKE UNAME . TYPE EQ resource SEMICOLON [ UNAME TILDE STRUCT STAR SIZEOF RETURN OFFSETOF MINUS LPAREN LNAME LBRACK LBRACE IF EOF DEFAULT CONSTANT CN_TYPE_SYNONYM CN_TRUE CN_TAKE CN_SPEC CN_PREDICATE CN_NULL CN_MEMBER_SHIFT CN_MATCH CN_LET CN_LEMMA CN_GOOD CN_FUNCTION CN_FALSE CN_ENSURES CN_EACH CN_DATATYPE CN_CONSTANT CN_ARRAY_SHIFT BANG AMPERSAND ]
@@ -17616,7 +17649,7 @@ loop_spec: CN_INV CN_TAKE UNAME WHILE
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH WHILE
 ##
-## Ends in an error in state: 1614.
+## Ends in an error in state: 1618.
 ##
 ## resource -> CN_EACH . LPAREN base_type UNAME VARIABLE SEMICOLON expr RPAREN LBRACE pred LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN RBRACE [ SEMICOLON ]
 ## resource -> CN_EACH . LPAREN base_type LNAME VARIABLE SEMICOLON expr RPAREN LBRACE pred LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN RBRACE [ SEMICOLON ]
@@ -17631,7 +17664,7 @@ loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH WHILE
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN WHILE
 ##
-## Ends in an error in state: 1615.
+## Ends in an error in state: 1619.
 ##
 ## resource -> CN_EACH LPAREN . base_type UNAME VARIABLE SEMICOLON expr RPAREN LBRACE pred LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN RBRACE [ SEMICOLON ]
 ## resource -> CN_EACH LPAREN . base_type LNAME VARIABLE SEMICOLON expr RPAREN LBRACE pred LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN RBRACE [ SEMICOLON ]
@@ -17646,7 +17679,7 @@ loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN WHILE
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID WHILE
 ##
-## Ends in an error in state: 1616.
+## Ends in an error in state: 1620.
 ##
 ## resource -> CN_EACH LPAREN base_type . UNAME VARIABLE SEMICOLON expr RPAREN LBRACE pred LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN RBRACE [ SEMICOLON ]
 ## resource -> CN_EACH LPAREN base_type . LNAME VARIABLE SEMICOLON expr RPAREN LBRACE pred LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN RBRACE [ SEMICOLON ]
@@ -17661,7 +17694,7 @@ loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID WHILE
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID UNAME WHILE
 ##
-## Ends in an error in state: 1617.
+## Ends in an error in state: 1621.
 ##
 ## resource -> CN_EACH LPAREN base_type UNAME . VARIABLE SEMICOLON expr RPAREN LBRACE pred LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN RBRACE [ SEMICOLON ]
 ## resource -> CN_EACH LPAREN base_type UNAME . TYPE SEMICOLON expr RPAREN LBRACE pred LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN RBRACE [ SEMICOLON ]
@@ -17674,7 +17707,7 @@ loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID UNAME WHILE
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID UNAME VARIABLE SEMICOLON CN_CONSTANT EOF
 ##
-## Ends in an error in state: 1620.
+## Ends in an error in state: 1624.
 ##
 ## resource -> CN_EACH LPAREN base_type UNAME VARIABLE SEMICOLON expr . RPAREN LBRACE pred LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN RBRACE [ SEMICOLON ]
 ##
@@ -17701,7 +17734,7 @@ loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID UNAME VARIABL
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID UNAME VARIABLE SEMICOLON CN_CONSTANT RPAREN LBRACE CN_BLOCK COMMA
 ##
-## Ends in an error in state: 1623.
+## Ends in an error in state: 1627.
 ##
 ## resource -> CN_EACH LPAREN base_type UNAME VARIABLE SEMICOLON expr RPAREN LBRACE pred . LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN RBRACE [ SEMICOLON ]
 ##
@@ -17712,14 +17745,14 @@ loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID UNAME VARIABL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1394, spurious reduction of production pred -> CN_BLOCK
+## In state 1398, spurious reduction of production pred -> CN_BLOCK
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID UNAME VARIABLE SEMICOLON CN_CONSTANT RPAREN LBRACE CN_BLOCK LPAREN CN_CONSTANT EOF
 ##
-## Ends in an error in state: 1625.
+## Ends in an error in state: 1629.
 ##
 ## resource -> CN_EACH LPAREN base_type UNAME VARIABLE SEMICOLON expr RPAREN LBRACE pred LPAREN loption(separated_nonempty_list(COMMA,expr)) . RPAREN RBRACE [ SEMICOLON ]
 ##
@@ -17748,7 +17781,7 @@ loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID UNAME VARIABL
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID UNAME TYPE SEMICOLON CN_CONSTANT EOF
 ##
-## Ends in an error in state: 1630.
+## Ends in an error in state: 1634.
 ##
 ## resource -> CN_EACH LPAREN base_type UNAME TYPE SEMICOLON expr . RPAREN LBRACE pred LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN RBRACE [ SEMICOLON ]
 ##
@@ -17775,7 +17808,7 @@ loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID UNAME TYPE SE
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID UNAME TYPE SEMICOLON CN_CONSTANT RPAREN LBRACE CN_BLOCK COMMA
 ##
-## Ends in an error in state: 1633.
+## Ends in an error in state: 1637.
 ##
 ## resource -> CN_EACH LPAREN base_type UNAME TYPE SEMICOLON expr RPAREN LBRACE pred . LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN RBRACE [ SEMICOLON ]
 ##
@@ -17786,14 +17819,14 @@ loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID UNAME TYPE SE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1394, spurious reduction of production pred -> CN_BLOCK
+## In state 1398, spurious reduction of production pred -> CN_BLOCK
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID UNAME TYPE SEMICOLON CN_CONSTANT RPAREN LBRACE CN_BLOCK LPAREN CN_CONSTANT EOF
 ##
-## Ends in an error in state: 1635.
+## Ends in an error in state: 1639.
 ##
 ## resource -> CN_EACH LPAREN base_type UNAME TYPE SEMICOLON expr RPAREN LBRACE pred LPAREN loption(separated_nonempty_list(COMMA,expr)) . RPAREN RBRACE [ SEMICOLON ]
 ##
@@ -17822,7 +17855,7 @@ loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID UNAME TYPE SE
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID LNAME WHILE
 ##
-## Ends in an error in state: 1638.
+## Ends in an error in state: 1642.
 ##
 ## resource -> CN_EACH LPAREN base_type LNAME . VARIABLE SEMICOLON expr RPAREN LBRACE pred LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN RBRACE [ SEMICOLON ]
 ## resource -> CN_EACH LPAREN base_type LNAME . TYPE SEMICOLON expr RPAREN LBRACE pred LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN RBRACE [ SEMICOLON ]
@@ -17835,7 +17868,7 @@ loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID LNAME WHILE
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID LNAME VARIABLE SEMICOLON CN_CONSTANT EOF
 ##
-## Ends in an error in state: 1641.
+## Ends in an error in state: 1645.
 ##
 ## resource -> CN_EACH LPAREN base_type LNAME VARIABLE SEMICOLON expr . RPAREN LBRACE pred LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN RBRACE [ SEMICOLON ]
 ##
@@ -17862,7 +17895,7 @@ loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID LNAME VARIABL
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID LNAME VARIABLE SEMICOLON CN_CONSTANT RPAREN LBRACE CN_BLOCK COMMA
 ##
-## Ends in an error in state: 1644.
+## Ends in an error in state: 1648.
 ##
 ## resource -> CN_EACH LPAREN base_type LNAME VARIABLE SEMICOLON expr RPAREN LBRACE pred . LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN RBRACE [ SEMICOLON ]
 ##
@@ -17873,14 +17906,14 @@ loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID LNAME VARIABL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1394, spurious reduction of production pred -> CN_BLOCK
+## In state 1398, spurious reduction of production pred -> CN_BLOCK
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID LNAME VARIABLE SEMICOLON CN_CONSTANT RPAREN LBRACE CN_BLOCK LPAREN CN_CONSTANT EOF
 ##
-## Ends in an error in state: 1646.
+## Ends in an error in state: 1650.
 ##
 ## resource -> CN_EACH LPAREN base_type LNAME VARIABLE SEMICOLON expr RPAREN LBRACE pred LPAREN loption(separated_nonempty_list(COMMA,expr)) . RPAREN RBRACE [ SEMICOLON ]
 ##
@@ -17909,7 +17942,7 @@ loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID LNAME VARIABL
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID LNAME TYPE SEMICOLON CN_CONSTANT EOF
 ##
-## Ends in an error in state: 1651.
+## Ends in an error in state: 1655.
 ##
 ## resource -> CN_EACH LPAREN base_type LNAME TYPE SEMICOLON expr . RPAREN LBRACE pred LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN RBRACE [ SEMICOLON ]
 ##
@@ -17936,7 +17969,7 @@ loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID LNAME TYPE SE
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID LNAME TYPE SEMICOLON CN_CONSTANT RPAREN LBRACE CN_BLOCK COMMA
 ##
-## Ends in an error in state: 1654.
+## Ends in an error in state: 1658.
 ##
 ## resource -> CN_EACH LPAREN base_type LNAME TYPE SEMICOLON expr RPAREN LBRACE pred . LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN RBRACE [ SEMICOLON ]
 ##
@@ -17947,14 +17980,14 @@ loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID LNAME TYPE SE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1394, spurious reduction of production pred -> CN_BLOCK
+## In state 1398, spurious reduction of production pred -> CN_BLOCK
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID LNAME TYPE SEMICOLON CN_CONSTANT RPAREN LBRACE CN_BLOCK LPAREN CN_CONSTANT EOF
 ##
-## Ends in an error in state: 1656.
+## Ends in an error in state: 1660.
 ##
 ## resource -> CN_EACH LPAREN base_type LNAME TYPE SEMICOLON expr RPAREN LBRACE pred LPAREN loption(separated_nonempty_list(COMMA,expr)) . RPAREN RBRACE [ SEMICOLON ]
 ##
@@ -17983,7 +18016,7 @@ loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_EACH LPAREN CN_ALLOC_ID LNAME TYPE SE
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_BLOCK COMMA
 ##
-## Ends in an error in state: 1661.
+## Ends in an error in state: 1665.
 ##
 ## resource -> pred . LPAREN loption(separated_nonempty_list(COMMA,expr)) RPAREN [ SEMICOLON ]
 ##
@@ -17994,14 +18027,14 @@ loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_BLOCK COMMA
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1394, spurious reduction of production pred -> CN_BLOCK
+## In state 1398, spurious reduction of production pred -> CN_BLOCK
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_BLOCK LPAREN CN_CONSTANT EOF
 ##
-## Ends in an error in state: 1663.
+## Ends in an error in state: 1667.
 ##
 ## resource -> pred LPAREN loption(separated_nonempty_list(COMMA,expr)) . RPAREN [ SEMICOLON ]
 ##
@@ -18030,7 +18063,7 @@ loop_spec: CN_INV CN_TAKE LNAME TYPE EQ CN_BLOCK LPAREN CN_CONSTANT EOF
 
 loop_spec: CN_INV CN_TAKE LNAME WHILE
 ##
-## Ends in an error in state: 1669.
+## Ends in an error in state: 1673.
 ##
 ## condition -> CN_TAKE LNAME . VARIABLE EQ resource SEMICOLON [ UNAME TILDE STRUCT STAR SIZEOF RETURN OFFSETOF MINUS LPAREN LNAME LBRACK LBRACE IF EOF DEFAULT CONSTANT CN_TYPE_SYNONYM CN_TRUE CN_TAKE CN_SPEC CN_PREDICATE CN_NULL CN_MEMBER_SHIFT CN_MATCH CN_LET CN_LEMMA CN_GOOD CN_FUNCTION CN_FALSE CN_ENSURES CN_EACH CN_DATATYPE CN_CONSTANT CN_ARRAY_SHIFT BANG AMPERSAND ]
 ## condition -> CN_TAKE LNAME . TYPE EQ resource SEMICOLON [ UNAME TILDE STRUCT STAR SIZEOF RETURN OFFSETOF MINUS LPAREN LNAME LBRACK LBRACE IF EOF DEFAULT CONSTANT CN_TYPE_SYNONYM CN_TRUE CN_TAKE CN_SPEC CN_PREDICATE CN_NULL CN_MEMBER_SHIFT CN_MATCH CN_LET CN_LEMMA CN_GOOD CN_FUNCTION CN_FALSE CN_ENSURES CN_EACH CN_DATATYPE CN_CONSTANT CN_ARRAY_SHIFT BANG AMPERSAND ]
@@ -18043,7 +18076,7 @@ loop_spec: CN_INV CN_TAKE LNAME WHILE
 
 loop_spec: CN_INV CN_LET WHILE
 ##
-## Ends in an error in state: 1678.
+## Ends in an error in state: 1682.
 ##
 ## condition -> CN_LET . UNAME VARIABLE EQ expr SEMICOLON [ UNAME TILDE STRUCT STAR SIZEOF RETURN OFFSETOF MINUS LPAREN LNAME LBRACK LBRACE IF EOF DEFAULT CONSTANT CN_TYPE_SYNONYM CN_TRUE CN_TAKE CN_SPEC CN_PREDICATE CN_NULL CN_MEMBER_SHIFT CN_MATCH CN_LET CN_LEMMA CN_GOOD CN_FUNCTION CN_FALSE CN_ENSURES CN_EACH CN_DATATYPE CN_CONSTANT CN_ARRAY_SHIFT BANG AMPERSAND ]
 ## condition -> CN_LET . LNAME VARIABLE EQ expr SEMICOLON [ UNAME TILDE STRUCT STAR SIZEOF RETURN OFFSETOF MINUS LPAREN LNAME LBRACK LBRACE IF EOF DEFAULT CONSTANT CN_TYPE_SYNONYM CN_TRUE CN_TAKE CN_SPEC CN_PREDICATE CN_NULL CN_MEMBER_SHIFT CN_MATCH CN_LET CN_LEMMA CN_GOOD CN_FUNCTION CN_FALSE CN_ENSURES CN_EACH CN_DATATYPE CN_CONSTANT CN_ARRAY_SHIFT BANG AMPERSAND ]
@@ -18058,7 +18091,7 @@ loop_spec: CN_INV CN_LET WHILE
 
 loop_spec: CN_INV CN_LET UNAME WHILE
 ##
-## Ends in an error in state: 1679.
+## Ends in an error in state: 1683.
 ##
 ## condition -> CN_LET UNAME . VARIABLE EQ expr SEMICOLON [ UNAME TILDE STRUCT STAR SIZEOF RETURN OFFSETOF MINUS LPAREN LNAME LBRACK LBRACE IF EOF DEFAULT CONSTANT CN_TYPE_SYNONYM CN_TRUE CN_TAKE CN_SPEC CN_PREDICATE CN_NULL CN_MEMBER_SHIFT CN_MATCH CN_LET CN_LEMMA CN_GOOD CN_FUNCTION CN_FALSE CN_ENSURES CN_EACH CN_DATATYPE CN_CONSTANT CN_ARRAY_SHIFT BANG AMPERSAND ]
 ## condition -> CN_LET UNAME . TYPE EQ expr SEMICOLON [ UNAME TILDE STRUCT STAR SIZEOF RETURN OFFSETOF MINUS LPAREN LNAME LBRACK LBRACE IF EOF DEFAULT CONSTANT CN_TYPE_SYNONYM CN_TRUE CN_TAKE CN_SPEC CN_PREDICATE CN_NULL CN_MEMBER_SHIFT CN_MATCH CN_LET CN_LEMMA CN_GOOD CN_FUNCTION CN_FALSE CN_ENSURES CN_EACH CN_DATATYPE CN_CONSTANT CN_ARRAY_SHIFT BANG AMPERSAND ]
@@ -18071,7 +18104,7 @@ loop_spec: CN_INV CN_LET UNAME WHILE
 
 loop_spec: CN_INV CN_LET UNAME VARIABLE EQ CN_CONSTANT RPAREN
 ##
-## Ends in an error in state: 1682.
+## Ends in an error in state: 1686.
 ##
 ## condition -> CN_LET UNAME VARIABLE EQ expr . SEMICOLON [ UNAME TILDE STRUCT STAR SIZEOF RETURN OFFSETOF MINUS LPAREN LNAME LBRACK LBRACE IF EOF DEFAULT CONSTANT CN_TYPE_SYNONYM CN_TRUE CN_TAKE CN_SPEC CN_PREDICATE CN_NULL CN_MEMBER_SHIFT CN_MATCH CN_LET CN_LEMMA CN_GOOD CN_FUNCTION CN_FALSE CN_ENSURES CN_EACH CN_DATATYPE CN_CONSTANT CN_ARRAY_SHIFT BANG AMPERSAND ]
 ##
@@ -18098,7 +18131,7 @@ loop_spec: CN_INV CN_LET UNAME VARIABLE EQ CN_CONSTANT RPAREN
 
 loop_spec: CN_INV CN_LET UNAME TYPE EQ CN_CONSTANT RPAREN
 ##
-## Ends in an error in state: 1686.
+## Ends in an error in state: 1690.
 ##
 ## condition -> CN_LET UNAME TYPE EQ expr . SEMICOLON [ UNAME TILDE STRUCT STAR SIZEOF RETURN OFFSETOF MINUS LPAREN LNAME LBRACK LBRACE IF EOF DEFAULT CONSTANT CN_TYPE_SYNONYM CN_TRUE CN_TAKE CN_SPEC CN_PREDICATE CN_NULL CN_MEMBER_SHIFT CN_MATCH CN_LET CN_LEMMA CN_GOOD CN_FUNCTION CN_FALSE CN_ENSURES CN_EACH CN_DATATYPE CN_CONSTANT CN_ARRAY_SHIFT BANG AMPERSAND ]
 ##
@@ -18125,7 +18158,7 @@ loop_spec: CN_INV CN_LET UNAME TYPE EQ CN_CONSTANT RPAREN
 
 loop_spec: CN_INV CN_LET LNAME WHILE
 ##
-## Ends in an error in state: 1688.
+## Ends in an error in state: 1692.
 ##
 ## condition -> CN_LET LNAME . VARIABLE EQ expr SEMICOLON [ UNAME TILDE STRUCT STAR SIZEOF RETURN OFFSETOF MINUS LPAREN LNAME LBRACK LBRACE IF EOF DEFAULT CONSTANT CN_TYPE_SYNONYM CN_TRUE CN_TAKE CN_SPEC CN_PREDICATE CN_NULL CN_MEMBER_SHIFT CN_MATCH CN_LET CN_LEMMA CN_GOOD CN_FUNCTION CN_FALSE CN_ENSURES CN_EACH CN_DATATYPE CN_CONSTANT CN_ARRAY_SHIFT BANG AMPERSAND ]
 ## condition -> CN_LET LNAME . TYPE EQ expr SEMICOLON [ UNAME TILDE STRUCT STAR SIZEOF RETURN OFFSETOF MINUS LPAREN LNAME LBRACK LBRACE IF EOF DEFAULT CONSTANT CN_TYPE_SYNONYM CN_TRUE CN_TAKE CN_SPEC CN_PREDICATE CN_NULL CN_MEMBER_SHIFT CN_MATCH CN_LET CN_LEMMA CN_GOOD CN_FUNCTION CN_FALSE CN_ENSURES CN_EACH CN_DATATYPE CN_CONSTANT CN_ARRAY_SHIFT BANG AMPERSAND ]
@@ -18138,7 +18171,7 @@ loop_spec: CN_INV CN_LET LNAME WHILE
 
 loop_spec: CN_INV CN_LET LNAME VARIABLE EQ CN_CONSTANT RPAREN
 ##
-## Ends in an error in state: 1691.
+## Ends in an error in state: 1695.
 ##
 ## condition -> CN_LET LNAME VARIABLE EQ expr . SEMICOLON [ UNAME TILDE STRUCT STAR SIZEOF RETURN OFFSETOF MINUS LPAREN LNAME LBRACK LBRACE IF EOF DEFAULT CONSTANT CN_TYPE_SYNONYM CN_TRUE CN_TAKE CN_SPEC CN_PREDICATE CN_NULL CN_MEMBER_SHIFT CN_MATCH CN_LET CN_LEMMA CN_GOOD CN_FUNCTION CN_FALSE CN_ENSURES CN_EACH CN_DATATYPE CN_CONSTANT CN_ARRAY_SHIFT BANG AMPERSAND ]
 ##
@@ -18165,7 +18198,7 @@ loop_spec: CN_INV CN_LET LNAME VARIABLE EQ CN_CONSTANT RPAREN
 
 loop_spec: CN_INV CN_LET LNAME TYPE EQ CN_CONSTANT RPAREN
 ##
-## Ends in an error in state: 1695.
+## Ends in an error in state: 1699.
 ##
 ## condition -> CN_LET LNAME TYPE EQ expr . SEMICOLON [ UNAME TILDE STRUCT STAR SIZEOF RETURN OFFSETOF MINUS LPAREN LNAME LBRACK LBRACE IF EOF DEFAULT CONSTANT CN_TYPE_SYNONYM CN_TRUE CN_TAKE CN_SPEC CN_PREDICATE CN_NULL CN_MEMBER_SHIFT CN_MATCH CN_LET CN_LEMMA CN_GOOD CN_FUNCTION CN_FALSE CN_ENSURES CN_EACH CN_DATATYPE CN_CONSTANT CN_ARRAY_SHIFT BANG AMPERSAND ]
 ##
@@ -18192,7 +18225,7 @@ loop_spec: CN_INV CN_LET LNAME TYPE EQ CN_CONSTANT RPAREN
 
 loop_spec: CN_INV CN_CONSTANT SEMICOLON WHILE
 ##
-## Ends in an error in state: 1698.
+## Ends in an error in state: 1702.
 ##
 ## nonempty_list(condition) -> condition . [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_ENSURES CN_DATATYPE ]
 ## nonempty_list(condition) -> condition . nonempty_list(condition) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_ENSURES CN_DATATYPE ]
@@ -18205,7 +18238,7 @@ loop_spec: CN_INV CN_CONSTANT SEMICOLON WHILE
 
 loop_spec: CN_INV CN_CONSTANT RPAREN
 ##
-## Ends in an error in state: 1700.
+## Ends in an error in state: 1704.
 ##
 ## condition -> assert_expr . SEMICOLON [ UNAME TILDE STRUCT STAR SIZEOF RETURN OFFSETOF MINUS LPAREN LNAME LBRACK LBRACE IF EOF DEFAULT CONSTANT CN_TYPE_SYNONYM CN_TRUE CN_TAKE CN_SPEC CN_PREDICATE CN_NULL CN_MEMBER_SHIFT CN_MATCH CN_LET CN_LEMMA CN_GOOD CN_FUNCTION CN_FALSE CN_ENSURES CN_EACH CN_DATATYPE CN_CONSTANT CN_ARRAY_SHIFT BANG AMPERSAND ]
 ##
@@ -18225,14 +18258,14 @@ loop_spec: CN_INV CN_CONSTANT RPAREN
 ## In state 1114, spurious reduction of production bool_or_expr -> bool_implies_expr
 ## In state 1081, spurious reduction of production list_expr -> bool_or_expr
 ## In state 1076, spurious reduction of production expr_without_let -> list_expr
-## In state 1468, spurious reduction of production assert_expr -> expr_without_let
+## In state 1472, spurious reduction of production assert_expr -> expr_without_let
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 cn_toplevel: CN_SPEC UNAME TYPE LPAREN CN_ALLOC_ID LNAME TYPE RBRACE
 ##
-## Ends in an error in state: 1717.
+## Ends in an error in state: 1721.
 ##
 ## cn_fun_spec -> CN_SPEC UNAME TYPE LPAREN cn_args . RPAREN SEMICOLON function_spec [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -18244,15 +18277,15 @@ cn_toplevel: CN_SPEC UNAME TYPE LPAREN CN_ALLOC_ID LNAME TYPE RBRACE
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 997, spurious reduction of production separated_nonempty_list(COMMA,base_type_cn_variable) -> base_type LNAME TYPE
-## In state 1582, spurious reduction of production loption(separated_nonempty_list(COMMA,base_type_cn_variable)) -> separated_nonempty_list(COMMA,base_type_cn_variable)
-## In state 1583, spurious reduction of production cn_args -> loption(separated_nonempty_list(COMMA,base_type_cn_variable))
+## In state 1586, spurious reduction of production loption(separated_nonempty_list(COMMA,base_type_cn_variable)) -> separated_nonempty_list(COMMA,base_type_cn_variable)
+## In state 1587, spurious reduction of production cn_args -> loption(separated_nonempty_list(COMMA,base_type_cn_variable))
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 cn_toplevel: CN_SPEC LNAME WHILE
 ##
-## Ends in an error in state: 1721.
+## Ends in an error in state: 1725.
 ##
 ## cn_fun_spec -> CN_SPEC LNAME . VARIABLE LPAREN cn_args RPAREN SEMICOLON function_spec [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ## cn_fun_spec -> CN_SPEC LNAME . TYPE LPAREN cn_args RPAREN SEMICOLON function_spec [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
@@ -18265,7 +18298,7 @@ cn_toplevel: CN_SPEC LNAME WHILE
 
 cn_toplevel: CN_SPEC LNAME VARIABLE LPAREN CN_ALLOC_ID LNAME TYPE RBRACE
 ##
-## Ends in an error in state: 1724.
+## Ends in an error in state: 1728.
 ##
 ## cn_fun_spec -> CN_SPEC LNAME VARIABLE LPAREN cn_args . RPAREN SEMICOLON function_spec [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -18277,15 +18310,15 @@ cn_toplevel: CN_SPEC LNAME VARIABLE LPAREN CN_ALLOC_ID LNAME TYPE RBRACE
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 997, spurious reduction of production separated_nonempty_list(COMMA,base_type_cn_variable) -> base_type LNAME TYPE
-## In state 1582, spurious reduction of production loption(separated_nonempty_list(COMMA,base_type_cn_variable)) -> separated_nonempty_list(COMMA,base_type_cn_variable)
-## In state 1583, spurious reduction of production cn_args -> loption(separated_nonempty_list(COMMA,base_type_cn_variable))
+## In state 1586, spurious reduction of production loption(separated_nonempty_list(COMMA,base_type_cn_variable)) -> separated_nonempty_list(COMMA,base_type_cn_variable)
+## In state 1587, spurious reduction of production cn_args -> loption(separated_nonempty_list(COMMA,base_type_cn_variable))
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 cn_toplevel: CN_SPEC LNAME TYPE LPAREN CN_ALLOC_ID LNAME TYPE RBRACE
 ##
-## Ends in an error in state: 1730.
+## Ends in an error in state: 1734.
 ##
 ## cn_fun_spec -> CN_SPEC LNAME TYPE LPAREN cn_args . RPAREN SEMICOLON function_spec [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -18297,15 +18330,15 @@ cn_toplevel: CN_SPEC LNAME TYPE LPAREN CN_ALLOC_ID LNAME TYPE RBRACE
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 997, spurious reduction of production separated_nonempty_list(COMMA,base_type_cn_variable) -> base_type LNAME TYPE
-## In state 1582, spurious reduction of production loption(separated_nonempty_list(COMMA,base_type_cn_variable)) -> separated_nonempty_list(COMMA,base_type_cn_variable)
-## In state 1583, spurious reduction of production cn_args -> loption(separated_nonempty_list(COMMA,base_type_cn_variable))
+## In state 1586, spurious reduction of production loption(separated_nonempty_list(COMMA,base_type_cn_variable)) -> separated_nonempty_list(COMMA,base_type_cn_variable)
+## In state 1587, spurious reduction of production cn_args -> loption(separated_nonempty_list(COMMA,base_type_cn_variable))
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 cn_toplevel: CN_FUNCTION LBRACK UNAME TYPE SEMICOLON
 ##
-## Ends in an error in state: 1736.
+## Ends in an error in state: 1740.
 ##
 ## cn_attrs -> LBRACK loption(separated_nonempty_list(COMMA,cn_variable)) . RBRACK [ VOID UNAME STRUCT LPAREN LNAME LBRACE CN_TUPLE CN_SET CN_REAL CN_POINTER CN_MAP CN_LIST CN_INTEGER CN_DATATYPE CN_BOOL CN_BITS CN_ALLOC_ID ]
 ##
@@ -18316,15 +18349,15 @@ cn_toplevel: CN_FUNCTION LBRACK UNAME TYPE SEMICOLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1381, spurious reduction of production separated_nonempty_list(COMMA,cn_variable) -> UNAME TYPE
-## In state 1384, spurious reduction of production loption(separated_nonempty_list(COMMA,cn_variable)) -> separated_nonempty_list(COMMA,cn_variable)
+## In state 1378, spurious reduction of production separated_nonempty_list(COMMA,cn_variable) -> UNAME TYPE
+## In state 1381, spurious reduction of production loption(separated_nonempty_list(COMMA,cn_variable)) -> separated_nonempty_list(COMMA,cn_variable)
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN CN_ALLOC_ID LNAME TYPE RBRACE
 ##
-## Ends in an error in state: 1744.
+## Ends in an error in state: 1748.
 ##
 ## cn_predicate -> CN_PREDICATE cn_attrs cn_pred_output UNAME VARIABLE LPAREN cn_args . RPAREN cn_option_pred_clauses [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -18336,15 +18369,15 @@ cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN CN_ALLOC_ID LNAME TY
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 997, spurious reduction of production separated_nonempty_list(COMMA,base_type_cn_variable) -> base_type LNAME TYPE
-## In state 1582, spurious reduction of production loption(separated_nonempty_list(COMMA,base_type_cn_variable)) -> separated_nonempty_list(COMMA,base_type_cn_variable)
-## In state 1583, spurious reduction of production cn_args -> loption(separated_nonempty_list(COMMA,base_type_cn_variable))
+## In state 1586, spurious reduction of production loption(separated_nonempty_list(COMMA,base_type_cn_variable)) -> separated_nonempty_list(COMMA,base_type_cn_variable)
+## In state 1587, spurious reduction of production cn_args -> loption(separated_nonempty_list(COMMA,base_type_cn_variable))
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE RETURN WHILE
 ##
-## Ends in an error in state: 1747.
+## Ends in an error in state: 1751.
 ##
 ## clause -> RETURN . expr [ SEMICOLON ]
 ## clause -> RETURN . [ SEMICOLON ]
@@ -18357,7 +18390,7 @@ cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE RETURN
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE IF LPAREN CN_CONSTANT EOF
 ##
-## Ends in an error in state: 1752.
+## Ends in an error in state: 1756.
 ##
 ## if_clauses -> IF LPAREN expr . RPAREN LBRACE clause SEMICOLON RBRACE ELSE if_clauses [ RBRACE ]
 ##
@@ -18384,7 +18417,7 @@ cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE IF LPA
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_TAKE WHILE
 ##
-## Ends in an error in state: 1755.
+## Ends in an error in state: 1759.
 ##
 ## clause -> CN_TAKE . UNAME VARIABLE EQ resource SEMICOLON clause [ SEMICOLON ]
 ## clause -> CN_TAKE . LNAME VARIABLE EQ resource SEMICOLON clause [ SEMICOLON ]
@@ -18399,7 +18432,7 @@ cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_TAK
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_TAKE UNAME WHILE
 ##
-## Ends in an error in state: 1756.
+## Ends in an error in state: 1760.
 ##
 ## clause -> CN_TAKE UNAME . VARIABLE EQ resource SEMICOLON clause [ SEMICOLON ]
 ## clause -> CN_TAKE UNAME . TYPE EQ resource SEMICOLON clause [ SEMICOLON ]
@@ -18412,7 +18445,7 @@ cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_TAK
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_LET WHILE
 ##
-## Ends in an error in state: 1761.
+## Ends in an error in state: 1765.
 ##
 ## clause -> CN_LET . UNAME VARIABLE EQ expr SEMICOLON clause [ SEMICOLON ]
 ## clause -> CN_LET . LNAME VARIABLE EQ expr SEMICOLON clause [ SEMICOLON ]
@@ -18427,7 +18460,7 @@ cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_LET
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_LET UNAME WHILE
 ##
-## Ends in an error in state: 1762.
+## Ends in an error in state: 1766.
 ##
 ## clause -> CN_LET UNAME . VARIABLE EQ expr SEMICOLON clause [ SEMICOLON ]
 ## clause -> CN_LET UNAME . TYPE EQ expr SEMICOLON clause [ SEMICOLON ]
@@ -18440,7 +18473,7 @@ cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_LET
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_LET UNAME VARIABLE EQ CN_CONSTANT RPAREN
 ##
-## Ends in an error in state: 1765.
+## Ends in an error in state: 1769.
 ##
 ## clause -> CN_LET UNAME VARIABLE EQ expr . SEMICOLON clause [ SEMICOLON ]
 ##
@@ -18467,7 +18500,7 @@ cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_LET
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE ASSERT LPAREN CN_CONSTANT EOF
 ##
-## Ends in an error in state: 1769.
+## Ends in an error in state: 1773.
 ##
 ## clause -> ASSERT LPAREN assert_expr . RPAREN SEMICOLON clause [ SEMICOLON ]
 ##
@@ -18487,14 +18520,14 @@ cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE ASSERT
 ## In state 1114, spurious reduction of production bool_or_expr -> bool_implies_expr
 ## In state 1081, spurious reduction of production list_expr -> bool_or_expr
 ## In state 1076, spurious reduction of production expr_without_let -> list_expr
-## In state 1468, spurious reduction of production assert_expr -> expr_without_let
+## In state 1472, spurious reduction of production assert_expr -> expr_without_let
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_LET UNAME TYPE EQ CN_CONSTANT RPAREN
 ##
-## Ends in an error in state: 1776.
+## Ends in an error in state: 1780.
 ##
 ## clause -> CN_LET UNAME TYPE EQ expr . SEMICOLON clause [ SEMICOLON ]
 ##
@@ -18521,7 +18554,7 @@ cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_LET
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_LET LNAME WHILE
 ##
-## Ends in an error in state: 1779.
+## Ends in an error in state: 1783.
 ##
 ## clause -> CN_LET LNAME . VARIABLE EQ expr SEMICOLON clause [ SEMICOLON ]
 ## clause -> CN_LET LNAME . TYPE EQ expr SEMICOLON clause [ SEMICOLON ]
@@ -18534,7 +18567,7 @@ cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_LET
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_LET LNAME VARIABLE EQ CN_CONSTANT RPAREN
 ##
-## Ends in an error in state: 1782.
+## Ends in an error in state: 1786.
 ##
 ## clause -> CN_LET LNAME VARIABLE EQ expr . SEMICOLON clause [ SEMICOLON ]
 ##
@@ -18561,7 +18594,7 @@ cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_LET
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_LET LNAME TYPE EQ CN_CONSTANT RPAREN
 ##
-## Ends in an error in state: 1787.
+## Ends in an error in state: 1791.
 ##
 ## clause -> CN_LET LNAME TYPE EQ expr . SEMICOLON clause [ SEMICOLON ]
 ##
@@ -18588,7 +18621,7 @@ cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_LET
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_TAKE LNAME WHILE
 ##
-## Ends in an error in state: 1796.
+## Ends in an error in state: 1800.
 ##
 ## clause -> CN_TAKE LNAME . VARIABLE EQ resource SEMICOLON clause [ SEMICOLON ]
 ## clause -> CN_TAKE LNAME . TYPE EQ resource SEMICOLON clause [ SEMICOLON ]
@@ -18601,7 +18634,7 @@ cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE CN_TAK
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE IF LPAREN CN_CONSTANT RPAREN LBRACE RETURN CN_CONSTANT RPAREN
 ##
-## Ends in an error in state: 1807.
+## Ends in an error in state: 1811.
 ##
 ## if_clauses -> IF LPAREN expr RPAREN LBRACE clause . SEMICOLON RBRACE ELSE if_clauses [ RBRACE ]
 ##
@@ -18622,14 +18655,14 @@ cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE IF LPA
 ## In state 1081, spurious reduction of production list_expr -> bool_or_expr
 ## In state 1076, spurious reduction of production expr_without_let -> list_expr
 ## In state 1115, spurious reduction of production expr -> expr_without_let
-## In state 1748, spurious reduction of production clause -> RETURN expr
+## In state 1752, spurious reduction of production clause -> RETURN expr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE RETURN CN_CONSTANT RPAREN
 ##
-## Ends in an error in state: 1815.
+## Ends in an error in state: 1819.
 ##
 ## clauses -> clause . SEMICOLON [ RBRACE ]
 ##
@@ -18650,14 +18683,14 @@ cn_toplevel: CN_PREDICATE CN_ALLOC_ID UNAME VARIABLE LPAREN RPAREN LBRACE RETURN
 ## In state 1081, spurious reduction of production list_expr -> bool_or_expr
 ## In state 1076, spurious reduction of production expr_without_let -> list_expr
 ## In state 1115, spurious reduction of production expr -> expr_without_let
-## In state 1748, spurious reduction of production clause -> RETURN expr
+## In state 1752, spurious reduction of production clause -> RETURN expr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 cn_toplevel: CN_LEMMA WHILE
 ##
-## Ends in an error in state: 1820.
+## Ends in an error in state: 1824.
 ##
 ## cn_lemma -> CN_LEMMA . UNAME VARIABLE LPAREN cn_args RPAREN CN_REQUIRES nonempty_list(condition) CN_ENSURES nonempty_list(condition) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ## cn_lemma -> CN_LEMMA . LNAME VARIABLE LPAREN cn_args RPAREN CN_REQUIRES nonempty_list(condition) CN_ENSURES nonempty_list(condition) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
@@ -18672,7 +18705,7 @@ cn_toplevel: CN_LEMMA WHILE
 
 cn_toplevel: CN_LEMMA UNAME WHILE
 ##
-## Ends in an error in state: 1821.
+## Ends in an error in state: 1825.
 ##
 ## cn_lemma -> CN_LEMMA UNAME . VARIABLE LPAREN cn_args RPAREN CN_REQUIRES nonempty_list(condition) CN_ENSURES nonempty_list(condition) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ## cn_lemma -> CN_LEMMA UNAME . TYPE LPAREN cn_args RPAREN CN_REQUIRES nonempty_list(condition) CN_ENSURES nonempty_list(condition) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
@@ -18685,7 +18718,7 @@ cn_toplevel: CN_LEMMA UNAME WHILE
 
 cn_toplevel: CN_LEMMA UNAME VARIABLE LPAREN CN_ALLOC_ID LNAME TYPE RBRACE
 ##
-## Ends in an error in state: 1824.
+## Ends in an error in state: 1828.
 ##
 ## cn_lemma -> CN_LEMMA UNAME VARIABLE LPAREN cn_args . RPAREN CN_REQUIRES nonempty_list(condition) CN_ENSURES nonempty_list(condition) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -18697,15 +18730,15 @@ cn_toplevel: CN_LEMMA UNAME VARIABLE LPAREN CN_ALLOC_ID LNAME TYPE RBRACE
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 997, spurious reduction of production separated_nonempty_list(COMMA,base_type_cn_variable) -> base_type LNAME TYPE
-## In state 1582, spurious reduction of production loption(separated_nonempty_list(COMMA,base_type_cn_variable)) -> separated_nonempty_list(COMMA,base_type_cn_variable)
-## In state 1583, spurious reduction of production cn_args -> loption(separated_nonempty_list(COMMA,base_type_cn_variable))
+## In state 1586, spurious reduction of production loption(separated_nonempty_list(COMMA,base_type_cn_variable)) -> separated_nonempty_list(COMMA,base_type_cn_variable)
+## In state 1587, spurious reduction of production cn_args -> loption(separated_nonempty_list(COMMA,base_type_cn_variable))
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 cn_toplevel: CN_LEMMA UNAME VARIABLE LPAREN RPAREN CN_REQUIRES CN_CONSTANT SEMICOLON EOF
 ##
-## Ends in an error in state: 1827.
+## Ends in an error in state: 1831.
 ##
 ## cn_lemma -> CN_LEMMA UNAME VARIABLE LPAREN cn_args RPAREN CN_REQUIRES nonempty_list(condition) . CN_ENSURES nonempty_list(condition) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -18716,14 +18749,14 @@ cn_toplevel: CN_LEMMA UNAME VARIABLE LPAREN RPAREN CN_REQUIRES CN_CONSTANT SEMIC
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1698, spurious reduction of production nonempty_list(condition) -> condition
+## In state 1702, spurious reduction of production nonempty_list(condition) -> condition
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 cn_toplevel: CN_LEMMA UNAME TYPE LPAREN CN_ALLOC_ID LNAME TYPE RBRACE
 ##
-## Ends in an error in state: 1832.
+## Ends in an error in state: 1836.
 ##
 ## cn_lemma -> CN_LEMMA UNAME TYPE LPAREN cn_args . RPAREN CN_REQUIRES nonempty_list(condition) CN_ENSURES nonempty_list(condition) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -18735,15 +18768,15 @@ cn_toplevel: CN_LEMMA UNAME TYPE LPAREN CN_ALLOC_ID LNAME TYPE RBRACE
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 997, spurious reduction of production separated_nonempty_list(COMMA,base_type_cn_variable) -> base_type LNAME TYPE
-## In state 1582, spurious reduction of production loption(separated_nonempty_list(COMMA,base_type_cn_variable)) -> separated_nonempty_list(COMMA,base_type_cn_variable)
-## In state 1583, spurious reduction of production cn_args -> loption(separated_nonempty_list(COMMA,base_type_cn_variable))
+## In state 1586, spurious reduction of production loption(separated_nonempty_list(COMMA,base_type_cn_variable)) -> separated_nonempty_list(COMMA,base_type_cn_variable)
+## In state 1587, spurious reduction of production cn_args -> loption(separated_nonempty_list(COMMA,base_type_cn_variable))
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 cn_toplevel: CN_LEMMA UNAME TYPE LPAREN RPAREN CN_REQUIRES CN_CONSTANT SEMICOLON EOF
 ##
-## Ends in an error in state: 1835.
+## Ends in an error in state: 1839.
 ##
 ## cn_lemma -> CN_LEMMA UNAME TYPE LPAREN cn_args RPAREN CN_REQUIRES nonempty_list(condition) . CN_ENSURES nonempty_list(condition) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -18754,14 +18787,14 @@ cn_toplevel: CN_LEMMA UNAME TYPE LPAREN RPAREN CN_REQUIRES CN_CONSTANT SEMICOLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1698, spurious reduction of production nonempty_list(condition) -> condition
+## In state 1702, spurious reduction of production nonempty_list(condition) -> condition
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 cn_toplevel: CN_LEMMA LNAME WHILE
 ##
-## Ends in an error in state: 1838.
+## Ends in an error in state: 1842.
 ##
 ## cn_lemma -> CN_LEMMA LNAME . VARIABLE LPAREN cn_args RPAREN CN_REQUIRES nonempty_list(condition) CN_ENSURES nonempty_list(condition) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ## cn_lemma -> CN_LEMMA LNAME . TYPE LPAREN cn_args RPAREN CN_REQUIRES nonempty_list(condition) CN_ENSURES nonempty_list(condition) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
@@ -18774,7 +18807,7 @@ cn_toplevel: CN_LEMMA LNAME WHILE
 
 cn_toplevel: CN_LEMMA LNAME VARIABLE LPAREN CN_ALLOC_ID LNAME TYPE RBRACE
 ##
-## Ends in an error in state: 1841.
+## Ends in an error in state: 1845.
 ##
 ## cn_lemma -> CN_LEMMA LNAME VARIABLE LPAREN cn_args . RPAREN CN_REQUIRES nonempty_list(condition) CN_ENSURES nonempty_list(condition) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -18786,15 +18819,15 @@ cn_toplevel: CN_LEMMA LNAME VARIABLE LPAREN CN_ALLOC_ID LNAME TYPE RBRACE
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 997, spurious reduction of production separated_nonempty_list(COMMA,base_type_cn_variable) -> base_type LNAME TYPE
-## In state 1582, spurious reduction of production loption(separated_nonempty_list(COMMA,base_type_cn_variable)) -> separated_nonempty_list(COMMA,base_type_cn_variable)
-## In state 1583, spurious reduction of production cn_args -> loption(separated_nonempty_list(COMMA,base_type_cn_variable))
+## In state 1586, spurious reduction of production loption(separated_nonempty_list(COMMA,base_type_cn_variable)) -> separated_nonempty_list(COMMA,base_type_cn_variable)
+## In state 1587, spurious reduction of production cn_args -> loption(separated_nonempty_list(COMMA,base_type_cn_variable))
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 cn_toplevel: CN_LEMMA LNAME VARIABLE LPAREN RPAREN CN_REQUIRES CN_CONSTANT SEMICOLON EOF
 ##
-## Ends in an error in state: 1844.
+## Ends in an error in state: 1848.
 ##
 ## cn_lemma -> CN_LEMMA LNAME VARIABLE LPAREN cn_args RPAREN CN_REQUIRES nonempty_list(condition) . CN_ENSURES nonempty_list(condition) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -18805,14 +18838,14 @@ cn_toplevel: CN_LEMMA LNAME VARIABLE LPAREN RPAREN CN_REQUIRES CN_CONSTANT SEMIC
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1698, spurious reduction of production nonempty_list(condition) -> condition
+## In state 1702, spurious reduction of production nonempty_list(condition) -> condition
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 cn_toplevel: CN_LEMMA LNAME TYPE LPAREN CN_ALLOC_ID LNAME TYPE RBRACE
 ##
-## Ends in an error in state: 1849.
+## Ends in an error in state: 1853.
 ##
 ## cn_lemma -> CN_LEMMA LNAME TYPE LPAREN cn_args . RPAREN CN_REQUIRES nonempty_list(condition) CN_ENSURES nonempty_list(condition) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -18824,15 +18857,15 @@ cn_toplevel: CN_LEMMA LNAME TYPE LPAREN CN_ALLOC_ID LNAME TYPE RBRACE
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 997, spurious reduction of production separated_nonempty_list(COMMA,base_type_cn_variable) -> base_type LNAME TYPE
-## In state 1582, spurious reduction of production loption(separated_nonempty_list(COMMA,base_type_cn_variable)) -> separated_nonempty_list(COMMA,base_type_cn_variable)
-## In state 1583, spurious reduction of production cn_args -> loption(separated_nonempty_list(COMMA,base_type_cn_variable))
+## In state 1586, spurious reduction of production loption(separated_nonempty_list(COMMA,base_type_cn_variable)) -> separated_nonempty_list(COMMA,base_type_cn_variable)
+## In state 1587, spurious reduction of production cn_args -> loption(separated_nonempty_list(COMMA,base_type_cn_variable))
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 cn_toplevel: CN_LEMMA LNAME TYPE LPAREN RPAREN CN_REQUIRES CN_CONSTANT SEMICOLON EOF
 ##
-## Ends in an error in state: 1852.
+## Ends in an error in state: 1856.
 ##
 ## cn_lemma -> CN_LEMMA LNAME TYPE LPAREN cn_args RPAREN CN_REQUIRES nonempty_list(condition) . CN_ENSURES nonempty_list(condition) [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -18843,14 +18876,14 @@ cn_toplevel: CN_LEMMA LNAME TYPE LPAREN RPAREN CN_REQUIRES CN_CONSTANT SEMICOLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1698, spurious reduction of production nonempty_list(condition) -> condition
+## In state 1702, spurious reduction of production nonempty_list(condition) -> condition
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 cn_toplevel: CN_FUNCTION WHILE
 ##
-## Ends in an error in state: 1855.
+## Ends in an error in state: 1859.
 ##
 ## cn_function -> CN_FUNCTION . cn_attrs LPAREN base_type RPAREN UNAME VARIABLE LPAREN cn_args RPAREN cn_option_func_body [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ## cn_function -> CN_FUNCTION . cn_attrs LPAREN base_type RPAREN LNAME VARIABLE LPAREN cn_args RPAREN cn_option_func_body [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
@@ -18865,7 +18898,7 @@ cn_toplevel: CN_FUNCTION WHILE
 
 cn_toplevel: CN_FUNCTION LBRACK RBRACK WHILE
 ##
-## Ends in an error in state: 1856.
+## Ends in an error in state: 1860.
 ##
 ## cn_function -> CN_FUNCTION cn_attrs . LPAREN base_type RPAREN UNAME VARIABLE LPAREN cn_args RPAREN cn_option_func_body [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ## cn_function -> CN_FUNCTION cn_attrs . LPAREN base_type RPAREN LNAME VARIABLE LPAREN cn_args RPAREN cn_option_func_body [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
@@ -18880,7 +18913,7 @@ cn_toplevel: CN_FUNCTION LBRACK RBRACK WHILE
 
 cn_toplevel: CN_FUNCTION LPAREN WHILE
 ##
-## Ends in an error in state: 1857.
+## Ends in an error in state: 1861.
 ##
 ## cn_function -> CN_FUNCTION cn_attrs LPAREN . base_type RPAREN UNAME VARIABLE LPAREN cn_args RPAREN cn_option_func_body [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ## cn_function -> CN_FUNCTION cn_attrs LPAREN . base_type RPAREN LNAME VARIABLE LPAREN cn_args RPAREN cn_option_func_body [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
@@ -18895,7 +18928,7 @@ cn_toplevel: CN_FUNCTION LPAREN WHILE
 
 cn_toplevel: CN_FUNCTION LPAREN CN_ALLOC_ID WHILE
 ##
-## Ends in an error in state: 1858.
+## Ends in an error in state: 1862.
 ##
 ## cn_function -> CN_FUNCTION cn_attrs LPAREN base_type . RPAREN UNAME VARIABLE LPAREN cn_args RPAREN cn_option_func_body [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ## cn_function -> CN_FUNCTION cn_attrs LPAREN base_type . RPAREN LNAME VARIABLE LPAREN cn_args RPAREN cn_option_func_body [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
@@ -18910,7 +18943,7 @@ cn_toplevel: CN_FUNCTION LPAREN CN_ALLOC_ID WHILE
 
 cn_toplevel: CN_FUNCTION LPAREN CN_ALLOC_ID RPAREN WHILE
 ##
-## Ends in an error in state: 1859.
+## Ends in an error in state: 1863.
 ##
 ## cn_function -> CN_FUNCTION cn_attrs LPAREN base_type RPAREN . UNAME VARIABLE LPAREN cn_args RPAREN cn_option_func_body [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ## cn_function -> CN_FUNCTION cn_attrs LPAREN base_type RPAREN . LNAME VARIABLE LPAREN cn_args RPAREN cn_option_func_body [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
@@ -18925,7 +18958,7 @@ cn_toplevel: CN_FUNCTION LPAREN CN_ALLOC_ID RPAREN WHILE
 
 cn_toplevel: CN_FUNCTION LPAREN CN_ALLOC_ID RPAREN UNAME WHILE
 ##
-## Ends in an error in state: 1860.
+## Ends in an error in state: 1864.
 ##
 ## cn_function -> CN_FUNCTION cn_attrs LPAREN base_type RPAREN UNAME . VARIABLE LPAREN cn_args RPAREN cn_option_func_body [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ## cn_function -> CN_FUNCTION cn_attrs LPAREN base_type RPAREN UNAME . TYPE LPAREN cn_args RPAREN cn_option_func_body [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
@@ -18938,7 +18971,7 @@ cn_toplevel: CN_FUNCTION LPAREN CN_ALLOC_ID RPAREN UNAME WHILE
 
 cn_toplevel: CN_FUNCTION LPAREN CN_ALLOC_ID RPAREN UNAME VARIABLE LPAREN CN_ALLOC_ID LNAME TYPE RBRACE
 ##
-## Ends in an error in state: 1863.
+## Ends in an error in state: 1867.
 ##
 ## cn_function -> CN_FUNCTION cn_attrs LPAREN base_type RPAREN UNAME VARIABLE LPAREN cn_args . RPAREN cn_option_func_body [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -18950,15 +18983,15 @@ cn_toplevel: CN_FUNCTION LPAREN CN_ALLOC_ID RPAREN UNAME VARIABLE LPAREN CN_ALLO
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 997, spurious reduction of production separated_nonempty_list(COMMA,base_type_cn_variable) -> base_type LNAME TYPE
-## In state 1582, spurious reduction of production loption(separated_nonempty_list(COMMA,base_type_cn_variable)) -> separated_nonempty_list(COMMA,base_type_cn_variable)
-## In state 1583, spurious reduction of production cn_args -> loption(separated_nonempty_list(COMMA,base_type_cn_variable))
+## In state 1586, spurious reduction of production loption(separated_nonempty_list(COMMA,base_type_cn_variable)) -> separated_nonempty_list(COMMA,base_type_cn_variable)
+## In state 1587, spurious reduction of production cn_args -> loption(separated_nonempty_list(COMMA,base_type_cn_variable))
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 cn_toplevel: CN_FUNCTION LPAREN CN_ALLOC_ID RPAREN LNAME TYPE LPAREN RPAREN LBRACE CN_CONSTANT RPAREN
 ##
-## Ends in an error in state: 1866.
+## Ends in an error in state: 1870.
 ##
 ## cn_option_func_body -> LBRACE expr . RBRACE [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -18985,7 +19018,7 @@ cn_toplevel: CN_FUNCTION LPAREN CN_ALLOC_ID RPAREN LNAME TYPE LPAREN RPAREN LBRA
 
 cn_toplevel: CN_FUNCTION LPAREN CN_ALLOC_ID RPAREN UNAME TYPE LPAREN CN_ALLOC_ID LNAME TYPE RBRACE
 ##
-## Ends in an error in state: 1871.
+## Ends in an error in state: 1875.
 ##
 ## cn_function -> CN_FUNCTION cn_attrs LPAREN base_type RPAREN UNAME TYPE LPAREN cn_args . RPAREN cn_option_func_body [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -18997,15 +19030,15 @@ cn_toplevel: CN_FUNCTION LPAREN CN_ALLOC_ID RPAREN UNAME TYPE LPAREN CN_ALLOC_ID
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 997, spurious reduction of production separated_nonempty_list(COMMA,base_type_cn_variable) -> base_type LNAME TYPE
-## In state 1582, spurious reduction of production loption(separated_nonempty_list(COMMA,base_type_cn_variable)) -> separated_nonempty_list(COMMA,base_type_cn_variable)
-## In state 1583, spurious reduction of production cn_args -> loption(separated_nonempty_list(COMMA,base_type_cn_variable))
+## In state 1586, spurious reduction of production loption(separated_nonempty_list(COMMA,base_type_cn_variable)) -> separated_nonempty_list(COMMA,base_type_cn_variable)
+## In state 1587, spurious reduction of production cn_args -> loption(separated_nonempty_list(COMMA,base_type_cn_variable))
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 cn_toplevel: CN_FUNCTION LPAREN CN_ALLOC_ID RPAREN LNAME WHILE
 ##
-## Ends in an error in state: 1874.
+## Ends in an error in state: 1878.
 ##
 ## cn_function -> CN_FUNCTION cn_attrs LPAREN base_type RPAREN LNAME . VARIABLE LPAREN cn_args RPAREN cn_option_func_body [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ## cn_function -> CN_FUNCTION cn_attrs LPAREN base_type RPAREN LNAME . TYPE LPAREN cn_args RPAREN cn_option_func_body [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
@@ -19018,7 +19051,7 @@ cn_toplevel: CN_FUNCTION LPAREN CN_ALLOC_ID RPAREN LNAME WHILE
 
 cn_toplevel: CN_FUNCTION LPAREN CN_ALLOC_ID RPAREN LNAME VARIABLE LPAREN CN_ALLOC_ID LNAME TYPE RBRACE
 ##
-## Ends in an error in state: 1877.
+## Ends in an error in state: 1881.
 ##
 ## cn_function -> CN_FUNCTION cn_attrs LPAREN base_type RPAREN LNAME VARIABLE LPAREN cn_args . RPAREN cn_option_func_body [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -19030,15 +19063,15 @@ cn_toplevel: CN_FUNCTION LPAREN CN_ALLOC_ID RPAREN LNAME VARIABLE LPAREN CN_ALLO
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 997, spurious reduction of production separated_nonempty_list(COMMA,base_type_cn_variable) -> base_type LNAME TYPE
-## In state 1582, spurious reduction of production loption(separated_nonempty_list(COMMA,base_type_cn_variable)) -> separated_nonempty_list(COMMA,base_type_cn_variable)
-## In state 1583, spurious reduction of production cn_args -> loption(separated_nonempty_list(COMMA,base_type_cn_variable))
+## In state 1586, spurious reduction of production loption(separated_nonempty_list(COMMA,base_type_cn_variable)) -> separated_nonempty_list(COMMA,base_type_cn_variable)
+## In state 1587, spurious reduction of production cn_args -> loption(separated_nonempty_list(COMMA,base_type_cn_variable))
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 cn_toplevel: CN_FUNCTION LPAREN CN_ALLOC_ID RPAREN LNAME TYPE LPAREN CN_ALLOC_ID LNAME TYPE RBRACE
 ##
-## Ends in an error in state: 1882.
+## Ends in an error in state: 1886.
 ##
 ## cn_function -> CN_FUNCTION cn_attrs LPAREN base_type RPAREN LNAME TYPE LPAREN cn_args . RPAREN cn_option_func_body [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ##
@@ -19050,15 +19083,15 @@ cn_toplevel: CN_FUNCTION LPAREN CN_ALLOC_ID RPAREN LNAME TYPE LPAREN CN_ALLOC_ID
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 997, spurious reduction of production separated_nonempty_list(COMMA,base_type_cn_variable) -> base_type LNAME TYPE
-## In state 1582, spurious reduction of production loption(separated_nonempty_list(COMMA,base_type_cn_variable)) -> separated_nonempty_list(COMMA,base_type_cn_variable)
-## In state 1583, spurious reduction of production cn_args -> loption(separated_nonempty_list(COMMA,base_type_cn_variable))
+## In state 1586, spurious reduction of production loption(separated_nonempty_list(COMMA,base_type_cn_variable)) -> separated_nonempty_list(COMMA,base_type_cn_variable)
+## In state 1587, spurious reduction of production cn_args -> loption(separated_nonempty_list(COMMA,base_type_cn_variable))
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 cn_toplevel: CN_DATATYPE WHILE
 ##
-## Ends in an error in state: 1885.
+## Ends in an error in state: 1889.
 ##
 ## cn_datatype -> CN_DATATYPE . UNAME VARIABLE LBRACE cn_cons_cases RBRACE [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ## cn_datatype -> CN_DATATYPE . LNAME VARIABLE LBRACE cn_cons_cases RBRACE [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
@@ -19073,7 +19106,7 @@ cn_toplevel: CN_DATATYPE WHILE
 
 cn_toplevel: CN_DATATYPE UNAME WHILE
 ##
-## Ends in an error in state: 1886.
+## Ends in an error in state: 1890.
 ##
 ## cn_datatype -> CN_DATATYPE UNAME . VARIABLE LBRACE cn_cons_cases RBRACE [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ## cn_datatype -> CN_DATATYPE UNAME . TYPE LBRACE cn_cons_cases RBRACE [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
@@ -19086,7 +19119,7 @@ cn_toplevel: CN_DATATYPE UNAME WHILE
 
 cn_toplevel: CN_DATATYPE LNAME TYPE LBRACE UNAME WHILE
 ##
-## Ends in an error in state: 1889.
+## Ends in an error in state: 1893.
 ##
 ## cn_cons_case -> UNAME . VARIABLE LBRACE cn_args RBRACE [ RBRACE COMMA ]
 ## cn_cons_case -> UNAME . TYPE LBRACE cn_args RBRACE [ RBRACE COMMA ]
@@ -19099,7 +19132,7 @@ cn_toplevel: CN_DATATYPE LNAME TYPE LBRACE UNAME WHILE
 
 cn_toplevel: CN_DATATYPE LNAME TYPE LBRACE UNAME VARIABLE LBRACE CN_ALLOC_ID LNAME TYPE RPAREN
 ##
-## Ends in an error in state: 1892.
+## Ends in an error in state: 1896.
 ##
 ## cn_cons_case -> UNAME VARIABLE LBRACE cn_args . RBRACE [ RBRACE COMMA ]
 ##
@@ -19111,15 +19144,15 @@ cn_toplevel: CN_DATATYPE LNAME TYPE LBRACE UNAME VARIABLE LBRACE CN_ALLOC_ID LNA
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 997, spurious reduction of production separated_nonempty_list(COMMA,base_type_cn_variable) -> base_type LNAME TYPE
-## In state 1582, spurious reduction of production loption(separated_nonempty_list(COMMA,base_type_cn_variable)) -> separated_nonempty_list(COMMA,base_type_cn_variable)
-## In state 1583, spurious reduction of production cn_args -> loption(separated_nonempty_list(COMMA,base_type_cn_variable))
+## In state 1586, spurious reduction of production loption(separated_nonempty_list(COMMA,base_type_cn_variable)) -> separated_nonempty_list(COMMA,base_type_cn_variable)
+## In state 1587, spurious reduction of production cn_args -> loption(separated_nonempty_list(COMMA,base_type_cn_variable))
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 cn_toplevel: CN_DATATYPE LNAME TYPE LBRACE UNAME TYPE LBRACE CN_ALLOC_ID LNAME TYPE RPAREN
 ##
-## Ends in an error in state: 1896.
+## Ends in an error in state: 1900.
 ##
 ## cn_cons_case -> UNAME TYPE LBRACE cn_args . RBRACE [ RBRACE COMMA ]
 ##
@@ -19131,15 +19164,15 @@ cn_toplevel: CN_DATATYPE LNAME TYPE LBRACE UNAME TYPE LBRACE CN_ALLOC_ID LNAME T
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 997, spurious reduction of production separated_nonempty_list(COMMA,base_type_cn_variable) -> base_type LNAME TYPE
-## In state 1582, spurious reduction of production loption(separated_nonempty_list(COMMA,base_type_cn_variable)) -> separated_nonempty_list(COMMA,base_type_cn_variable)
-## In state 1583, spurious reduction of production cn_args -> loption(separated_nonempty_list(COMMA,base_type_cn_variable))
+## In state 1586, spurious reduction of production loption(separated_nonempty_list(COMMA,base_type_cn_variable)) -> separated_nonempty_list(COMMA,base_type_cn_variable)
+## In state 1587, spurious reduction of production cn_args -> loption(separated_nonempty_list(COMMA,base_type_cn_variable))
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 cn_toplevel: CN_DATATYPE LNAME TYPE LBRACE LNAME WHILE
 ##
-## Ends in an error in state: 1898.
+## Ends in an error in state: 1902.
 ##
 ## cn_cons_case -> LNAME . VARIABLE LBRACE cn_args RBRACE [ RBRACE COMMA ]
 ## cn_cons_case -> LNAME . TYPE LBRACE cn_args RBRACE [ RBRACE COMMA ]
@@ -19152,7 +19185,7 @@ cn_toplevel: CN_DATATYPE LNAME TYPE LBRACE LNAME WHILE
 
 cn_toplevel: CN_DATATYPE LNAME TYPE LBRACE LNAME VARIABLE LBRACE CN_ALLOC_ID LNAME TYPE RPAREN
 ##
-## Ends in an error in state: 1901.
+## Ends in an error in state: 1905.
 ##
 ## cn_cons_case -> LNAME VARIABLE LBRACE cn_args . RBRACE [ RBRACE COMMA ]
 ##
@@ -19164,15 +19197,15 @@ cn_toplevel: CN_DATATYPE LNAME TYPE LBRACE LNAME VARIABLE LBRACE CN_ALLOC_ID LNA
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 997, spurious reduction of production separated_nonempty_list(COMMA,base_type_cn_variable) -> base_type LNAME TYPE
-## In state 1582, spurious reduction of production loption(separated_nonempty_list(COMMA,base_type_cn_variable)) -> separated_nonempty_list(COMMA,base_type_cn_variable)
-## In state 1583, spurious reduction of production cn_args -> loption(separated_nonempty_list(COMMA,base_type_cn_variable))
+## In state 1586, spurious reduction of production loption(separated_nonempty_list(COMMA,base_type_cn_variable)) -> separated_nonempty_list(COMMA,base_type_cn_variable)
+## In state 1587, spurious reduction of production cn_args -> loption(separated_nonempty_list(COMMA,base_type_cn_variable))
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 cn_toplevel: CN_DATATYPE LNAME TYPE LBRACE LNAME TYPE LBRACE CN_ALLOC_ID LNAME TYPE RPAREN
 ##
-## Ends in an error in state: 1905.
+## Ends in an error in state: 1909.
 ##
 ## cn_cons_case -> LNAME TYPE LBRACE cn_args . RBRACE [ RBRACE COMMA ]
 ##
@@ -19184,15 +19217,15 @@ cn_toplevel: CN_DATATYPE LNAME TYPE LBRACE LNAME TYPE LBRACE CN_ALLOC_ID LNAME T
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 997, spurious reduction of production separated_nonempty_list(COMMA,base_type_cn_variable) -> base_type LNAME TYPE
-## In state 1582, spurious reduction of production loption(separated_nonempty_list(COMMA,base_type_cn_variable)) -> separated_nonempty_list(COMMA,base_type_cn_variable)
-## In state 1583, spurious reduction of production cn_args -> loption(separated_nonempty_list(COMMA,base_type_cn_variable))
+## In state 1586, spurious reduction of production loption(separated_nonempty_list(COMMA,base_type_cn_variable)) -> separated_nonempty_list(COMMA,base_type_cn_variable)
+## In state 1587, spurious reduction of production cn_args -> loption(separated_nonempty_list(COMMA,base_type_cn_variable))
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 cn_toplevel: CN_DATATYPE LNAME TYPE LBRACE LNAME TYPE LBRACE RBRACE WHILE
 ##
-## Ends in an error in state: 1911.
+## Ends in an error in state: 1915.
 ##
 ## separated_nonempty_list(COMMA,cn_cons_case) -> cn_cons_case . [ RBRACE ]
 ## separated_nonempty_list(COMMA,cn_cons_case) -> cn_cons_case . COMMA separated_nonempty_list(COMMA,cn_cons_case) [ RBRACE ]
@@ -19205,7 +19238,7 @@ cn_toplevel: CN_DATATYPE LNAME TYPE LBRACE LNAME TYPE LBRACE RBRACE WHILE
 
 cn_toplevel: CN_DATATYPE LNAME WHILE
 ##
-## Ends in an error in state: 1918.
+## Ends in an error in state: 1922.
 ##
 ## cn_datatype -> CN_DATATYPE LNAME . VARIABLE LBRACE cn_cons_cases RBRACE [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
 ## cn_datatype -> CN_DATATYPE LNAME . TYPE LBRACE cn_cons_cases RBRACE [ EOF CN_TYPE_SYNONYM CN_SPEC CN_PREDICATE CN_LEMMA CN_FUNCTION CN_DATATYPE ]
@@ -19218,7 +19251,7 @@ cn_toplevel: CN_DATATYPE LNAME WHILE
 
 fundef_spec: CN_TRUSTED SEMICOLON CN_TYPE_SYNONYM
 ##
-## Ends in an error in state: 1940.
+## Ends in an error in state: 1944.
 ##
 ## fundef_spec -> function_spec . EOF [ # ]
 ##
@@ -19229,17 +19262,17 @@ fundef_spec: CN_TRUSTED SEMICOLON CN_TYPE_SYNONYM
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1589, spurious reduction of production option(accesses_or_function) ->
-## In state 1604, spurious reduction of production option(requires_clauses) ->
-## In state 1704, spurious reduction of production option(ensures_clauses) ->
-## In state 1708, spurious reduction of production function_spec -> option(__anonymous_0) option(accesses_or_function) option(requires_clauses) option(ensures_clauses)
+## In state 1593, spurious reduction of production option(accesses_or_function) ->
+## In state 1608, spurious reduction of production option(requires_clauses) ->
+## In state 1708, spurious reduction of production option(ensures_clauses) ->
+## In state 1712, spurious reduction of production function_spec -> option(__anonymous_0) option(accesses_or_function) option(requires_clauses) option(ensures_clauses)
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 loop_spec: CN_INV CN_CONSTANT SEMICOLON CN_TYPE_SYNONYM
 ##
-## Ends in an error in state: 1944.
+## Ends in an error in state: 1948.
 ##
 ## loop_spec -> CN_INV nonempty_list(condition) . EOF [ # ]
 ##
@@ -19250,14 +19283,14 @@ loop_spec: CN_INV CN_CONSTANT SEMICOLON CN_TYPE_SYNONYM
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 1698, spurious reduction of production nonempty_list(condition) -> condition
+## In state 1702, spurious reduction of production nonempty_list(condition) -> condition
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 translation_unit: BOOL LNAME TYPE BOOL SEMICOLON WHILE
 ##
-## Ends in an error in state: 1958.
+## Ends in an error in state: 1962.
 ##
 ## declaration_list -> declaration_list . no_leading_attribute_declaration [ VOLATILE VOID UNSIGNED UNION UNAME TYPEOF TYPEDEF THREAD_LOCAL STRUCT STATIC_ASSERT STATIC SIGNED SHORT RESTRICT REGISTER NORETURN LONG LNAME LBRACES LBRACE INT INLINE FLOAT EXTERN ENUM DOUBLE CONST COMPLEX CHAR CERB_MAGIC BOOL AUTO ATOMIC ALIGNAS ]
 ## option(declaration_list) -> declaration_list . [ LBRACES LBRACE CERB_MAGIC ]
@@ -19270,7 +19303,7 @@ translation_unit: BOOL LNAME TYPE BOOL SEMICOLON WHILE
 
 translation_unit: CERB_MAGIC WHILE
 ##
-## Ends in an error in state: 1961.
+## Ends in an error in state: 1965.
 ##
 ## external_declaration_list -> external_declaration_list . external_declaration [ VOLATILE VOID UNSIGNED UNION UNAME TYPEOF TYPEDEF THREAD_LOCAL STRUCT STATIC_ASSERT STATIC SIGNED SHORT RESTRICT REGISTER NORETURN LONG LNAME LBRACK_LBRACK INT INLINE FLOAT EXTERN EOF ENUM DOUBLE CONST COMPLEX CHAR CERB_MAGIC BOOL AUTO ATOMIC ALIGNAS ]
 ## translation_unit -> external_declaration_list . EOF [ # ]
@@ -19283,7 +19316,7 @@ translation_unit: CERB_MAGIC WHILE
 
 translation_unit: BOOL LNAME TYPE RPAREN
 ##
-## Ends in an error in state: 1965.
+## Ends in an error in state: 1969.
 ##
 ## function_definition1 -> declaration_specifiers declarator_varname . [ VOLATILE VOID UNSIGNED UNION UNAME TYPEOF TYPEDEF THREAD_LOCAL STRUCT STATIC_ASSERT STATIC SIGNED SHORT RESTRICT REGISTER NORETURN LONG LNAME LBRACES LBRACE INT INLINE FLOAT EXTERN ENUM DOUBLE CONST COMPLEX CHAR CERB_MAGIC BOOL AUTO ATOMIC ALIGNAS ]
 ## init_declarator(declarator_varname) -> declarator_varname . [ SEMICOLON COMMA ]
@@ -19307,7 +19340,7 @@ translation_unit: BOOL LNAME TYPE RPAREN
 
 translation_unit: LBRACK_LBRACK ALIGNAS RBRACK RBRACK WHILE
 ##
-## Ends in an error in state: 1967.
+## Ends in an error in state: 1971.
 ##
 ## attribute_declaration -> attribute_specifier_sequence . SEMICOLON [ VOLATILE VOID UNSIGNED UNION UNAME TYPEOF TYPEDEF THREAD_LOCAL STRUCT STATIC_ASSERT STATIC SIGNED SHORT RESTRICT REGISTER NORETURN LONG LNAME LBRACK_LBRACK INT INLINE FLOAT EXTERN EOF ENUM DOUBLE CONST COMPLEX CHAR CERB_MAGIC BOOL AUTO ATOMIC ALIGNAS ]
 ## attribute_specifier_sequence -> attribute_specifier_sequence . attribute_specifier [ VOLATILE VOID UNSIGNED UNION UNAME TYPEOF TYPEDEF THREAD_LOCAL STRUCT STATIC SIGNED SHORT SEMICOLON RESTRICT REGISTER NORETURN LONG LNAME LBRACK_LBRACK INT INLINE FLOAT EXTERN ENUM DOUBLE CONST COMPLEX CHAR BOOL AUTO ATOMIC ALIGNAS ]
@@ -19323,7 +19356,7 @@ translation_unit: LBRACK_LBRACK ALIGNAS RBRACK RBRACK WHILE
 
 translation_unit: LBRACK_LBRACK ALIGNAS RBRACK RBRACK BOOL LNAME TYPE RPAREN
 ##
-## Ends in an error in state: 1969.
+## Ends in an error in state: 1973.
 ##
 ## function_definition1 -> attribute_specifier_sequence declaration_specifiers declarator_varname . [ VOLATILE VOID UNSIGNED UNION UNAME TYPEOF TYPEDEF THREAD_LOCAL STRUCT STATIC_ASSERT STATIC SIGNED SHORT RESTRICT REGISTER NORETURN LONG LNAME LBRACES LBRACE INT INLINE FLOAT EXTERN ENUM DOUBLE CONST COMPLEX CHAR CERB_MAGIC BOOL AUTO ATOMIC ALIGNAS ]
 ## init_declarator(declarator_varname) -> declarator_varname . [ SEMICOLON COMMA ]


### PR DESCRIPTION
Add support for parsing optional CN ghost returns ("output ghost arguments") of C function calls:

    f(... [/*@ <list of CN expressions/input ghost args>[; <list of CN variables/output ghost args>] @*/])

where square brackets mean optional.