### PR TITLE
Mem2reg (Analysis + Transform plan)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,9 +5,7 @@ Cerberus is a C semantics tool written in OCaml with a Dune build system.
 ## Build & run
 
 ```sh
-dune build                        # build everything
-dune build backend/driver/        # build the cerberus binary only
-./_build/default/backend/driver/cerberus --help
+make && make installl # buid everything and install it to the opam path
 
 # Common invocations
 cerberus file.c                   # parse + elaborate only
@@ -16,6 +14,8 @@ cerberus --pp core file.c         # pretty-print Core IR
 cerberus --typecheck-core file.c  # typecheck the Core IR
 cerberus --sw mem2reg file.c      # enable a switch
 ```
+
+Always use `make && make install` for building instead of dune commands.
 
 ## Architecture
 
@@ -61,10 +61,6 @@ automatically compiled into `cerb_frontend`.
        My_pass.transform_file core_file
      else core_file in
    ```
-
-## Buidling
-
-Always use `make && make install` for building instead of dune commands.
 
 ## Tests
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,161 @@
+# Cerberus
+
+Cerberus is a C semantics tool written in OCaml with a Dune build system.
+
+## Build & run
+
+```sh
+dune build                        # build everything
+dune build backend/driver/        # build the cerberus binary only
+./_build/default/backend/driver/cerberus --help
+
+# Common invocations
+cerberus file.c                   # parse + elaborate only
+cerberus --exec --batch file.c    # execute and print result
+cerberus --pp core file.c         # pretty-print Core IR
+cerberus --typecheck-core file.c  # typecheck the Core IR
+cerberus --sw mem2reg file.c      # enable a switch
+```
+
+## Architecture
+
+| Library / binary | Path | Role |
+|---|---|---|
+| `cerb_frontend` | `ocaml_frontend/` | C→AIL→Core elaboration, rewriters, switches |
+| `cerb_backend` | `backend/common/` | Pipeline orchestration (`pipeline.ml`) |
+| `cerberus` binary | `backend/driver/main.ml` | CLI entry point |
+
+The pipeline in `backend/common/pipeline.ml`:
+1. C source → Cabs (C parser)
+2. Cabs → AIL (`Cabs_to_ail.desugar`)
+3. AIL → Core (`Translation.translate`)
+4. `core_passes` — per-file Core transforms, then typechecking
+
+## Important: generated code
+
+`ocaml_frontend/generated/` is auto-generated from Lem specs in
+`frontend/model/`. **Do not edit those files directly.** Read them only to
+understand translation output; the authoritative sources are the `.lem` files.
+
+The `ocaml_frontend/dune` file uses `(include_subdirs unqualified)`, so any
+`.ml` file added anywhere under `ocaml_frontend/` (including subdirs) is
+automatically compiled into `cerb_frontend`.
+
+## How to add a Cerberus switch
+
+1. Add a constructor to `cerb_switch` in `ocaml_frontend/switches.ml` and
+   `ocaml_frontend/switches.mli`.
+2. Add a `| "name" -> Some SW_name` case in `read_switch` (before `| _ -> None`).
+3. For a simple boolean switch, add `| SW_name` to the equality arm of `pred`
+   (lines ~115–126 of `switches.ml`).
+
+## How to add a Core pass
+
+1. Create `ocaml_frontend/rewriters/my_pass.ml` — see `remove_unspecs.ml` for
+   a minimal example. Expose `val transform_file`.
+2. In `backend/common/pipeline.ml`, inside `core_passes`, add after the
+   `Remove_unspecs` block:
+   ```ocaml
+   let core_file =
+     if Switches.(has_switch SW_my_pass) then
+       My_pass.transform_file core_file
+     else core_file in
+   ```
+
+## Buidling
+
+Always use `make && make install` for building instead of dune commands.
+
+## Tests
+
+```sh
+cd tests
+USE_OPAM='' bash run.sh              # full suite (parsing, ci, tcc, gcc-torture)
+USE_OPAM='' bash run-ci.sh           # CI subset only
+```
+
+Always set `USE_OPAM=''`; without it, `common.sh` invokes cerberus via
+`dune exec`, which emits deprecation warnings and timing lines on stderr that
+pollute output comparisons for `*.error.c` and `*.syntax-only.c` tests.
+
+CI tests live in `tests/ci/`. Each test is a `.c` file run with
+`cerberus --exec --batch`; expected output is in `tests/ci/expected/*.expected`.
+Instructions to Claude for writing OCaml code: 
+
+# Writing Code
+
+0. When writing code, do these things first: 
+
+   1. Write a plan with high-level architectural decisions. Analyze this plan for defects, 
+      and keep fixing them until no obvious deficiencies remain. 
+
+   2. Write a detailed design document, with design choices for each module. Again, before
+      proceeding to implementaiton, analyze the design for obvious flaws before proceeding. 
+      If there is a fundamental design problem, DO NOT try to smooth it over. Instead, consult
+      the user about how to proceed, giving them the key options. 
+
+   3. If the detailed design reveals a key flaw, consider whether the high-level plan needs
+      to be revised. Consult the user about how to proceed, and give them some options. 
+
+   4. Copy each design document to a file `doc/history/YYYY-MM-DD_PLAN-NAME.md`, so the user can
+      read it, and new sessions can understand the changes. 
+
+# Writing OCaml code specifically
+
+1. Programs should be composed of small modules, each implementing a single concern or
+   data structure. However, mutual recursion between functions is a good reason to
+   place them in the same module — prefer a single larger module with `and`-linked
+   mutually recursive functions over separate modules connected by callbacks or
+   recursive module declarations.
+
+2. Write .mli files first, before writing any part of a module.
+
+   - .mli files should emphasize the algebraic structure of the data structure. 
+
+   - Name the primary type of an .mli file as `t`, so that clients can refer to it as 
+     `Foo.t`, or `'a Foo.t`. 
+
+   - Unless otherwise necessary, hide the implementation type. 
+
+   - Parameterized types of the form `'a t` should expose a `map : ('a -> 'b) -> 'a t -> 'b t`
+     primitive in their interface. 
+
+   - If a type constructor has monadic structure, then define `return : 'a -> 'a t` and
+     `(let+) : 'a -> ('a -> 'b t) -> 'b t` operations.
+
+   - If a type can be ordered, then expose a `compare : t -> t > int` primitive. 
+
+   - If a type can be printed, expose a `print : Format.formatter -> t -> unit` method in the 
+     interface. Use the Format module's indentation directives to ensure that print methods are
+     nicely laid out.
+
+   - If a module exposes a parameterized type, give parameterized comparison and printing
+     functions. 
+
+3. Here are some bad language features to avoid: 
+
+   - NEVER use Obj.magic, or any other feature which can break type safety. 
+
+   - NEVER use generic equality, since this violates data abstraction. Always use a 
+     type-specific `compare` operation.
+
+3. Unless explicitly instructed otherwise, DO NOT write code which uses effects.
+
+   - Use a monad with a result type instead of exceptions. 
+
+   - Prefer monadic state-passing to mutable data structures. 
+
+   - Permission to use mutable data structures is granted on a per-module basis, and 
+     permission in one module does not grant it in any other. 
+
+   - Do not perform IO operations, except for debugging, and in any top-level main-like functions. 
+
+3. Write programs by pattern matching over data structures. Avoid
+   using partial accessors or incomplete patterns matches.
+  
+4. Higher-order functions should be used sparingly, in idiomatic ways.
+
+   - Introducing monadic code to eliminate repeated nested pattern matches is acceptable. 
+   - Use of map, filter, and other algebraically well-behaved functions is acceptable. 
+   - Avoid the use of folds, because they offer no reasoning advantages over explicit
+     structural recursion.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,11 @@ Instructions to Claude for writing OCaml code:
       to be revised. Consult the user about how to proceed, and give them some options. 
 
    4. Copy each design document to a file `doc/history/YYYY-MM-DD_PLAN-NAME.md`, so the user can
-      read it, and new sessions can understand the changes. 
+      read it, and new sessions can understand the changes.
+
+   5. Write the plan FIRST before writing any code. Leave a "Post implementation addendum"
+      placeholder section and after the implementation and testing is done, and the user's
+      feedback on the code incorporated, append any changes from the plan to that section.
 
 # Writing OCaml code specifically
 

--- a/backend/common/pipeline.ml
+++ b/backend/common/pipeline.ml
@@ -562,6 +562,11 @@ let core_passes (conf, io) ~filename core_file =
     else
       core_file in
   let core_file =
+    if Switches.(has_switch SW_copy_prop) then
+      Copy_propagation.transform_file core_file
+    else
+      core_file in
+  let core_file =
     if Switches.(has_switch SW_mem2reg) then
       Core_mem2reg.transform_file core_file
     else

--- a/backend/common/pipeline.ml
+++ b/backend/common/pipeline.ml
@@ -561,6 +561,11 @@ let core_passes (conf, io) ~filename core_file =
       Remove_unspecs.rewrite_file core_file
     else
       core_file in
+  let core_file =
+    if Switches.(has_switch SW_mem2reg) then
+      Core_mem2reg.transform_file core_file
+    else
+      core_file in
   Core_indet.hackish_order <$> begin
     if conf.sequentialise_core || conf.typecheck_core then
       typed_core_passes (conf, io) core_file >>= fun (core_file, typed_core_file) ->

--- a/backend/common/pipeline.ml
+++ b/backend/common/pipeline.ml
@@ -478,8 +478,8 @@ let untype_file (file: 'a Core.typed_file) : 'a Core.file =
   let untype_generic_fun_map_decl = function
     | Fun (bty, xs, pe) ->
         Fun (bty, xs, untype_pexpr pe)
-    | Proc (loc, mrk, bTy, xs, e) ->
-        Proc (loc, mrk, bTy, xs, untype_expr e)
+    | Proc (loc, mrk, bTy, xs, e, promotable) ->
+        Proc (loc, mrk, bTy, xs, untype_expr e, promotable)
     | ProcDecl _ as decl ->
         decl
     | BuiltinDecl _ as decl ->

--- a/doc/history/2026-03-13_mem2reg-plan.md
+++ b/doc/history/2026-03-13_mem2reg-plan.md
@@ -1,0 +1,347 @@
+# mem2reg — initial design plan
+
+**Date:** 2026-03-13
+**Branch:** mem2reg
+**Files changed:** `ocaml_frontend/rewriters/core_mem2reg.ml`,
+  `ocaml_frontend/rewriters/core_mem2reg.mli`,
+  `ocaml_frontend/switches.ml`, `ocaml_frontend/switches.mli`,
+  `backend/common/pipeline.ml`
+
+## Goal
+
+Implement a `mem2reg`-style optimisation pass that promotes function-local
+variables whose address is never taken from stack-allocated Core objects
+(Create / Store0 / Load0 / Kill sequences) to pure Core let-bindings.
+
+The pass is gated on a new Cerberus switch `mem2reg`.  The transformed program
+must be semantically equivalent to the original; it simply avoids unnecessary
+memory operations for variables that never escape.
+
+---
+
+## Background: how C locals become Core
+
+When the elaboration (`Translation.translate`) converts an AIL function body
+containing `int x;` it:
+
+1. Emits a `Create` memory action that allocates an object and binds a *pointer
+   symbol* `ptr_x`:
+
+   ```
+   Esseq( Pattern([CaseBase(Some ptr_x, BTy_object OTy_pointer)]),
+          Eaction(Paction(NA, Action(loc, (), Create(align_pe, ctype_pe,
+                    PrefSource(ident_loc, [f_sym; x_sym]))))),
+          body )
+   ```
+
+2. Every `x = v` assignment becomes a `Store0`:
+
+   ```
+   Esseq( Pattern([CaseBase(None, BTy_unit)]),
+          Eaction(Paction(NA, Action(loc, (), Store0(false, ctype_pe,
+                    PEsym ptr_x, val_pe, NA)))),
+          continuation )
+   ```
+
+3. Every use of `x` becomes a `Load0`:
+
+   ```
+   Esseq( Pattern([CaseBase(Some loaded_x, BTy_loaded ...)]),
+          Eaction(Paction(NA, Action(loc, (), Load0(ctype_pe,
+                    PEsym ptr_x, NA)))),
+          continuation )
+   ```
+
+4. At the end of the C scope, a `Kill` disposes of the allocation:
+
+   ```
+   Esseq( Pattern([CaseBase(None, BTy_unit)]),
+          Eaction(Paction(NA, Action(loc, (), Kill(Static0 ctype, PEsym ptr_x)))),
+          continuation )
+   ```
+
+The goal of mem2reg is to erase the Create/Kill and replace every Store0 with a
+let-binding and every Load0 with a reference to the most recently stored value.
+
+---
+
+## Analysis level: AIL vs Core
+
+The chosen approach is **Core-level analysis**.
+
+### AIL-level analysis (rejected)
+
+The AIL AST directly mirrors C surface syntax, so detecting address-of operations
+is straightforward — pattern match on `AilEunary(Address, AilEident(sym))`.  Running
+the analysis early gives access to richer variable context (storage class, declaration
+location) and would let a simple set of promotable symbols be passed forward.
+
+However three problems rule it out:
+
+1. **Cross-level correlation.**  There is no explicit table mapping an AIL symbol for
+   a local variable to its corresponding Core pointer symbol.  We would have to either
+   (a) parse the `PrefSource` prefix in the Core transform, or (b) build the mapping
+   during elaboration.  Both options are messy.
+
+2. **Incomplete coverage — elaboration-generated address-taking.**  Some address-taking
+   occurs *inside* the AIL→Core translation and does not appear as
+   `AilEunary(Address, ...)` in the AIL AST at all.  Examples include compound
+   literals, variadic argument passing, and certain builtins that take addresses
+   internally during translation.  An AIL-level analysis would miss these and
+   incorrectly conclude a variable is promotable when it is not.
+
+3. **Pipeline coupling.**  Passing analysis results from the AIL phase to the Core
+   phase requires threading state through the pipeline, touching the return type of
+   `c_frontend_and_elaboration`, the signature of `core_passes`, and more.
+
+4. **Qualifier handling.**  AIL analysis would need to explicitly check `register` and
+   `volatile` qualifiers and skip them.  The Core analysis handles this implicitly: a
+   `volatile` access compiles to an operation whose use pattern differs from a plain
+   Load0/Store0, so it falls into `Use_other` and the variable is not promoted.
+
+### Core-level analysis (chosen)
+
+At the Core level, we inspect every use of a Create-bound pointer symbol.  If every
+use is `Load0`, `Store0`, or `Kill`, it is promotable regardless of how the AIL
+looked.
+
+**Pros**
+
+- **Self-contained.**  The entire pass lives in one file; no pipeline signature
+  changes are needed.
+- **Naturally handles implicit address-taking.**  Any elaboration artefact that
+  passes `ptr_x` to a function or uses it in pointer arithmetic will produce a
+  non-`Load0`/`Store0`/`Kill` use and the symbol will not be promoted — including
+  the elaboration-generated cases that an AIL analysis would miss.
+- **Covers Core-only inputs.**  When Cerberus is fed a `.core` file directly,
+  the AIL program does not exist; the Core analysis still works.
+
+**Cons**
+
+- Requires understanding the structure of elaborated Core.  Mitigated by the
+  conservative catch-all `Use_other` category.
+
+---
+
+## Phase 1 – Analysis: which pointer symbols are promotable?
+
+Within each `Proc` body, a pointer symbol `ptr_x` (introduced by a `Create`)
+is **promotable** if every occurrence of `PEsym ptr_x` is:
+
+- The *address* argument of `Load0(_, PEsym ptr_x, _)`
+- The *address* argument of `Store0(_, _, PEsym ptr_x, _, _)`
+- The *pointer* argument of `Kill(_, PEsym ptr_x)`
+
+And it does **not** appear in:
+
+- Any function / procedure call argument list (`Eccall`, `Eproc`)
+- `PEmember_shift(PEsym ptr_x, ...)` or `PEarray_shift(PEsym ptr_x, ...)`
+- `PEmemop(_, pes)` where `PEsym ptr_x ∈ pes`
+- Atomic operations: `SeqRMW`, `RMW0`, `CompareExchange{Strong,Weak}`,
+  `LinuxLoad`, `LinuxStore`, `LinuxRMW`
+- Any pure expression position not listed above
+- A `CreateReadOnly` action
+- Being stored through another pointer (`Store0(_, _, _, PEsym ptr_x, _)`)
+- Anywhere under `Esave` (conservative: excludes loop-written vars)
+
+**Implementation**: `collect_ptr_uses : Symbol.sym -> expr -> use list`
+
+```ocaml
+type use =
+  | Use_load    (* Load0(_, PEsym ptr, _) – address arg *)
+  | Use_store   (* Store0(_, _, PEsym ptr, _, _) – address arg *)
+  | Use_kill    (* Kill(_, PEsym ptr) *)
+  | Use_other   (* any other position *)
+```
+
+---
+
+## Phase 2 – Transformation
+
+```ocaml
+type env = (Symbol.sym * Symbol.sym) list
+(* maps ptr_sym -> current_val_sym (the last-stored value) *)
+
+val transform_expr : env -> Symbol.SSet.t -> expr -> expr
+```
+
+### Straight-line cases
+
+**Create** (promotable): drop it, recurse on body with same env.
+
+**Store** (promotable):
+```
+Esseq(_, Store0(_, _, PEsym ptr_x, val_pe, _), cont)
+→
+Elet(CaseBase(new_val_sym, bty), Epure(val_pe),
+     transform_expr (env[ptr_x ↦ new_val_sym]) promotable cont)
+```
+Fresh `new_val_sym` via `Cerb_fresh.fresh_sym ()`.
+
+**Load** (promotable, ptr_x ∈ dom(env)):
+```
+Esseq(CaseBase(Some loaded_x, _), Load0(_, PEsym ptr_x, _), cont)
+→
+Elet(CaseBase(loaded_x, bty), Epure(PEsym (lookup env ptr_x)),
+     transform_expr env promotable cont)
+```
+If `ptr_x ∉ dom(env)`: leave Load in place (UB path, safe to skip).
+
+**Kill** (promotable): drop it, recurse on continuation.
+
+### Branching: `Eif` and `Ecase`
+
+For `Esseq(unit_pat, Eif(cond, e_true, e_false), cont)`:
+
+1. Compute `written_vars = {ptr_x ∈ promotable | Store0(ptr_x) in e_true or e_false}`
+2. If `written_vars = ∅`: transform branches and cont independently with same env.
+3. If `written_vars ≠ ∅`:
+   - Mint `phi_sym_x` for each `ptr_x ∈ written_vars`
+   - Thread each branch to return final value of each `ptr_x` at its tail
+   - `Eif` result becomes a tuple `(unit × loaded(ty_1) × ... × loaded(ty_n))`
+   - Destructure tuple, bind `phi_sym_x` vars
+   - Transform `cont` with `env` extended by `ptr_x ↦ phi_sym_x`
+
+`Ecase` handled analogously (union of written_vars over all arms).
+
+Branch-threading helper:
+```ocaml
+val thread_branch
+  :  env
+  -> Symbol.SSet.t
+  -> Symbol.sym list   (* vars to thread *)
+  -> expr              (* branch body *)
+  -> Symbol.sym list   (* phi value syms produced *)
+   * expr              (* transformed branch *)
+```
+
+### Loops (`Esave` / `Erun`)
+
+Any `ptr_x` appearing under `Esave` is excluded from promotion (conservative).
+This is enforced in the analysis phase.
+
+### Non-matching expressions
+
+Structural recursion: transform sub-expressions with current env.
+(`Eccall`, `Eproc`, `Ewseq`, `Ebound`, `End`, `Epar`, `Ewait`)
+
+---
+
+## Files to create / modify
+
+### 1. New: `ocaml_frontend/rewriters/core_mem2reg.ml`
+
+Auto-compiled by `(include_subdirs unqualified)` in `ocaml_frontend/dune`.
+
+Expose:
+```ocaml
+val transform_file : (unit, unit) Core.generic_file -> (unit, unit) Core.generic_file
+```
+
+### 2. Modified: `ocaml_frontend/switches.ml`
+
+- Add `| SW_mem2reg` to `cerb_switch` type (after `SW_magic_comment_char_dollar`)
+- Add `| "mem2reg" -> Some SW_mem2reg` in `read_switch`
+- Add `| SW_mem2reg` to the simple-equality arm of `pred`
+
+### 3. Modified: `ocaml_frontend/switches.mli`
+
+Add `| SW_mem2reg` to `cerb_switch` type.
+
+### 4. Modified: `backend/common/pipeline.ml`
+
+In `core_passes`, after `Remove_unspecs.rewrite_file`, before `Core_indet.hackish_order`:
+
+```ocaml
+let core_file =
+  if Switches.(has_switch SW_mem2reg) then
+    Core_mem2reg.transform_file core_file
+  else
+    core_file in
+```
+
+---
+
+## Concrete example
+
+```c
+int foo(int y) {
+    int x = y + 1;
+    return x;
+}
+```
+
+Before:
+```
+Proc(foo, [y], integer,
+  Esseq(ptr_x_pat, Create(...),
+    Esseq(_, Store0(_, _, PEsym ptr_x, y+1, _),
+      Esseq(loaded_x_pat, Load0(_, PEsym ptr_x, _),
+        Esseq(_, Kill(_, PEsym ptr_x),
+          Epure(PEsym loaded_x))))))
+```
+
+After:
+```
+Proc(foo, [y], integer,
+  Elet(CaseBase(val_sym_0, ...),  Epure(y + 1),
+    Elet(CaseBase(loaded_x, ...), Epure(PEsym val_sym_0),
+      Epure(PEsym loaded_x))))
+```
+
+---
+
+## Testing strategy
+
+### Unit tests (`tests/ci/`)
+
+| File | What it tests |
+|---|---|
+| `mem2reg_simple.c` | Single local, straight-line init + return |
+| `mem2reg_multi.c` | Multiple independent locals in one function |
+| `mem2reg_if.c` | Local written in both branches of an `if`, read after |
+| `mem2reg_if_one_branch.c` | Local written in only one branch, read after |
+| `mem2reg_loop.c` | Local written before a `while` loop, not inside it |
+| `mem2reg_no_promote_address.c` | `&x` taken — must NOT be promoted |
+| `mem2reg_no_promote_arg.c` | Local passed to a function — must NOT be promoted |
+| `mem2reg_no_promote_loop_write.c` | Local written inside a loop body — not promoted |
+| `mem2reg_struct.c` | Struct local — not promoted (member-shift disqualifies it) |
+| `mem2reg_mixed.c` | Function with both promotable and non-promotable locals |
+
+### Regression
+
+```sh
+for file in ci/*.c; do
+  cerberus --exec --batch "$file" > tmp/base.out 2>&1
+  cerberus --exec --batch --sw mem2reg "$file" > tmp/opt.out 2>&1
+  diff -q tmp/base.out tmp/opt.out || echo "REGRESSION: $file"
+done
+```
+
+### Core inspection
+
+```sh
+cerberus --pp core --sw mem2reg mem2reg_simple.c          # Create/Kill must be gone
+cerberus --pp core --sw mem2reg mem2reg_no_promote_address.c  # Create/Kill must remain
+```
+
+### Typechecking
+
+```sh
+cerberus --typecheck-core --sw mem2reg tests/ci/mem2reg_*.c
+```
+
+### Negative promotion (grep-based)
+
+```sh
+cerberus --pp core --sw mem2reg mem2reg_no_promote_address.c | grep -q "create" \
+  && echo "PASS" || echo "FAIL: variable incorrectly promoted"
+```
+
+---
+
+## Out-of-scope / future work
+
+- Promoting struct/union locals (member-shift uses disqualify them)
+- Loop-carried promotions (variables written inside a loop body)
+- CN interaction (pass should run before CN annotations are processed)

--- a/doc/history/2026-03-16_mem2reg-analysis.md
+++ b/doc/history/2026-03-16_mem2reg-analysis.md
@@ -1,0 +1,132 @@
+# Plan: mem2reg Analysis Phase
+
+## Context
+
+The `core_mem2reg.ml` pass is currently a stub (identity transform). This plan
+implements **Phase 1 only**: the analysis that decides which Create-bound pointer
+symbols are promotable. The transform phase comes later.
+
+After this work, running `cerberus --sw mem2reg -d 3 file.c` will print which
+pointer syms are promotable for each `Proc`, with no change to program semantics.
+
+---
+
+## High-level architectural decisions
+
+**Single module, single concern.** Analysis and (future) transform stay in one
+module because analysis results feed directly into the transform; splitting them
+would require a callback or recursive-module declaration. Mutually recursive
+functions (`collect_uses` / `sym_occurs_in_expr` / `sym_occurs_in_action`) are
+kept together with `and` linkage.
+
+**Plain recursive functions, not `Core_rewriter`.** `Core_rewriter` is designed
+for tree rewrites. The analysis is a pure fold/query over the expression tree;
+direct structural recursion is simpler and more readable.
+
+**Conservative correctness over completeness.** Any use of a pointer symbol that
+is not a plain Load0/Store0/Kill address argument immediately disqualifies it.
+This keeps the analysis simple and safe, at the cost of missing some promotable
+vars. `Esave` bodies are always conservative (loops may re-enter).
+
+**Architectural flaw check:** No obvious flaws. The analysis is a read-only pass
+that returns the file unchanged, so it cannot break existing semantics.
+
+---
+
+## Detailed design
+
+### New files
+
+| File | Purpose |
+|---|---|
+| `ocaml_frontend/rewriters/core_mem2reg.mli` | Public interface (written first) |
+| `ocaml_frontend/rewriters/core_mem2reg.ml` | Implementation |
+| `doc/history/2026-03-16_mem2reg-analysis.md` | Design doc archive |
+
+### `core_mem2reg.mli`
+
+The module exposes exactly one function. All internal types are hidden.
+
+```ocaml
+(** Promote function-local, non-address-taken C variables from
+    Create/Store0/Load0/Kill sequences to pure Core let-bindings. *)
+
+val transform_file : Symbol.sym Core.file -> Symbol.sym Core.file
+```
+
+(`Core.file` is `type 'a file = (unit, 'a) generic_file` — the untyped file
+that `core_passes` in `pipeline.ml` passes around.)
+
+---
+
+### Internal type `use`
+
+```ocaml
+type use =
+  | Use_load    (* Load0(_, PEsym ptr, _) — address argument *)
+  | Use_store   (* Store0(_, _, PEsym ptr, _, _) — address argument *)
+  | Use_kill    (* Kill(_, PEsym ptr) *)
+  | Use_other   (* any other occurrence *)
+```
+
+`use_is_promotable` replaces any `u <> Use_other` guards (avoids generic equality):
+
+```ocaml
+let use_is_promotable = function
+  | Use_load | Use_store | Use_kill -> true
+  | Use_other -> false
+```
+
+### Occurrence helpers
+
+Three mutually recursive functions: `sym_occurs_in_pexpr`, `sym_occurs_in_expr`,
+`sym_occurs_in_action`. Return `bool`: does `PEsym sym` appear anywhere in this
+term? Used as the conservative fallback.
+
+### `classify_action`
+
+Returns `use list` for a given sym in one action. Load0/Store0/Kill are
+classified precisely; everything else uses `sym_occurs_in_action` as fallback.
+
+### `collect_uses`
+
+Structural recursion over `expr`. `Esave` is always conservative (loop bodies).
+
+### `collect_creates`
+
+Finds all `Esseq`-bound `Create(PrefSource _)` syms. `PrefSource` required —
+excludes dynamic `Alloc0` and `CreateReadOnly`.
+
+### `find_promotable`
+
+Calls `collect_creates` and filters by `is_promotable`. Emits debug at level 3.
+
+### `transform_file`
+
+Analysis phase only. Iterates over `file.funs` bindings for debug output using
+`Pmap.bindings_list`, then returns the file structurally unchanged.
+
+---
+
+## Verification
+
+```sh
+# 1. Build and install
+make && make install
+
+# 2. Simple case — one promotable var
+cerberus --sw mem2reg -d 3 tests/ci/0341-mem2reg_simple.c 2>&1 | grep mem2reg
+# Expected: "[mem2reg] foo: 1 promotable: [ptr_x_NNN]"
+
+# 3. Address-taken — zero promotable
+cerberus --sw mem2reg -d 3 tests/ci/0346-mem2reg_no_promote_address.c 2>&1 | grep mem2reg
+# Expected: "[mem2reg] ...: 0 promotable: []"
+
+# 4. No-switch case — no output
+cerberus tests/ci/0341-mem2reg_simple.c 2>&1 | grep mem2reg
+# Expected: (empty)
+
+# 5. Mixed — partial promotion
+cerberus --sw mem2reg -d 3 tests/ci/0350-mem2reg_mixed.c 2>&1 | grep mem2reg
+# Expected: some syms listed, some not
+```

--- a/doc/history/2026-03-16_mem2reg-callconv.md
+++ b/doc/history/2026-03-16_mem2reg-callconv.md
@@ -1,0 +1,138 @@
+
+# mem2reg — value-passing calling convention support
+
+**Date:** 2026-03-16
+**Branch:** mem2reg
+**Files changed:** `ocaml_frontend/rewriters/core_mem2reg.ml`, `ocaml_frontend/rewriters/core_mem2reg.mli`
+
+## Context
+
+The mem2reg analysis (`ocaml_frontend/rewriters/core_mem2reg.ml`) previously only
+promoted `Create(PrefSource _)` bindings — C source-level local variables.
+Function parameters were excluded because under the standard `Normal_callconv`
+they are passed as pointers by the caller; the callee receives a pointer it does
+not own, so there is no `Create` inside the callee to promote.
+
+Under `Inner_arg_callconv` (enabled by `SW_inner_arg_temps`, used by CN), the
+elaboration places the allocation, initialisation, and deallocation of each
+non-variadic parameter **inside the callee body** as a `Create(PrefFunArg _)` /
+`Store` / ... / `Kill` sequence.  These have exactly the same shape as a
+promotable local variable, and should be promoted when the parameter's address
+is never taken.
+
+`file.calling_convention` (type `Core.calling_convention`, values
+`Normal_callconv | Inner_arg_callconv`) is already threaded through the entire
+pipeline.  The pass just needs to read it.
+
+## Design
+
+The minimal change is to add a single `~also_fun_args : bool` parameter to
+`collect_creates`.  When `true`, the function also yields syms bound by
+`Create(PrefFunArg _)` alongside the existing `Create(PrefSource _)` arm.
+`transform_file` computes `also_fun_args` once from `file.calling_convention`
+and threads it down.
+
+This keeps the analysis path-insensitive to the calling convention: the
+promotability predicate (`collect_uses`) is unchanged — it already handles any
+Create-bound pointer sym the same way, regardless of whether it came from a
+local variable or a parameter slot.
+
+### Why `also_fun_args` rather than inspecting the prefix inside `collect_uses`
+
+`collect_uses` classifies every **use** of a sym (load / store / kill / other).
+Whether a sym was *introduced* by a `PrefSource` or `PrefFunArg` create is
+orthogonal to how it is used.  Introducing the distinction at the
+`collect_creates` level (where the sym is bound) keeps both functions
+single-purpose.
+
+## Changes
+
+### `collect_creates` — new `~also_fun_args` arm
+
+```ocaml
+(* collect_creates finds Create-bound syms that are candidates for
+   promotion.  Under Normal_callconv only PrefSource (C local variables)
+   are considered; under Inner_arg_callconv PrefFunArg (callee-owned
+   parameter temporaries) are also included, since in that convention
+   the callee creates and owns the argument slot.                      *)
+
+let rec collect_creates ~also_fun_args (Expr (_, e_)) : Symbol.sym list =
+  match e_ with
+  | Esseq (
+      Pattern (_, CaseBase (Some ptr_sym, _)),
+      Expr (_, Eaction (Paction (_, Action (_, _, Create (_, _, Symbol.PrefSource _))))),
+      body
+    ) ->
+      ptr_sym :: collect_creates ~also_fun_args body
+  | Esseq (
+      Pattern (_, CaseBase (Some ptr_sym, _)),
+      Expr (_, Eaction (Paction (_, Action (_, _, Create (_, _, Symbol.PrefFunArg _))))),
+      body
+    ) when also_fun_args ->
+      ptr_sym :: collect_creates ~also_fun_args body
+  | Ewseq (_, e1, e2) | Esseq (_, e1, e2) ->
+      collect_creates ~also_fun_args e1 @ collect_creates ~also_fun_args e2
+  (* remaining arms all thread ~also_fun_args *)
+```
+
+### `transform_file` — read `file.calling_convention`
+
+```ocaml
+let transform_file file =
+  let also_fun_args = match file.calling_convention with
+    | Inner_arg_callconv -> true
+    | Normal_callconv    -> false
+  in
+  List.iter (fun (f_sym, decl) ->
+    match decl with
+    | Proc (_, _, _, _, body) ->
+        ignore (find_promotable ~also_fun_args f_sym body)
+    | Fun _ | ProcDecl _ | BuiltinDecl _ -> ()
+  ) (Pmap.bindings_list file.funs);
+  file
+```
+
+### `.mli` doc comment
+
+```ocaml
+(** Promote function-local, non-address-taken C variables — and, under
+    [Inner_arg_callconv], callee-owned parameter temporaries — from
+    Create/Store0/Load0/Kill sequences to pure Core let-bindings.
+    Which categories are considered is determined by
+    [file.calling_convention]. *)
+```
+
+## Calling-convention background
+
+Under `Normal_callconv` (the default), function arguments are passed as
+pointers; the **caller** allocates the argument slot.  The callee only holds a
+borrowed pointer and never owns the allocation, so there is no matching
+`Create`/`Kill` in the callee body.
+
+Under `Inner_arg_callconv` (switch `SW_inner_arg_temps`, used by CN), arguments
+are passed as Core **values** (`BTy_loaded _`); the **callee** allocates the
+argument slot via `Create(PrefFunArg _)` at function entry, initialises it with
+a `Store`, and deallocates it with `Kill` on every exit path.  The resulting
+shape is identical to a C local variable and is directly promotable if the
+parameter's address is never taken.
+
+## Verification
+
+```sh
+make && make install
+
+# 1. Normal_callconv: CI suite unaffected
+cd tests && USE_OPAM='' bash run-ci.sh   # 198/198
+
+# 2. Inner_arg_callconv: parameter slot promoted
+cerberus --sw="mem2reg,inner_arg_temps" -d 3 \
+  tests/ci/0347-mem2reg_no_promote_arg.c 2>&1 | grep "\[mem2reg\]"
+# id: 1 promotable: [x]   ← parameter x now promoted
+# main: 1 promotable: [x]
+
+# 3. Address-taken local: not promoted even under Inner_arg_callconv
+cerberus --sw="mem2reg,inner_arg_temps" -d 3 \
+  tests/ci/0346-mem2reg_no_promote_address.c 2>&1 | grep "\[mem2reg\]"
+# foo: 1 promotable: [p]   ← p slot (never address-taken in foo) promoted
+# main: 0 promotable: []   ← x address taken via &x, not promoted
+```

--- a/doc/history/2026-03-16_mem2reg-core-rewriter.md
+++ b/doc/history/2026-03-16_mem2reg-core-rewriter.md
@@ -1,0 +1,116 @@
+# Discussion: Should mem2reg use `core_rewriter`?
+
+## What `core_rewriter` provides
+
+`core_rewriter` is a transformation functor `Rewriter(Eff: Monad)` that provides a
+visitor pattern with three mutually-recursive rewriters — `rw_pexpr`, `rw_action`,
+`rw_expr` — each returning one of:
+
+```
+Unchanged | Update v | Traverse | PostTraverseAction f
+| DoChildrenPost f | ChangeDoChildrenPost(v, f)
+```
+
+The `Eff` monad parameter threads arbitrary state through the traversal.
+
+---
+
+## Analysis phase — do NOT use `core_rewriter`
+
+The analysis phase consists of four functions: `collect_creates`, `collect_uses`,
+`check_definitely_init`, and `no_mixed_unseq_uses`.  None of them fit the
+`core_rewriter` model.
+
+### `collect_creates`
+
+A simple 28-line recursive descent accumulating a symbol list.
+Rewriting it with `core_rewriter` would require instantiating the functor, defining
+three rewriter records for a single pattern, and wiring `PostTraverseAction`
+callbacks.  Net result: more code, more indirection, no gain.
+
+### `collect_uses`
+
+A **context-sensitive fold**, not a transformation.  It classifies uses
+differently depending on where in the AST the symbol appears:
+
+- Inside `Esave` → always `Use_other` (requires a downward context flag)
+- As the address argument of `Load0`/`Store0`/`Kill`/`SeqRMW` → `classify_action`
+- Anywhere else → `Use_other`
+
+`core_rewriter` has no mechanism to:
+- Pass a "we are inside `Esave`" context flag downward
+- Distinguish *which* argument position a pexpr occupies within an action
+- Return a classification rather than a transformed node
+
+Forcing this in would require the `Eff` monad to carry a context stack *and* an
+accumulated use list, with per-constructor `PostTraverseAction` hooks — strictly
+more complex than the current 47-line hand-rolled traversal.
+
+### `check_definitely_init`
+
+A **two-valued downward-and-upward pass** that returns `(safe, init_after)`:
+
+- `safe`: no load-before-store on any syntactic path
+- `init_after`: on ALL syntactic paths, at least one store has occurred
+
+It carries `already_init : bool` **downward** — a context value that changes as
+the traversal descends through sequential nodes.  `core_rewriter` threads monadic
+state sequentially through children but has no concept of a *downward* context; it
+cannot model "pass `already_init = true` into the continuation after seeing a
+store".
+
+Two cases require non-uniform child handling that `core_rewriter` cannot express:
+
+- **`Ewseq`**: the init-after result of `e1` is propagated *into* `e1`'s own
+  subtree but **not** into `e2` (negative actions in `e1` are not sequenced before
+  `e2`).  A uniform left-to-right state thread would incorrectly propagate `ia1`
+  to `e2`.
+- **`Eunseq`**: each arm is visited with the *same* `already_init` (no arm's
+  result is visible to any sibling).  `safe` and `init_after` are both
+  all-arms-must-agree conjunctions.
+
+Additionally the function returns `(bool * bool)`, not a transformed node — there
+is no natural way to encode that in `core_rewriter`'s result type.
+
+### `no_mixed_unseq_uses`
+
+A **collective-arms predicate** over `Eunseq` nodes.  For each `Eunseq` it asks:
+*does any arm write `sym` while ≥ 2 arms mention `sym`?*  This is a conflict check
+across all sibling arms simultaneously.
+
+`core_rewriter` visits children one at a time and cannot gather information about
+all siblings before deciding whether the parent node is safe.  Implementing this
+check would require a `PostTraverseAction` hook that re-examines all arms after the
+fact — but the rewriter has already dispatched to each arm independently, so the
+sibling set is no longer available.
+
+Like `check_definitely_init`, the function returns a `bool`, not a transformed
+node.
+
+**Conclusion: keep all four analysis functions hand-rolled.**
+
+---
+
+## Transformation phase — also do NOT use `core_rewriter`
+
+For straight-line code, threading an `env : (sym * sym) list` through the `Eff`
+state monad and returning `Update` would work.  But mem2reg must correctly handle
+**branches** (`Eif`, `Ecase`):
+
+When a promotable variable is written inside one or both branches, the algorithm
+must:
+
+1. **Fork** the env — transform each branch independently with the *same* env snapshot.
+2. Compute `written_vars` across branches.
+3. Mint fresh `phi_sym` per written variable.
+4. Restructure the outer `Esseq` node so the `Eif` result becomes a tuple
+   `(unit × val_ty_1 × … × val_ty_n)`; destructure the tuple and extend the env
+   with `ptr_x ↦ phi_sym_x` before transforming the continuation.
+
+`core_rewriter` threads state **sequentially** through children — it cannot fork
+state for parallel branches.  Handling branching would require manually calling the
+rewriter recursively inside a `rw_expr` handler for `Eif`/`Ecase`, which defeats
+the purpose of using the framework at all.
+
+**Conclusion: Phase 2 is also hand-rolled**, using an explicit recursive
+`transform_expr env promotable expr` function.

--- a/doc/history/2026-03-16_mem2reg-definite-assignment.md
+++ b/doc/history/2026-03-16_mem2reg-definite-assignment.md
@@ -1,0 +1,164 @@
+# Plan: mem2reg — Definite-Assignment Analysis Fix (revised)
+
+## Problem
+
+The current `find_promotable` checks that every use of a Create-bound symbol is
+a Load0, Store0, or Kill.  However it does **not** verify that a Load0 is always
+preceded by a Store0 on every path through the function body.
+
+If a promotable variable is loaded before it has been stored on some path, the
+Create node will be dropped and there will be no `Elet` binding that introduces the
+loaded value's name.  The transformed program is ill-scoped even if the original C
+was undefined behaviour.
+
+## Polarity system
+
+`frontend/model/core.lem` lines 152-154:
+
+```lem
+type polarity =  (* memory action polarities *)
+ | Pos (* sequenced by letweak and letstrong *)
+ | Neg (* only sequenced by letstrong *)
+```
+
+`Ewseq` is `letweak`; `Esseq` is `letstrong`.  **`Neg` actions in e1 of an
+`Ewseq` are not sequenced before e2.**  Every `Store0` in generated code is
+wrapped in `Paction(Neg, ...)` and placed in the e1 of an `Ewseq`, so a Store0
+in e1 of an `Ewseq` is NOT guaranteed visible to e2.
+
+## New predicate: `check_definitely_init`
+
+Add a recursive helper that returns a pair:
+
+```ocaml
+(* Returns (safe, init_after):
+     safe       – no load-before-store on any syntactic path through expr
+     init_after – on ALL syntactic paths through expr, at least one store
+                  has occurred (so a subsequent load would be safe)       *)
+val check_definitely_init
+  :  Symbol.sym     (* the pointer symbol being analysed *)
+  -> bool           (* already_init: a store has occurred on every path so far *)
+  -> (unit, unit) Core.generic_expr
+  -> bool * bool
+```
+
+### Recursive rules
+
+Starting call: `check_definitely_init sym false body`
+(the variable is uninitialized at the point of its `Create`).
+
+| Node | `safe` | `init_after` |
+|---|---|---|
+| `Store0(ptr_sym, …)` | `true` | `true` |
+| `Load0(…, ptr_sym, …)` | `already_init` | `already_init` |
+| `Kill(…, ptr_sym)` | `true` | `false` (scope ends) |
+| `SeqRMW(_, _, PEsym ptr_sym, …)` | `already_init` | `true` |
+| `Esseq(_, e1, e2)` | run e1 → `(s1, ia1)`, run e2 with `ia1` → `(s2, ia2)`; `s1 && s2` | `ia2` |
+| `Ewseq(_, e1, e2)` | run e1 → `(s1, ia1)`, run e2 with **`already_init`** → `(s2, ia2)`; `s1 && s2` | `ia1 \|\| ia2` |
+| `Eunseq(arms)` | run each arm with `already_init`; `AND(si)` | `AND(iai)` |
+| `Eif(_, et, ef)` | run et and ef both with `already_init`; AND safes | AND `init_after`s |
+| `Ecase(_, arms)` | run every arm with `already_init`; AND all `safe` | AND all `init_after` |
+| `Esave(…)` | conservative: if sym occurs anywhere inside → `false`; else `true` | `already_init` |
+| `Elet(_, _, e)` / `Ebound e` / `Eannot(_, e)` | recurse on `e` | recurse |
+| everything else (leaf or does not mention sym) | `true` | `already_init` |
+
+**Why `Ewseq` ≠ `Esseq`**: e1's `Neg` stores are not sequenced before e2, so
+e2 receives `already_init` (not `ia1`).  However, both e1 and e2 always execute,
+so `init_after = ia1 || ia2` (either sub-expression's store is visible to the
+outer context once the `Ewseq` completes).
+
+**`Eunseq`**: no arm's result is visible to any sibling arm.  All arms get
+`already_init`; `init_after` requires every arm to have stored (intersection).
+
+**`SeqRMW`**: atomically reads then writes.  Requires `already_init` to be safe
+(the read part); leaves the variable initialised (`init_after = true`).
+
+**`Esave` — why the conservative bail-out is necessary**: `Esave(label, args,
+body)` is the loop-header form in Core.  `Erun(label, vals)` anywhere in `body`
+is an unconditional back-edge jump back to the label, so `Esave` is the target of
+a cycle in the control-flow graph.
+
+A correct definite-initialisation analysis over a loop requires a **fixpoint
+computation**: start with `already_init = false` at the header, analyse the body,
+feed `init_after` back as the new `already_init` for the next iteration, and
+repeat until stable.  `check_definitely_init` is a single syntactic descent — it
+visits each node exactly once and therefore cannot model back-edges.
+
+The hazard becomes concrete with a conditionally-storing loop:
+
+```
+Esave(L, [],
+  Eif(cond,
+    Esseq(_, Store0(addr=sym, …), …),
+    Epure unit),            (* no store on this branch *)
+  Esseq(loaded, Load0(addr=sym), …),
+  … Erun(L, []) …)
+```
+
+On the first iteration where `cond` is false, the Load0 executes before any
+Store0 — unsafe.  A single-pass analysis that na\"ively propagated `init_after =
+true` from a prior iteration back around the back-edge would miss this.
+
+Rather than implement fixpoint iteration, the code conservatively rejects any
+variable that appears inside an `Esave` at all (returning `safe = false`).  This
+is sound: a looping variable is never promoted.  The cost is rejecting cases that
+are actually safe (e.g. a variable stored unconditionally on every loop iteration
+before it is ever read), but those patterns are rare in front-end-generated Core
+and not worth the added complexity.
+
+## New predicate: `no_mixed_unseq_uses`
+
+Binary operator subexpressions compile to `Eunseq` arms.  If one arm writes sym
+(Store0/SeqRMW with `addr = PEsym sym`) while another arm also mentions sym, the
+C semantics are an unsequenced race (UB).  Promoting sym in that case would
+silently remove the Store0 and suppress Cerberus's race detector.
+
+```
+no_mixed_unseq_uses : sym -> expr -> bool
+```
+
+Walks recursively.  For each `Eunseq(arms)`:
+- `writing_arms` = arms that write sym (Store0 or SeqRMW with `addr = PEsym sym`)
+- `mentioning_arms` = arms that mention sym at all
+- if `writing_arms ≠ []` and `|mentioning_arms| ≥ 2` → return `false`
+
+Also recurse into each arm.
+
+## New use variant: `Use_seqrmw`
+
+`SeqRMW(_, _, PEsym ptr, tmp, upd)` atomically reads and writes through `ptr`.
+It is promotable when `ptr = PEsym sym` — classified as `Use_seqrmw`.
+If sym occurs elsewhere in the SeqRMW (in `upd_pe`) it is `Use_other`
+(conservative: the pointer sym should not leak into the value computation).
+
+## Updated `find_promotable`
+
+```ocaml
+let find_promotable ~also_fun_args f_sym body =
+  let creates = collect_creates ~also_fun_args body in
+  let is_promotable s =
+    List.for_all use_is_promotable (collect_uses s body)
+    && fst (check_definitely_init s false body)
+    && no_mixed_unseq_uses s body
+  in
+  ...
+```
+
+## Effect on the transformation
+
+Because `check_definitely_init` guarantees that every Load0 for a promoted symbol
+is preceded by a Store0 on every path, the `transform_expr` function can assert
+(or simply omit the check) that when it encounters a `Load0` for a promoted pointer,
+the pointer is already in the env.  The "leave Load in place as fallback" path is
+not needed.
+
+## Test cases (0351-0356 under tests/ci/)
+
+| File | Expected | Reason |
+|---|---|---|
+| `0351-mem2reg_unseq_uninit.undef.c` | UB036 | `x` uninit; Load0 in Eunseq arm with `already_init=false` |
+| `0352-mem2reg_unseq_init.undef.c` | UB035 | `x` init; `check_definitely_init` passes but `no_mixed_unseq_uses` blocks (Store0 in arm2, Load0 in arm1) |
+| `0353-mem2reg_unseq_reads.c` | exits 14 | `x + x` — both arms read-only; `no_mixed_unseq_uses` allows promotion |
+| `0354-mem2reg_seqrmw_post.c` | exits 0 | `x++` — `Use_seqrmw`, `already_init=true` → promoted |
+| `0355-mem2reg_seqrmw_pre.c` | exits 1 | `++x` — same as above |
+| `0356-mem2reg_unseq_seqrmw.undef.c` | UB035 | `x + (x++)` — SeqRMW in arm2 writes; `no_mixed_unseq_uses` blocks promotion |

--- a/doc/history/2026-03-16_mem2reg-transform.md
+++ b/doc/history/2026-03-16_mem2reg-transform.md
@@ -1,0 +1,177 @@
+# Plan: mem2reg Phase 2 — Transformation Pass
+
+## Context
+
+`core_mem2reg.ml` has a complete Phase 1 (analysis: `collect_creates`,
+`collect_uses`, `find_promotable`) but `transform_file` is still a stub that
+returns the file unchanged.  Phase 2 implements the actual transformation.
+
+The rationale for hand-rolling rather than using `core_rewriter` is in
+`2026-03-16_mem2reg-core-rewriter.md`.  The definite-assignment analysis fix that
+Phase 2 depends on is in `2026-03-16_mem2reg-definite-assignment.md`.
+
+---
+
+## Key files
+
+| File | Change |
+|---|---|
+| `ocaml_frontend/rewriters/core_mem2reg.ml` | Add `type env`, `check_definitely_init`, `transform_expr`, `thread_branch`, update `transform_file` |
+| `ocaml_frontend/rewriters/core_mem2reg.mli` | No change (interface already correct) |
+
+---
+
+## New types
+
+```ocaml
+(* Maps ptr_sym -> current val_sym (last-stored value) *)
+type env = (Symbol.sym * Symbol.sym) list
+```
+
+Helper: `lookup : env -> Symbol.sym -> Symbol.sym option`
+
+---
+
+## `transform_expr` — straight-line cases
+
+Signature:
+```ocaml
+val transform_expr
+  :  env
+  -> Symbol.SSet.t
+  -> (unit, unit) Core.generic_expr
+  -> (unit, unit) Core.generic_expr
+```
+
+### Create (promotable)
+
+Drop the `Esseq(…, Create(PrefSource _), body)` node entirely; recurse on `body`
+with the same env.
+
+### Store (promotable)
+
+```
+Esseq(_, Eaction(Store0(_, _, PEsym ptr_x, val_pe, _)), cont)
+→ Elet(CaseBase(new_sym, bty), Epure(val_pe),
+       transform_expr (env[ptr_x ↦ new_sym]) promotable cont)
+```
+
+`new_sym` is minted via `Cerb_fresh.fresh_sym ()`.  `bty` is the base type of the
+stored value (extracted from the Store0 type argument).
+
+### Load (promotable, ptr_x ∈ dom(env))
+
+```
+Esseq(CaseBase(Some loaded_x, bty), Eaction(Load0(_, PEsym ptr_x, _)), cont)
+→ Elet(CaseBase(loaded_x, bty), Epure(PEsym (lookup env ptr_x)),
+       transform_expr env promotable cont)
+```
+
+Because `check_definitely_init` guarantees every Load is preceded by a Store on
+every path, `ptr_x` is always in `dom(env)` when reached.  No fallback is needed.
+
+### Kill (promotable)
+
+Drop `Esseq(_, Eaction(Kill(_, PEsym ptr_x)), cont)`; recurse on `cont` unchanged.
+
+### All other nodes
+
+Structural recursion — recurse into sub-expressions with the current env unchanged.
+
+---
+
+## `thread_branch` — branch helper
+
+When branching, some promotable pointer variables may be written inside one or
+more arms.  After the branch those updated values must be available in the
+continuation.  `thread_branch` transforms one arm and arranges for the current
+value of each variable in `to_thread` to be returned as an extra element of the
+arm's result.
+
+```ocaml
+val thread_branch
+  :  env
+  -> Symbol.SSet.t            (* promotable *)
+  -> Symbol.sym list          (* ptr_syms whose values must be threaded out *)
+  -> (unit, unit) Core.generic_expr
+  -> Symbol.sym list          (* fresh val_syms, one per threaded ptr *)
+   * (unit, unit) Core.generic_expr  (* transformed arm *)
+```
+
+Implementation: transform the arm body normally, then wrap its final expression so
+that the innermost continuation returns a tuple
+`Epure(PEtuple [original_val; PEsym v_1; …; PEsym v_n])` where each `v_i` is
+`lookup env' ptr_i` in the env *after* transforming the arm (`env'`).
+
+The caller is responsible for picking a *single* set of `phi_sym`s for the whole
+join point (one fresh sym per threaded ptr), then destructuring the tuple result to
+bind them.
+
+---
+
+## `transform_expr` — branching: `Eif`
+
+For `Esseq(unit_pat, Eif(cond, e_true, e_false), cont)`:
+
+1. Compute `written` = `{ptr_x ∈ promotable | Store0(ptr_x) appears in e_true or e_false}`.
+2. **No writes** (`written = ∅`): transform both branches and `cont` with the same env; reconstruct `Esseq(unit_pat, Eif(cond, e_true', e_false'), cont')`.
+3. **Writes present**:
+   - `to_thread = SSet.elements written`
+   - Call `thread_branch env promotable to_thread e_true` → `(val_syms_t, e_true')`
+   - Call `thread_branch env promotable to_thread e_false` → `(val_syms_f, e_false')`
+   - Mint one `phi_sym_x` per element of `to_thread`
+   - Build result pattern: `CaseTuple [unit_pat; CaseBase(phi_1, bty_1); …]`
+   - Build `env'` = env extended with `ptr_x ↦ phi_sym_x` for each written ptr
+   - Return:
+     ```
+     Esseq(result_pat, Eif(cond, e_true', e_false'),
+           transform_expr env' promotable cont)
+     ```
+
+`Ecase` is handled analogously: union of `written` over all arms; one
+`thread_branch` call per arm.
+
+---
+
+## Updated `transform_file`
+
+```ocaml
+let transform_file file =
+  let also_fun_args = match file.calling_convention with
+    | Inner_arg_callconv -> true
+    | Normal_callconv    -> false
+  in
+  let transform_decl f_sym decl =
+    match decl with
+    | Proc (annots, loc, params, ret_ty, body) ->
+        let promotable = find_promotable ~also_fun_args f_sym body in
+        let promotable_set =
+          List.fold_left (fun s x -> Symbol.SSet.add x s) Symbol.SSet.empty promotable
+        in
+        let body' = transform_expr [] promotable_set body in
+        Proc (annots, loc, params, ret_ty, body')
+    | Fun _ | ProcDecl _ | BuiltinDecl _ -> decl
+  in
+  { file with funs = Pmap.mapi transform_decl file.funs }
+```
+
+---
+
+## Verification
+
+```sh
+make && make install
+
+# Core IR inspection — Create/Kill must be gone for simple locals
+cerberus --pp core --sw mem2reg tests/ci/mem2reg_simple.c
+
+# Create/Kill must remain for non-promotable vars (address taken)
+cerberus --pp core --sw mem2reg tests/ci/mem2reg_no_promote_address.c
+
+# Typecheck transformed output
+cerberus --typecheck-core --sw mem2reg tests/ci/mem2reg_*.c
+
+# Regression: output must be identical with and without the pass
+cd tests
+USE_OPAM='' bash run-mem2reg.sh
+```

--- a/doc/history/2026-03-18_mem2reg-esave-erun.md
+++ b/doc/history/2026-03-18_mem2reg-esave-erun.md
@@ -1,0 +1,369 @@
+# Plan: Esave/Erun support in mem2reg analysis
+
+## Context
+
+The mem2reg analysis in `ocaml_frontend/rewriters/core_mem2reg.ml` conservatively
+rejects every variable that appears inside any `Esave` or `Erun`.
+
+**Elaboration invariants:**
+
+1. **Default args** of `Esave` are always addresses of C locals in scope:
+   `Esave(L, [(param, (_, PEsym ptr)), ...], body)`.
+2. **The body** of `Esave` refers **only** to its declared parameter syms — not
+   the outer ptr syms, not even in nested `Erun` args.
+
+   > **[Correction]** This invariant is **too strong** and does not hold in
+   > practice.  Non-CREATE-bound syms — most notably function-parameter pointers
+   > (e.g. `n` in `int fact(int n)`) — can appear freely in an Esave body without
+   > being passed as params.  The elaboration only threads **CREATE-bound local
+   > pointer syms** through Esave params; other in-scope syms (function parameters,
+   > globals) are referenced directly from the body.  The correct, weaker invariant
+   > is: **for any CREATE-bound local pointer sym `s`, every occurrence of `s`
+   > inside an Esave body is via a param that aliases `s` as a bare `PEsym`**.
+   > This is sufficient to justify the NoAlias shortcut in `collect_uses` and
+   > `check_definitely_init`.
+
+3. **`Erun` args** are always addresses of local vars in the *current* scope.
+   Inside an `Esave` body the current scope is the param syms, so back-edge Erun
+   args are param syms.  Outside an `Esave` they are outer ptr syms.
+4. **`Erun` is terminal**: control flows *into* Erun but never out of it.
+   `init_after` for an Erun is vacuously `true` (the continuation is unreachable).
+5. **`Erun` scope**: can appear as a forward jump, backward jump, or recursive
+   back-edge inside an Esave body.  Not necessarily nested inside the target Esave.
+6. **Escape propagation**: if `param_sym` escapes (gets `Use_other`) in an Esave
+   body, then the default arg and **all** `Erun` args to that label at that
+   parameter position are also considered escaping.
+
+## Critical file
+
+`ocaml_frontend/rewriters/core_mem2reg.ml`
+
+---
+
+## Design
+
+### Key insight: memoize per-Esave analysis on demand
+
+Both `collect_uses` and `check_definitely_init` share a need to analyse Esave bodies: once when entering via a default arg, and once per `Erun` call site.  Rather than a pre-compute pass, we memoize results keyed by `(label_sym, param_position)`.  On the first demand the body is traversed; subsequent requests hit the cache.
+
+---
+
+### Function signatures
+
+```ocaml
+val collect_uses
+  :  use_memo_info
+  -> Symbol.sym
+  -> ('a, 'b, Symbol.sym) generic_expr
+  -> use list
+
+val check_definitely_init
+  :  init_memo_info
+  -> Symbol.sym
+  -> bool                               (* already_init *)
+  -> ('a, 'b, Symbol.sym) generic_expr
+  -> bool * bool                        (* safe, init_after *)
+```
+
+### New data structures
+
+```ocaml
+(* One entry per Esave label in the memo table. *)
+type 'a esave_memo_entry = {
+  params  : (Symbol.sym * pexpr) list;            (* (param_sym, default_pe) by position *)
+  body    : (unit, unit, Symbol.sym) generic_expr;
+  results : (Symbol.sym, 'a) Pmap.map ref;        (* param_sym -> cached result, filled lazily *)
+}
+
+(* 'a = use list        for collect_uses                                    *)
+(* 'a = bool * bool     for check_definitely_init  (safe_uninit, inits_param) *)
+(*   safe_uninit:   fst (check_definitely_init ... param_sym false body)    *)
+(*   inits_param:   snd (check_definitely_init ... param_sym false body)    *)
+type 'a memo_save_info = (Symbol.sym, 'a esave_memo_entry) Pmap.map
+```
+
+A **pre-walk** (`collect_esave_defs : expr -> 'a memo_save_info`)
+populates every `Esave` label with its `params` and `body`, leaving `results`
+as `ref Pmap.empty`.  This enables `Erun` call sites to resolve forward references.
+
+`find_promotable` calls `collect_esave_defs` once to get `use_memo`, then derives
+`init_memo` by mapping each entry to a new record with a fresh `ref Pmap.empty`
+(reusing `params` and `body`).
+
+**Closedness check** (performed in `collect_esave_defs`): for each `Esave(L,
+params, body)`, perform two defensive checks, both signalling
+`failwith "Core_mem2reg: ..."` on failure:
+
+1. *Direct-alias args*: every default arg `pe` in `params` is a bare `PEsym` —
+   i.e., `is_pesym some_sym pe`.  A complex default arg would mean the param
+   cannot be a direct pointer alias.
+2. *Body closedness*: traverse `body` with a **bound-variable environment**
+   (a `Symbol.sym` set) initialised with the declared `param_sym`s.  As the
+   traversal descends into binding forms it extends the environment:
+   - `Esseq`/`Ewseq` patterns bind the LHS sym before descending into the RHS.
+   - `Elet(_, sym, e)` binds `sym` before descending into `e`.
+   - Inner `Esave(L', params', body')` binds each `param_sym'` before descending
+     into `body'` (but NOT into the default args of `params'`, which belong to
+     the outer scope).
+   Whenever a sym is *used* (as a `PEsym` in a pexpr, or as a load/store address,
+   or as an Erun argument) and is not in the current environment, call
+   `failwith "Core_mem2reg: Esave body not closed — free sym"`.
+
+   <!-- Note: Core type-checking can/should be adjusted so that Esaves are
+        checked to be closed in this way too, making this a re-enforcement of
+        a property already guaranteed by construction. -->
+
+These are defensive checks against future elaboration changes.  When both pass,
+the `NoAlias` cases in `collect_uses` and `check_definitely_init` can safely
+skip the body.
+
+> **[Correction]** Both checks were removed during implementation:
+>
+> - *Check 1 (direct-alias args)* was removed first.  The `ret_509` return label
+>   generated by the elaborator has a non-loop-carried default arg of `Specified(0)`
+>   (not a bare `PEsym`), causing a spurious failure on every function.
+>
+> - *Check 2 (body closedness)* was removed next.  Tests `0015-while_break.c`,
+>   `0016-do_break.c`, `0017-for_simple.c`, `0021-fact.c`, `0022-while_continue.c`,
+>   `0054-while_factorial5.c`, `0070-do-while1.c`, `0071-do-while2.c`,
+>   `0126-duff_device.c`, and `0317-compound-literal-lifetime.c` all failed because
+>   their loop Esave bodies freely reference function-parameter pointer syms that
+>   are not Esave params (see corrected Invariant 2 above).  A separate bug was also
+>   found: the `SeqRMW` action binds a sym in its update lambda (`a_537 => ...`)
+>   that the traversal forgot to add to the environment; this was fixed before the
+>   check was removed.
+>
+> The NoAlias shortcut is still sound, justified by the **corrected** Invariant 2
+> (the elaboration only threads CREATE-bound syms through params), not by global
+> body closedness.
+
+**One-pass sufficiency:**
+- `collect_uses`: the sentinel `results[param_sym] = []` for back-edges is exact.
+  A back-edge `Erun(L, [param])` passes the alias with no semantic value-use;
+  `[]` is the correct result, not an approximation.
+- `check_definitely_init`: no fixpoint is needed.  For an `Erun(L, args)` where
+  `args[i] = PEsym sym`, control jumps unconditionally to the body of `Esave L`
+  with `param_sym` (at position i) receiving sym's current init state.  The
+  sequential continuation after the `Erun` is unreachable, so `init_after = true`.
+  Safety is `already_init || safe_uninit` where `safe_uninit` is computed for the
+  target param.  For a back-edge `Erun` (inside the body currently being analysed),
+  the sentinel `safe_uninit = true` is used; this is an over-approximation but is
+  safe: the over-approximation of `safe_uninit` can only make the outer Eif/Ecase
+  more optimistic about the back-edge branch, while the non-back-edge exit paths
+  are computed exactly.  Concretely, if a load-before-store exists on any exit path,
+  that path still computes `safe = false` regardless of the sentinel.
+
+---
+
+### Helper: `find_single_direct_alias sym pairs`
+
+```ocaml
+(* Given an association list of (param_sym, pe) pairs, returns:
+     None           — sym does not appear as a bare PEsym in any pe
+     Some param_sym — sym appears as a bare PEsym in exactly one pe
+   Raises failwith if sym appears in more than one pe (invariant violation). *)
+let find_single_direct_alias sym pairs =
+  match List.filter_map (fun (param_sym, pe) ->
+    if is_pesym sym pe then Some param_sym else None) pairs
+  with
+  | []          -> None
+  | [param_sym] -> Some param_sym
+  | _           -> failwith "Core_mem2reg: multiple direct aliases for the same sym"
+```
+
+The Esave and Erun cases in both `collect_uses` and `check_definitely_init` follow
+the same pattern: look up the Esave entry in the memo by label, find the aliased
+`param_sym` via `find_single_direct_alias`, then either return the cached result or
+compute it (with sentinel pre-fill for back-edge termination).
+
+### Change 1: `collect_uses` — Esave case
+
+```ocaml
+| Esave ((label_sym, _), params, _body) ->
+    (* All default args are bare PEsym by the closedness check.
+       Closedness also guarantees sym is not free in body unless it is a param. *)
+    let entry = Pmap.find label_sym use_memo in
+    (match find_single_direct_alias sym (List.map (fun (p, (_, pe)) -> (p, pe)) params) with
+    | None           -> []   (* NoAlias: by closedness, not in body *)
+    | Some param_sym ->
+        (match Pmap.lookup param_sym !(entry.results) with
+        | Some cached -> cached
+        | None ->
+            entry.results := Pmap.add param_sym [] !(entry.results);  (* sentinel *)
+            let result = collect_uses use_memo param_sym entry.body in
+            entry.results := Pmap.add param_sym result !(entry.results);
+            result))
+```
+
+### Change 2: `collect_uses` — Erun case
+
+```ocaml
+| Erun (_, label_sym, args) ->
+    (* Closedness guarantees args matching sym are direct PEsym aliases. *)
+    let entry = Pmap.find label_sym use_memo in
+    (match find_single_direct_alias sym (List.combine (List.map fst entry.params) args) with
+    | None           -> []
+    | Some param_sym ->
+        (match Pmap.lookup param_sym !(entry.results) with
+        | Some cached -> cached
+        | None ->
+            entry.results := Pmap.add param_sym [] !(entry.results);
+            let result = collect_uses use_memo param_sym entry.body in
+            entry.results := Pmap.add param_sym result !(entry.results);
+            result))
+```
+
+---
+
+### Change 3: `check_definitely_init` — Esave case
+
+```ocaml
+| Esave ((label_sym, _), params, _body) ->
+    let entry = Pmap.find label_sym init_memo in
+    (match find_single_direct_alias sym (List.map (fun (p, (_, pe)) -> (p, pe)) params) with
+    | None           -> (true, already_init)  (* NoAlias: by closedness, not in body *)
+    | Some param_sym ->
+        let (safe_uninit, inits_param) =
+          match Pmap.lookup param_sym !(entry.results) with
+          | Some cached -> cached
+          | None ->
+              (* Sentinel (true, true): safe over-approximation for back-edge Eruns.
+                 Any load-before-store in the body is encountered sequentially
+                 *before* the back-edge Erun in the analysis.  That load sets
+                 safe=false, which propagates through && rules regardless of the
+                 sentinel.  The sentinel therefore cannot mask a real unsafety.
+                 Using (false,false) instead would over-conservatively reject safe
+                 loops; (true,true) is the minimal sound choice. *)
+              entry.results := Pmap.add param_sym (true, true) !(entry.results);
+              let r = check_definitely_init init_memo param_sym false entry.body in
+              entry.results := Pmap.add param_sym r !(entry.results);
+              r
+        in
+        (* already_init: the local var can be loaded during transform at this
+             default-arg use point (sym has been stored on all incoming paths).
+           safe_uninit: the parameter does not need to be initialized going in
+             (the body always stores before loading on every control-flow path).
+           The || says the transform can still proceed in either case:
+             - already_init → we can emit a Load here to pass the current value in
+             - safe_uninit  → we can drop this arg; the body self-initializes
+           inits_param: the body unconditionally writes param_sym before completion,
+             so sym's storage is definitely initialized after the Esave exits.
+           already_init || inits_param: sym is init after Esave if it was init
+             going in, or the body always initializes param_sym. *)
+        (already_init || safe_uninit, already_init || inits_param))
+```
+
+### Change 4: `check_definitely_init` — Erun case (add explicit case)
+
+```ocaml
+| Erun (_, label_sym, args) ->
+    (* Erun unconditionally jumps to Esave L's body.
+       init_after = true: the sequential continuation is unreachable.
+       Closedness guarantees all Erun args matching sym are direct PEsym aliases
+       (no structural occurrences), so no structural check is needed here. *)
+    let entry = Pmap.find label_sym init_memo in
+    let safe =
+      match find_single_direct_alias sym (List.combine (List.map fst entry.params) args) with
+      | None           -> true   (* sym not in args; vacuously safe *)
+      | Some param_sym ->
+          let (safe_uninit, _) =
+            match Pmap.lookup param_sym !(entry.results) with
+            | Some cached -> cached
+            | None ->
+                (* Sentinel (true, true): same reasoning as Esave case above. *)
+                entry.results := Pmap.add param_sym (true, true) !(entry.results);
+                let r = check_definitely_init init_memo param_sym false entry.body in
+                entry.results := Pmap.add param_sym r !(entry.results);
+                r
+          in
+          (* already_init: the local var can be loaded during transform at this
+               Erun arg use point (sym has been stored on all incoming paths).
+             safe_uninit: the parameter does not need to be initialized going in.
+             The || says the transform can still proceed in either case:
+               - already_init → we can emit a Load here to pass the current value
+               - safe_uninit  → we can drop this arg; the body self-initializes
+             init_after = true: Erun is terminal; the continuation is unreachable. *)
+          already_init || safe_uninit
+    in
+    (safe, true)
+```
+
+---
+
+### Change 5: `no_mixed_unseq_uses` — Esave case
+
+No memo needed; delegates to param directly using `find_single_direct_alias`:
+
+```ocaml
+| Esave (_, params, body) ->
+    (match find_single_direct_alias sym (List.map (fun (p, (_, pe)) -> (p, pe)) params) with
+    | None           -> true
+    | Some param_sym -> no_mixed_unseq_uses param_sym body)
+```
+
+### Change 6: `expr_writes_sym` — Esave case
+
+```ocaml
+| Esave (_, params, body) ->
+    (match find_single_direct_alias sym (List.map (fun (p, (_, pe)) -> (p, pe)) params) with
+    | None           -> false
+    | Some param_sym -> expr_writes_sym param_sym body)
+```
+
+---
+
+### Update `find_promotable`
+
+```ocaml
+let find_promotable ~also_fun_args f_sym body =
+  let use_memo  : use list memo_save_info = collect_esave_defs body in
+  let init_memo : (bool * bool) memo_save_info =
+    Pmap.map (fun { params; body; _ } ->
+      { params; body; results = ref Pmap.empty }) use_memo in
+  let creates = collect_creates ~also_fun_args body in
+  let is_promotable s =
+    List.for_all use_is_promotable (collect_uses use_memo s body)
+    && fst (check_definitely_init init_memo s false body)
+    && no_mixed_unseq_uses s body
+  in
+  ...
+```
+
+`collect_esave_defs` is a simple recursive walk that builds the `memo_save_info`
+with empty `results` maps.  `no_mixed_unseq_uses` and `expr_writes_sym` do not
+recurse through Erun and need no memo tables.
+
+---
+
+## Test cases to add under `tests/ci/`
+
+| File | Expected | Scenario |
+|---|---|---|
+| `0361-mem2reg_loop_read_preinit.c` | exits 42 | Var init'd before loop, only **read** inside loop body |
+| `0362-mem2reg_loop_escape.c` | exits 0 | Loop body calls `fn(&x)` — param escapes → NOT promoted |
+| `0363-mem2reg_nested_loops.c` | exits 3 | Outer var read inside inner loop — nested Esave alias |
+| `0364-mem2reg_loop_uninit_load.c` | UB | `int x; do { x; } while (x > 0); return x;` — uninit load inside do-while; sentinel `(true,true)` must not mask it |
+
+---
+
+## History file
+
+Per `CLAUDE.md`, copy plan to `doc/history/2026-03-18_mem2reg-esave-erun.md`.
+
+---
+
+## Verification
+
+```sh
+make && make install
+
+cd tests
+USE_OPAM='' bash run-ci.sh 2>&1 | grep -E "036[1-4]"
+
+# Full suite
+USE_OPAM='' bash run-ci.sh
+
+# Debug: check which vars are marked promotable
+cerberus --sw mem2reg --verbosity=3 tests/ci/0361-mem2reg_loop_read_preinit.c \
+  2>&1 | grep mem2reg
+```

--- a/doc/history/2026-03-20_copy-prop.md
+++ b/doc/history/2026-03-20_copy-prop.md
@@ -1,0 +1,158 @@
+# Plan: Pure Symbol Rebinding Elimination (`copy_prop` pass)
+
+## Context
+
+C-elaborated Core consistently wraps every local variable load in an intermediate
+alias binding:
+
+```core
+let weak a_511: pointer = pure(x) in   (* Ewseq — introduces alias *)
+load('signed int', a_511)              (* Load0(a_511) — load via alias *)
+```
+
+These `let weak alias = pure(sym)` bindings are semantically trivial (they copy a
+pure value into a fresh name with no memory or sequencing effect), but they
+pollute the IR and impede other analyses.  In particular, as documented in
+`doc/history/2026-03-20_mem2reg-weak-init.md`, the mem2reg
+`check_definitely_init` analysis never sees a direct `Load0(PEsym sym)` because
+all loads go through such aliases — making its safety check vacuous.  Eliminating
+the aliases before mem2reg runs would restore the full precision of that analysis.
+
+The pass performs **copy propagation on pure symbol rebindings**: it finds
+bindings of the form `let alias = pure(sym)` (in any of the three Core binding
+forms that can wrap a pure expression), propagates `sym` for `alias` throughout
+the continuation, and drops the binding entirely.
+
+---
+
+## Patterns eliminated
+
+The pass handles two families of binding:
+
+### Simple case — bare pure-symbol RHS
+
+The RHS of the binding is exactly `pure(sym)`.  The binding is **dropped
+entirely** (the `Ewseq`/`Esseq`/`Elet` wrapper is removed):
+
+| Binding form | OCaml pattern |
+|---|---|
+| Weak-sequenced | `Ewseq(CaseBase(Some alias), Expr(Epure(Pexpr(PEsym src))), body)` |
+| Strong-sequenced | `Esseq(CaseBase(Some alias), Expr(Epure(Pexpr(PEsym src))), body)` |
+| Pure let in expr | `Elet(CaseBase(Some alias), Pexpr(PEsym src), body_expr)` |
+| Pure let in pexpr | `PElet(CaseBase(Some alias), Pexpr(PEsym src), body_pexpr)` |
+
+Wildcard variants (`CaseBase(None, _)`) on a pure-sym RHS are also dropped (no
+alias to propagate, and a pure expression has no side effects).
+
+### Extended case — effectful RHS ending in pure(sym)
+
+The RHS has side effects (stores, loads, etc.) but its **tail value** — the
+result produced on every non-diverging path — is `pure(sym)`.
+
+The canonical example is the compound literal from `2026-03-20_mem2reg-weak-init.md`:
+
+```core
+(* Before: a_510 is bound to a complex chain ending in pure(a_508) *)
+let weak a_510: pointer =
+  let weak a_509: loaded integer = pure(Specified(42)) in
+  let weak _: unit = store('signed int', a_508, a_509) in
+  pure(a_508) in          (* <-- tail is pure(a_508) *)
+load('signed int', a_510)
+```
+
+```core
+(* After: alias changed to wildcard, a_510 replaced by a_508 in body *)
+let weak _: pointer =
+  let weak a_509: loaded integer = pure(Specified(42)) in
+  let weak _: unit = store('signed int', a_508, a_509) in
+  pure(a_508) in
+load('signed int', a_508)   (* Load0 now sees a_508 directly *)
+```
+
+The **binding is kept** (its side effects must still execute) but the **pattern is
+changed to a wildcard** and `alias` is substituted with `src` in `body`.
+
+### `tail_sym` analysis
+
+```ocaml
+let rec tail_sym (Expr (_, e_)) =
+  match e_ with
+  | Epure (Pexpr (_, _, PEsym s))       -> Some s
+  | Ewseq (_, _, e2) | Esseq (_, _, e2) -> tail_sym e2
+  | Elet  (_, _, e2)                    -> tail_sym e2
+  | Ebound e | Eannot (_, e)            -> tail_sym e
+  | _ -> None
+```
+
+`tail_sym` is conservative: it returns `None` for any branching node.
+
+---
+
+## New files
+
+```
+ocaml_frontend/rewriters/copy_propagation.mli
+ocaml_frontend/rewriters/copy_propagation.ml
+```
+
+## Switch
+
+- `SW_copy_prop` added to `cerb_switch` type in `switches.ml` + `switches.mli`
+- `"copy_prop"` mapped in `read_switch`
+- Added to simple-equality arm of `pred`
+
+## Pipeline
+
+Inserted **before** `Core_mem2reg` so that aliases are inlined before mem2reg runs.
+
+## Testing
+
+- New CI tests: 0366–0373
+- Phase 1 regression script: `tests/run-copy-prop-phase1.sh`
+- Phase 2 elimination check script: `tests/run-copy-prop-phase2.sh`
+
+---
+
+## Post-implementation addendum
+
+### Design changes from plan
+
+**Binding nodes are never dropped.**  The plan called for dropping the binding
+wrapper entirely in the simple case.  During implementation this caused test
+failures: UB source locations in `.undef.c` expected output changed because the
+`Ewseq`/`Esseq` node carrying the location annotation was removed.  The fix is to
+always replace the named pattern with a wildcard (`CaseBase(None, cbty)`) and keep
+the binding node, preserving its annotations.  This applies uniformly to both the
+simple and extended cases for `Ewseq`/`Esseq`/`Elet`/`PElet`.
+
+**`tail_sym` uses a binder accumulator.**  The plan's `tail_sym` could return a
+symbol that was itself bound *inside* the RHS (e.g. `let a = (let b = load(x) in
+pure(b))` — `b` is the tail sym but is out-of-scope in the body).  Substituting
+such a symbol in the body is a scope error caught by `--typecheck-core`.
+
+The fix folds the out-of-scope check into `tail_sym` itself via a `binders`
+accumulator: as the function follows the linear chain toward the tail, it records
+every symbol introduced by a `CaseBase(Some s, _)` pattern along that path.  At
+the leaf, if the tail sym appears in `binders` the function returns `None`.  This
+is a single-pass check with no separate `is_bound_in_expr` traversal.
+
+**Uniform `tail_sym` call sites.**  Because `tail_sym` already handles the base
+case `Epure(PEsym s)` (it returns `Some s` when `binders` is empty and `s` is not
+locally bound), the `propagate_expr` match arms for `Ewseq`/`Esseq` no longer need
+to special-case the bare `pure(sym)` form separately.  A single `match tail_sym e1
+with` covers both the simple and extended cases.
+
+### Test results
+
+| Suite | Passed | Failed |
+|---|---|---|
+| copy_prop phase 1 (regression, 208 tests) | 208 | 0 |
+| copy_prop phase 2 (elimination counts) | 9 | 0 |
+| mem2reg phase 1 (regression, 188 tests) | 188 | 0 |
+| mem2reg phase 2 (elimination counts) | 21 | 0 |
+| CI full suite | 208 | 0 |
+
+Key integration result: `--sw copy_prop --sw mem2reg` on `0373-copy_prop_and_mem2reg.c`
+(compound literal `int x = (int){42}`) reduces `create()` count from 2 (mem2reg alone)
+to 0 (copy_prop + mem2reg), confirming that copy_prop exposes the compound literal
+pointer directly to mem2reg's `check_definitely_init` analysis.

--- a/doc/history/2026-03-20_mem2reg-weak-init.md
+++ b/doc/history/2026-03-20_mem2reg-weak-init.md
@@ -274,3 +274,114 @@ cd tests
 USE_OPAM='' bash run-mem2reg-phase1.sh
 USE_OPAM='' bash run-mem2reg-phase2.sh
 ```
+
+---
+
+## Post-implementation addendum: Write_kind does not affect promotability counts
+
+After implementing the refactoring and adding `0365-mem2reg_compound_lit.c`, it
+was verified empirically (via `-d 3` debug output) that the old and new analyses
+produce **identical** promotable-variable counts on every test including `0365`.
+This section records why, and what would be needed to observe a real difference.
+
+### The alias indirection invariant
+
+C-generated Core **never** emits a bare `Load0(_, PEsym sym, _)` for a local
+variable.  Every load goes through an intermediate alias:
+
+```core
+let weak a_511: pointer = pure(x) in   (* Ewseq(a_511, Epure(PEsym x), …) *)
+load('signed int', a_511)              (* Load0(a_511) — a_511 ≠ x        *)
+```
+
+`collect_uses` has a dedicated arm that recognises this
+`Ewseq(alias, Epure(PEsym sym), body)` pattern and follows it, classifying the
+load as `Use_load` for `sym`.  `check_definitely_init` has **no such arm**: it
+only checks `Load0(_, PEsym sym, _)` directly.  Because the address in the load
+is always the alias (`a_511`), not `sym` itself, `check_definitely_init` falls
+through to the catch-all for every load of a C local and unconditionally returns
+`(true, of_bool strongly_init)`.
+
+Consequence: the `Ewseq` rule in `check_definitely_init` — the only place where
+old and new analyses differ — **never fires** on C-elaborated Core.  The
+Write_kind refactoring is therefore a soundness fix for a pattern that cannot
+currently arise, not an observable behavioural change.
+
+### Why `0365-mem2reg_compound_lit.c` does not demonstrate the difference
+
+The C source and its Core IR make this concrete:
+
+```c
+int main(void) {
+    int x = (int){ 42 };
+    return x;
+}
+```
+
+```core
+proc main (): eff loaded integer :=
+  let strong a_508: pointer = create(Ivalignof('signed int'), 'signed int') in
+  let strong x: pointer = create(Ivalignof('signed int'), 'signed int') in
+  let strong a_507: loaded integer =
+    bound(
+      let weak a_510: pointer =
+        let weak a_509: loaded integer = pure(Specified(42)) in
+        let weak _: unit = store('signed int', a_508, a_509) in
+        pure(a_508) in
+      load('signed int', a_510)
+    ) in
+  store('signed int', x, conv_loaded_int('signed int', a_507)) ;
+  let strong a_512: loaded integer =
+    bound(
+      let weak a_511: pointer = pure(x) in
+      load('signed int', a_511)
+    ) in
+  kill('signed int', x) ;
+  run ret_506(conv_loaded_int('signed int', a_512)) ;
+  kill('signed int', x) ;
+  kill('signed int', a_508) ;
+  …
+```
+
+Two create-bound pointers appear: `a_508` (the compound-literal temporary) and
+`x` (the destination variable).
+
+**`a_508` is not promotable** — but not because of `check_definitely_init`.
+Its uses are classified by `collect_uses` as follows:
+
+- `store(a_508, a_509)` → `Use_store` ✓
+- `pure(a_508)` at the tail of the nested Ewseq chain → `sym_occurs_in_pexpr`
+  returns true inside an `Epure` that does **not** match the flat
+  `Ewseq(alias, Epure(PEsym sym), body)` alias pattern (it is the tail of a
+  three-level Ewseq chain, not a direct binding) → `Use_other` ✗
+
+`Use_other` disqualifies `a_508` before `check_definitely_init` is called.
+
+**`x` is promotable** in both old and new analysis:
+
+- `store(x, …)` → `Use_store` ✓
+- `let weak a_511 = pure(x) in load(a_511)` → flat alias pattern → `Use_load` ✓
+- `kill(x)` → `Use_kill` ✓
+
+`check_definitely_init` for `x` sees only catch-all nodes (no direct
+`Load0(PEsym x)`), so it always returns `safe = true`.
+
+Debug output (both old and new):
+```
+(debug 3): [mem2reg] main: 1 promotable: [x]
+```
+
+### What would actually trigger the difference
+
+The Write_kind `Ewseq` rule would change behaviour only for a Core pattern of
+the form:
+
+```core
+let weak _ = store(sym, val) in   (* Store0(Paction Pos, sym, val) in Ewseq e1 *)
+load(sym)                         (* Load0(sym) directly — no alias             *)
+```
+
+with `sym` itself as the load address.  Such a pattern does not arise from the
+current C→Core elaboration.  A future IR change, a hand-written Core test, or a
+non-C front-end could produce it; the Write_kind analysis is already correct for
+that case.

--- a/doc/history/2026-03-20_mem2reg-weak-init.md
+++ b/doc/history/2026-03-20_mem2reg-weak-init.md
@@ -1,0 +1,276 @@
+# Plan: Refactor `check_definitely_init` to use `write_kind`
+
+## Context
+
+`check_definitely_init` currently returns `bool * bool` where the second bool means
+"sym is definitely initialized after this expression."  This conflates two distinct
+notions of initialization that matter for correctness:
+
+- **Strong** (`Paction Pos` store, or Esseq-sequenced write): the store is committed
+  before any continuation that follows with `Esseq`.
+- **Weak** (`Paction Neg` store in an `Ewseq` bound): the store is *unsequenced* w.r.t.
+  the `Ewseq` continuation, so the continuation cannot rely on it.
+
+A `Load0` or `SeqRMW` is only safe if the variable was **strongly** initialized.
+The existing `bool` cannot express this distinction, causing the analysis to be
+either unsound (if Weak is treated as Strong) or overly conservative (if Weak is
+treated as No_write).
+
+---
+
+## New module
+
+```ocaml
+module Write_kind = struct
+  type t = No_write | Weak | Strong
+
+  (* || = join: least upper bound — goes up the lattice *)
+  let (||) a b = match a, b with
+    | No_write, x | x, No_write -> x
+    | Strong,   _ | _, Strong   -> Strong
+    | Weak,     Weak             -> Weak
+
+  (* && = meet: greatest lower bound — goes down the lattice *)
+  let (&&) a b = match a, b with
+    | Strong,   x | x, Strong   -> x
+    | No_write, _ | _, No_write -> No_write
+    | Weak,     Weak             -> Weak
+
+  let of_bool = function true -> Strong | false -> No_write
+
+  let is_strong   = function Strong   -> true | _ -> false
+  let is_weak     = function Weak     -> true | _ -> false
+  let is_no_write = function No_write -> true | _ -> false
+end
+```
+
+Lattice: `No_write < Weak < Strong`. `(||)` is join (goes up); `(&&)` is meet (goes down).
+
+---
+
+## Signature change
+
+The `already_init` parameter is renamed to `strongly_init` (it remains a `bool`).
+It is only ever `true` (sym is strongly initialized on entry) or `false`.
+When converting a `Write_kind.t` result to a `bool` to pass as `strongly_init`
+to a sub-expression, use `Write_kind.is_strong`, `is_weak`, or `is_no_write`
+as appropriate — never a generic `to_bool`.
+
+```ocaml
+val check_definitely_init :
+  (bool * Write_kind.t) memo_save_info ->
+  Symbol.sym ->
+  bool ->                    (* strongly_init: sym is strongly initialized on entry *)
+  (_, _, _) generic_expr ->
+  bool * Write_kind.t        (* (safe, init_after) *)
+```
+
+The `init_memo` type annotation changes from `(bool * bool) memo_save_info`
+to `(bool * Write_kind.t) memo_save_info`.
+
+---
+
+## Case-by-case rules
+
+### Leaf actions
+
+`strongly_init` is a `bool`. Where the existing code returned `already_init` as
+`init_after`, now use `Write_kind.of_bool strongly_init`.
+
+| Action | Condition | Returns |
+|--------|-----------|---------|
+| `Store0 (Paction Pos, _, addr, _, _)` when `is_pesym sym addr` | — | `(true, Write_kind.Strong)` |
+| `Store0 (Paction Neg, _, addr, _, _)` when `is_pesym sym addr` | — | `(true, Write_kind.Weak)` |
+| `Load0 (_, addr, _)` when `is_pesym sym addr` | — | `(strongly_init, Write_kind.of_bool strongly_init)` |
+| `Kill (_, addr)` when `is_pesym sym addr` | — | `(true, Write_kind.No_write)` |
+| `SeqRMW (_, _, addr, _, _)` when `is_pesym sym addr` | — | `(strongly_init, Write_kind.Strong)` |
+| anything else | — | `(true, Write_kind.of_bool strongly_init)` |
+
+### `Esseq(_, e1, e2)` — strong sequencing
+
+Strong sequencing promotes Weak writes to Strong before threading into e2:
+a Neg store that is strongly sequenced IS committed before e2.
+Use `not (Write_kind.is_no_write ia1)` to convert: any initialization (Weak or
+Strong) becomes `true`; No_write stays `false`.
+
+```ocaml
+let (s1, ia1) = check_definitely_init memo sym strongly_init e1 in
+let (s2, ia2) = check_definitely_init memo sym (not (Write_kind.is_no_write ia1)) e2 in
+(s1 && s2, ia2)
+```
+
+### `Ewseq(_, e1, e2)` — weak sequencing
+
+Only a Strong write in e1 is sequenced before e2. Weak writes are unsequenced, so
+e2 sees only `strongly_init`.
+
+```ocaml
+let (s1, ia1) = check_definitely_init memo sym strongly_init e1 in
+let (s2, ia2) = check_definitely_init memo sym (Write_kind.is_strong ia1 || strongly_init) e2 in
+(s1 && s2, Write_kind.(ia1 || ia2))
+```
+
+### `Eunseq arms` — unsequenced
+
+All arms see `strongly_init`. `init_after` is the **meet** of all arms (all paths
+must initialize, and the weakest strength wins).
+
+```ocaml
+let results = List.map (check_definitely_init memo sym strongly_init) arms in
+let safe    = List.for_all (fun (s, _) -> s) results in
+let ia      = List.fold_left Write_kind.(fun acc (_, k) -> acc && k) Write_kind.Strong results in
+(safe, ia)
+```
+
+### `Eif(_, et, ef)` and `Ecase(_, arms)` — conditional
+
+Both branches see `strongly_init`. `init_after` is the **meet** across branches.
+
+```ocaml
+(* Eif *)
+let (st, iat) = check_definitely_init memo sym strongly_init et in
+let (sf, iaf) = check_definitely_init memo sym strongly_init ef in
+(st && sf, Write_kind.(iat && iaf))
+
+(* Ecase: fold Write_kind.(&&) over all arm results, starting from Write_kind.Strong *)
+```
+
+### `Esave` — loop header
+
+Sentinel changes from `(true, true)` to `(true, Write_kind.Strong)` (same reasoning;
+Strong is the over-approximating choice for the fixpoint sentinel).
+
+Safety and init-after at the Esave call site:
+
+```ocaml
+let safe      = strongly_init || safe_uninit in
+let init_after = Write_kind.(of_bool strongly_init || inits_param) in
+(safe, init_after)
+```
+
+### `Erun` — loop back-edge (terminal)
+
+```ocaml
+let safe = strongly_init || safe_uninit in
+(safe, Write_kind.Strong)   (* continuation unreachable; Strong is vacuously correct *)
+```
+
+### `Elet / Ebound / Eannot` — transparent
+
+```ocaml
+check_definitely_init memo sym strongly_init inner_e
+```
+
+### Catch-all
+
+```ocaml
+(true, Write_kind.of_bool strongly_init)
+```
+
+---
+
+## Call site changes
+
+In `find_promotable`:
+
+```ocaml
+(* init_memo type annotation *)
+let init_memo : (bool * Write_kind.t) memo_save_info = ...
+
+(* initial call: sym is not strongly initialized at function entry *)
+fst (check_definitely_init init_memo s false body)
+```
+
+---
+
+## Critical files
+
+- `ocaml_frontend/rewriters/core_mem2reg.ml` — all changes live here
+
+---
+
+## Verification
+
+```sh
+make && make install
+cerberus --sw mem2reg file.c      # check a local C file
+cd tests && USE_OPAM='' bash run-ci.sh
+```
+
+---
+
+## Rigorous Testing of Write_kind
+
+### Background: what the old vs new analysis does differently
+
+The only behavioural change relative to the old `bool`-based analysis is in the
+`Ewseq` case:
+
+| Scenario | Old (bool) | New (Write_kind) |
+|---|---|---|
+| `Store0(Paction Pos)` in Ewseq e1, `Load0` in e2 | e2 sees `already_init` (false) → **NOT safe** → not promoted | e2 sees `is_strong Strong = true` → **safe** → promoted |
+| `Store0(Paction Neg)` in Ewseq e1, `Load0` in e2 | e2 sees `already_init` (false) → not safe | e2 sees `is_strong Weak = false` → not safe (correct) |
+| Any store in Esseq e1, `Load0` in e2 | e2 sees `ia1 = true` → safe | e2 sees `not (is_no_write ?) = true` → same |
+
+The canonical C construct that generates `Store0(Paction Pos)` inside `Ewseq e1`
+followed by `Load0` in `e2` is a **compound literal**: `(T){ expr }` creates an
+anonymous temporary whose initialization store appears as `Ewseq(_, Store0(Pos,
+ptr_tmp, val), Load0(ptr_tmp))` in the Core IR.
+
+### New test: `0365-mem2reg_compound_lit.c`
+
+```c
+/* Tests that a local variable initialised via a compound literal is
+   promotable.  The Core IR for (int){ 42 } contains:
+       Ewseq(_, Store0(Paction Pos, ptr_tmp, 42), Load0(ptr_tmp))
+   Under the old bool-based analysis, Load0 in the Ewseq e2 saw
+   `already_init = false` (init in e1 was not forwarded) → NOT promotable.
+   Under the new Write_kind analysis, Strong from e1 propagates to e2 → IS
+   promotable.  This is the "strong write in weak sequence" test case. */
+int main(void) {
+    int x = (int){ 42 };
+    return x;
+}
+```
+
+- **Expected output**: `Defined {value: "Specified(42)", stdout: "", stderr: "", blocked: "false"}`
+- **Phase 2 stub count**: determined empirically after implementation (see below)
+- **Phase 2 fully-working target**: 0 (both compound-literal temp and x are promotable)
+
+### Steps to add the test
+
+1. Write `tests/ci/0365-mem2reg_compound_lit.c` with the content above.
+2. Write `tests/ci/expected/0365-mem2reg_compound_lit.expected` with the expected output.
+3. Determine the phase 2 stub create count:
+   ```sh
+   cerberus --nolibc --pp core --sw mem2reg tests/ci/0365-mem2reg_compound_lit.c \
+     | grep -c 'create('
+   ```
+4. Add to `elim_expected` in `tests/run-mem2reg-phase2.sh`:
+   ```bash
+   [0365-mem2reg_compound_lit.c]=N   # N from step 3
+   ```
+5. Update the fully-working-pass comment at the top of `run-mem2reg-phase2.sh`
+   to include `0365=0`.
+
+### Write the plan to `doc/history/`
+
+As per `CLAUDE.md`, copy this plan to:
+```
+doc/history/2026-03-20_write-kind-refactor.md
+```
+
+### Full verification sequence
+
+```sh
+make && make install
+
+# Determine create count for new test
+cerberus --nolibc --pp core --sw mem2reg \
+  tests/ci/0365-mem2reg_compound_lit.c | grep -c 'create('
+
+# Run both mem2reg phases
+cd tests
+USE_OPAM='' bash run-mem2reg-phase1.sh
+USE_OPAM='' bash run-mem2reg-phase2.sh
+```

--- a/doc/history/2026-03-21_sequentialisable.md
+++ b/doc/history/2026-03-21_sequentialisable.md
@@ -1,0 +1,218 @@
+# Plan: Unify promotability analyses into `sequentialisable`
+
+## Context
+
+`core_mem2reg.ml` previously ran three separate analyses on a procedure body to decide
+if a Create-bound pointer `sym` is promotable:
+
+1. `check_definitely_init` — checks that no load-before-store occurs on any path and
+   tracks `Write_kind` (No_write / Weak / Strong) across branches.
+2. `expr_writes_sym` — helper for (3): predicate, "does this sub-expr contain a Store0
+   to sym?".
+3. `no_mixed_unseq_uses` — checks that if sym appears in a write arm of an `Eunseq`,
+   no other arm also mentions sym (would hide a sequencing violation).
+
+All three traverse the same IR and share overlapping logic.  They are collapsed into
+one abstract-interpretation function `sequentialisable` that returns the event sequence
+the expression performs on `sym` together with the env (init state) of `sym` after
+the expression.
+
+---
+
+## New types
+
+### `module Mem_event`
+
+```ocaml
+module Mem_event = struct
+  type t = Pos_store | Neg_store | Load | Kill
+end
+```
+
+No pexpr payload.  Values are tracked directly in `env`.
+
+### `env`
+
+```ocaml
+type env = Uninit | Init of pexpr | DelayedInit of pexpr | Killed
+```
+
+- `Uninit` — no store observed yet on this path.
+- `Init pe` — sym was last stored with committed value `pe`.
+- `DelayedInit pe` — sym was stored (Neg polarity, Ewseq e1) but not yet committed;
+  subsequent e2 must not observe this.
+- `Killed` — sym's allocation was freed.
+
+### Exceptions
+
+```ocaml
+exception Not_sequentialisable
+exception Load_from_uninit
+```
+
+`Not_sequentialisable` is raised when:
+- Any action on sym is encountered with `env = DelayedInit _`.
+- An `Eunseq` has ≥2 arms with events on sym, or mixed read/write arms.
+
+`Load_from_uninit` is raised specifically when `Load0` or `SeqRMW` encounters
+`env = Uninit`.  It is caught by `esave_needs_init` to detect that the Esave body
+needs sym initialized on entry; if the outer env is `Init _` this is recoverable.
+
+---
+
+## `sequentialisable` signature
+
+```ocaml
+val sequentialisable :
+  seq_memo ->
+  Symbol.sym -> env ->
+  (unit, unit, Symbol.sym) generic_expr ->
+  (Mem_event.t list * env) option
+```
+
+- `None` — the expression's control flow ends in an `Erun` on all paths (vacuously OK).
+- `Some (events, env')` — events observed on sym and the env after the expression.
+- Raises `Not_sequentialisable` on any conflict.
+
+Uses `let ( let* ) = Option.bind`.
+
+---
+
+## Memoization: `seq_memo`
+
+Reuses the polymorphic `'a esave_memo_entry` / `'a memo_save_info` machinery with
+`'a = bool * (Mem_event.t list * env) option`:
+
+```ocaml
+(* seq_memo_result: (init_needed, body_result)
+     init_needed – false: body self-initialises; true: needs Init _ on entry
+     body_result – None while analysis in progress (sentinel) or when all body
+                   paths end in Erun; Some (ev, env') after a non-Erun result *)
+type seq_memo_result = bool * (Mem_event.t list * env) option
+type seq_memo = seq_memo_result memo_save_info
+```
+
+Built the same way as `init_memo` was:
+
+```ocaml
+let seq_memo : seq_memo =
+  Pmap.map (fun { params; body; _ } ->
+    { params; body; results = ref (Pmap.empty Symbol.compare_sym) }) use_memo
+```
+
+---
+
+## Case-by-case design
+
+### `Eaction`
+
+All actions on sym first check: if `env = DelayedInit _`, raise `Not_sequentialisable`.
+
+| Action | Condition | Events | `env'` |
+|---|---|---|---|
+| `Store0(_, _, addr, val_pe, _)` Pos | `is_pesym sym addr` | `[Pos_store]` | `Init val_pe` |
+| `Store0(_, _, addr, val_pe, _)` Neg | `is_pesym sym addr` | `[Neg_store]` | `DelayedInit val_pe` |
+| `Load0(_, addr, _)` | `is_pesym sym addr`, `env = Init _` | `[Load]` | `env` |
+| `Load0` | `is_pesym sym addr`, `env = Uninit` | raise `Load_from_uninit` | — |
+| `Load0` | `is_pesym sym addr`, other non-Init env | raise `Not_sequentialisable` | — |
+| `Kill(_, addr)` | `is_pesym sym addr` | `[Kill]` | `Killed` |
+| `SeqRMW(_, _, addr, tmp_sym, upd_pe)` | `is_pesym sym addr`, `env = Init pe` | `[Load; Pos_store]` | `Init (subst tmp_sym pe upd_pe)` |
+| `SeqRMW` | `is_pesym sym addr`, `env = Uninit` | raise `Load_from_uninit` | — |
+| `SeqRMW` | `is_pesym sym addr`, other non-Init env | raise `Not_sequentialisable` | — |
+| other | — | `[]` | `env` |
+
+### `Esseq (_, e1, e2)`
+
+Strong sequencing commits any store in e1 before e2 begins, so a `DelayedInit`
+result from e1 is promoted to `Init` for e2.
+
+```ocaml
+let* (ev1, env1) = sequentialisable seq_memo sym env e1 in
+let env1' = match env1 with DelayedInit pe -> Init pe | _ -> env1 in
+let* (ev2, env2) = sequentialisable seq_memo sym env1' e2 in
+Some (ev1 @ ev2, env2)
+```
+
+### `Ewseq (_, e1, e2)`
+
+If e1 produces `DelayedInit`, any subsequent action on sym in e2 will raise
+`Not_sequentialisable` naturally (since all actions check `DelayedInit` first).
+We thread `env1` directly into e2 without any special-casing.
+
+```ocaml
+let* (ev1, env1) = sequentialisable seq_memo sym env e1 in
+let* (ev2, env2) = sequentialisable seq_memo sym env1 e2 in
+Some (ev1 @ ev2, env2)
+```
+
+### `Eif` and `Ecase`
+
+Pass the same incoming `env` into each branch; combine results by checking that events
+agree and envs are compatible.
+
+`combine_branches pe_cond r1 r2`:
+- Both `None` → `None`
+- One `None`, other `Some result` → `Some result`
+- Both `Some (ev1, env1)` and `Some (ev2, env2)`:
+  - Events are appended (over-approximation).
+  - Envs: `Uninit+Uninit→Uninit`, `Killed+Killed→Killed`, `Init/Init→Init(PEif)`,
+    `Delayed/Delayed→Delayed(PEif)`, `Init/Delayed→Delayed(PEif)`,
+    otherwise raise.
+  - Return `Some (ev1, combined_env)`
+
+### `Eunseq arms`
+
+Collect arms with events; if all reads → OK; if exactly one write arm → OK; else raise.
+
+### `Esave` and `Erun`
+
+Shared helper `esave_needs_init seq_memo sym env label_sym param_sym`:
+- Looks up `(label_sym, param_sym)` in memo.
+- If `init_needed=true` and outer `env ≠ Init _`: raise `Load_from_uninit`.
+- If not memoised: write sentinel `(false, None)`, run with `Uninit`, catch
+  `Load_from_uninit`, re-run with outer `env` and mark `init_needed=true`.
+
+---
+
+## Removals
+
+| Removed | Replaced by |
+|---|---|
+| `module Write_kind` | `env` + `Mem_event` |
+| `check_definitely_init` | `sequentialisable` |
+| `expr_writes_sym` | events-list inspection |
+| `no_mixed_unseq_uses` | `Eunseq` case of `sequentialisable` |
+| `init_memo` in `find_promotable` | `seq_memo` |
+
+---
+
+## Post-implementation addendum
+
+### Implementation notes
+
+**`sym_occurs_in_expr` removal**: `sym_occurs_in_expr` and `sym_occurs_in_action`
+were previously defined as a mutually-recursive `and` chain with
+`sym_occurs_in_pexpr`.  After removing `no_mixed_unseq_uses`, neither is referenced
+by any other function in the file (only `sym_occurs_in_action` is still needed by
+`classify_action`).  Removed `sym_occurs_in_expr` entirely and detached
+`sym_occurs_in_action` from the `and` chain, making it a standalone `let`.
+
+**`combine_branches` signature**: needs `pe_cond : pexpr` to construct `PEif` nodes
+when combining `Init`/`DelayedInit` envs from branches.  For `Ecase`, the case
+discriminant `pe` is used as condition for all combination steps — semantically
+approximate but fine for analysis (only constructor of env matters).
+
+**`Ewseq` precision**: the new design is slightly more conservative than
+`check_definitely_init` for one pattern: if sym is `Init` before `Ewseq e1`, and e1
+does a Neg/weak store, the old code kept `strongly_init=true` for e2.  The new code
+threads `DelayedInit` into e2, and any action there raises `Not_sequentialisable`.
+This pattern does not appear in elaborated C code for normal stack variables, so no
+test regression was observed.
+
+### Test results (all passing)
+
+- `run-mem2reg-phase1.sh`: 188 passed, 0 failed
+- `run-mem2reg-phase2.sh`: 21 passed, 0 failed
+- `run-copy-prop-phase1.sh`: 208 passed, 0 failed
+- `run-copy-prop-phase2.sh`: 9 passed, 0 failed
+- `run-ci.sh`: 208 passed, 0 failed

--- a/doc/history/2026-03-23_copy-prop-pexpr-env.md
+++ b/doc/history/2026-03-23_copy-prop-pexpr-env.md
@@ -1,0 +1,213 @@
+# Copy Propagation: Generalise env from `sym → sym` to `sym → pexpr`
+
+## Context
+
+`copy_propagation.ml` eliminates trivial bindings by substituting aliases with their source values. Its environment currently maps `sym → sym`, meaning only sym-to-sym aliases can be propagated. The goal is to generalise the env to `sym → pexpr` so that non-sym pure values (e.g. `Specified(0)`, compound pure expressions) found at the tails of effectful RHS expressions can also be propagated into body uses.
+
+The tuple-pattern / `Eunseq` handling is deferred to a later task.
+
+## Critical File
+
+`ocaml_frontend/rewriters/copy_propagation.ml` — only file modified.
+
+Also update: `ocaml_frontend/rewriters/copy_propagation.mli` (doc comment).
+
+---
+
+## Implementation Plan
+
+### 1. Env type change
+
+```ocaml
+(* Old *)
+type env = (Symbol.sym, Symbol.sym) Pmap.map
+(* New *)
+type env = (Symbol.sym, pexpr) Pmap.map
+(* pexpr = (unit, Symbol.sym) generic_pexpr, in scope via `open Core` *)
+```
+
+`apply_env` is removed. Callers use `Pmap.lookup s env` directly.
+
+```ocaml
+let empty_env : env = Pmap.empty Symbol.compare_sym
+let extend_env env alias pe = Pmap.add alias pe env
+```
+
+---
+
+### 2. New helpers: `pexpr_safe` and `binders_of_pat`
+
+`pexpr_safe binders pe` — conservative check that none of `pe`'s free syms are in `binders`. Complex forms (`PEif`, `PElet`, `PEcase`, `PEconstrained`) return `false` to avoid needing a full free-variable analysis.
+
+```ocaml
+let rec pexpr_safe binders (Pexpr (_, _, pe_)) =
+  match pe_ with
+  | PEsym s ->
+      not (List.exists (fun b -> Symbol.compare_sym s b = 0) binders)
+  | PEval _ | PEimpl _ | PEundef _ | PEerror _ -> true
+  | PEctor (_, pes)            -> List.for_all (pexpr_safe binders) pes
+  | PEnot pe1                  -> pexpr_safe binders pe1
+  | PEop (_, pe1, pe2)
+  | PEwrapI (_, _, pe1, pe2)
+  | PEcatch_exceptional_condition (_, _, pe1, pe2)
+  | PEare_compatible (pe1, pe2)
+  | PEarray_shift (pe1, _, pe2)  -> pexpr_safe binders pe1 && pexpr_safe binders pe2
+  | PEmemberof (_, _, pe1)
+  | PEmember_shift (pe1, _, _)
+  | PEconv_int (_, pe1)
+  | PEis_scalar pe1 | PEis_integer pe1
+  | PEis_signed pe1 | PEis_unsigned pe1
+  | PEbmc_assume pe1 | PEcfunction pe1
+  | PEunion (_, _, pe1)          -> pexpr_safe binders pe1
+  | PEmemop (_, pes) | PEcall (_, pes) -> List.for_all (pexpr_safe binders) pes
+  | PEstruct (_, fields)         ->
+      List.for_all (fun (_, pe1) -> pexpr_safe binders pe1) fields
+  | PEif _ | PElet _ | PEcase _ | PEconstrained _ -> false  (* conservative *)
+```
+
+```ocaml
+let rec binders_of_pat (Pattern (_, pat_)) =
+  match pat_ with
+  | CaseBase (None, _)   -> []
+  | CaseBase (Some s, _) -> [s]
+  | CaseCtor (_, pats)   -> List.concat_map binders_of_pat pats
+```
+
+---
+
+### 3. Replace `tail_sym`/`tail_sym_acc` with `tail_pexpr`/`tail_pexpr_acc`
+
+Returns `pexpr option` instead of `sym option`. At the `Epure pe` leaf, any safe pexpr passes (not just `PEsym`).
+
+```ocaml
+let rec tail_pexpr_acc binders (Expr (_, e_)) =
+  match e_ with
+  | Epure pe ->
+      if pexpr_safe binders pe then Some pe else None
+  | Ewseq (pat, _, e2) | Esseq (pat, _, e2) ->
+      tail_pexpr_acc (binders_of_pat pat @ binders) e2
+  | Elet (pat, _, e2) ->
+      tail_pexpr_acc (binders_of_pat pat @ binders) e2
+  | Ebound e | Eannot (_, e) ->
+      tail_pexpr_acc binders e
+  | _ -> None
+
+let tail_pexpr e = tail_pexpr_acc [] e
+```
+
+Key differences from `tail_sym_acc`:
+- `Epure pe` leaf returns `Some pe` for any safe pexpr (not just `PEsym s`).
+- Uses `binders_of_pat` which handles `CaseCtor` tuple patterns (old code only tracked `CaseBase(Some s)` binders).
+
+---
+
+### 4. Update `propagate_pexpr`
+
+**`PEsym s`** — return the stored pexpr directly if found:
+```ocaml
+| PEsym s ->
+    (match Pmap.lookup s env with
+     | Some pe -> pe
+     | None    -> Pexpr (annots, bty, PEsym s))
+```
+
+**`PElet CaseBase(Some alias)` with `PEsym src` RHS** — look up `src` in env to get its pexpr, store that for `alias`:
+```ocaml
+| PElet (Pattern (p_annots, CaseBase (Some alias, cbty)),
+         (Pexpr (_, _, PEsym src) as rhs), body) ->
+    let pe_src = match Pmap.lookup src env with
+                 | Some pe -> pe
+                 | None    -> rhs in
+    Pexpr (annots, bty,
+      PElet (Pattern (p_annots, CaseBase (None, cbty)),
+             propagate_pexpr env rhs,
+             propagate_pexpr (extend_env env alias pe_src) body))
+```
+
+The existing `_ ->` fallthrough arm is unchanged (don't propagate non-PEsym `Elet` RHS).
+
+---
+
+### 5. Update `propagate_expr`
+
+**`Ewseq`/`Esseq CaseBase(Some alias)`** — switch `tail_sym` to `tail_pexpr`; store `pexpr` in env:
+```ocaml
+| Ewseq (Pattern (p_annots, CaseBase (Some alias, cbty)), e1, body) ->
+    let e1' = propagate_expr env e1 in
+    (match tail_pexpr e1' with
+     | Some pe ->
+         Expr (annots, Ewseq (Pattern (p_annots, CaseBase (None, cbty)),
+                              e1',
+                              propagate_expr (extend_env env alias pe) body))
+     | None ->
+         Expr (annots, Ewseq (Pattern (p_annots, CaseBase (Some alias, cbty)),
+                              e1',
+                              propagate_expr env body)))
+(* Symmetric for Esseq *)
+```
+
+Note: `tail_pexpr e1'` is called on the already-propagated `e1'`, so the extracted pexpr is already in canonical form.
+
+**`Elet CaseBase(Some alias)` with `PEsym src` RHS** — use `Pmap.lookup` instead of old `apply_env`:
+```ocaml
+| Elet (Pattern (p_annots, CaseBase (Some alias, cbty)), pe1, body) ->
+    (match pe1 with
+     | Pexpr (_, _, PEsym src) ->
+         let pe_src = match Pmap.lookup src env with
+                      | Some pe -> pe
+                      | None    -> pe1 in
+         Expr (annots,
+           Elet (Pattern (p_annots, CaseBase (None, cbty)),
+                 propagate_pexpr env pe1,
+                 propagate_expr (extend_env env alias pe_src) body))
+     | _ ->
+         Expr (annots,
+           Elet (Pattern (p_annots, CaseBase (Some alias, cbty)),
+                 propagate_pexpr env pe1,
+                 propagate_expr env body)))
+```
+
+All other arms (`Ewseq (pat, e1, e2)`, `Esseq (pat, e1, e2)`, `Elet (pat, pe1, e2)` catch-alls, and all other expr forms) are structurally unchanged — just propagate recursively.
+
+---
+
+## Design Notes
+
+- **Annotation loss at substitution site** is acceptable: `bty = unit` throughout untyped Core; occurrence-site annots on `PEsym` nodes are typically empty.
+- **`Elet` CaseBase arm stays conservative** (PEsym RHS only): avoids expression explosion for non-trivial pure let bindings. The generalisation only affects the VALUES stored in the env (now pexprs) and the VALUES extracted via `tail_pexpr` (now any safe pure expr, not just PEsym).
+- **`binders_of_pat` replaces the inline `CaseBase(Some s, _)` extraction** in `tail_sym_acc`. The new version correctly handles `CaseCtor` tuple patterns — if a chain contains a `let (a, b) = ...` binding, both `a` and `b` are now added to `binders`, preventing either from leaking via `tail_pexpr`.
+- **No generic equality used**: avoid `bindings = []`; pattern-match on `[]` instead.
+
+---
+
+## `.mli` Update
+
+```ocaml
+(** Pure expression rebinding elimination.
+
+    Eliminates bindings of the form [let alias = pure(e) in body] by
+    substituting [e] for [alias] throughout [body].  The binding node is
+    preserved (pattern replaced by a wildcard) so that source-location
+    annotations are not lost.
+
+    Handles:
+    - {b Single named bindings} ([CaseBase(Some alias, _)]) against
+      [pure(sym)] (pure let) or effectful RHS whose tail is [pure(e)].
+      The tail [e] may be any pure expression, not just a symbol alias.
+
+    No memory events, sequencing, or values are changed. *)
+
+val transform_file : unit Core.file -> unit Core.file
+```
+
+---
+
+## Verification
+
+```sh
+make && make install
+cd tests && USE_OPAM='' bash run-ci.sh       # all existing tests must pass
+USE_OPAM='' bash run-copy-prop-phase1.sh     # copy-prop specific tests 0366–0373
+```
+
+Write doc history: `doc/history/2026-03-23_copy-prop-pexpr-env.md`.

--- a/doc/history/2026-03-23_copy-prop-rose-tree.md
+++ b/doc/history/2026-03-23_copy-prop-rose-tree.md
@@ -1,0 +1,130 @@
+# Copy Propagation: Rose-tree tail, tuple patterns, Eunseq RHS
+
+**Date:** 2026-03-23
+**File:** `ocaml_frontend/rewriters/copy_propagation.ml`
+
+---
+
+## Motivation
+
+The previous `tail_pexpr` (returning `pexpr option`) returned `None` for
+`Eunseq`, so copy-propagation could not extract bindings when:
+
+- the pattern was a tuple (`CaseCtor(Ctuple, pats)`), and
+- the RHS was `Eunseq(es)` — the standard Core encoding of C comparison
+  operators, function-pointer loads, and other unsequenced expressions.
+
+For example, in the Core of `do_uninit.c`:
+
+```
+let weak (a_516, a_517) = unseq(load(x), pure(Specified(0))) in
+case (a_516, a_517) of ...
+```
+
+`a_517` was always 0, but the pass could not propagate that constant into the
+`case` because the pattern was a tuple and the RHS was `Eunseq`.
+
+---
+
+## Design
+
+### `pexpr_tree`
+
+A rose tree that mirrors the `Eunseq` / `CaseCtor(Ctuple)` nesting:
+
+```ocaml
+type pexpr_tree =
+  | Leaf of pexpr option   (* known/unknown pure expression *)
+  | Node of pexpr_tree list (* Eunseq with per-arm subtrees *)
+```
+
+### `tail_pexpr_acc` / `tail_pexpr`
+
+Return type changed from `pexpr option` to `pexpr_tree`.  The `Eunseq` case
+now builds a `Node`:
+
+```ocaml
+| Eunseq es -> Node (List.map (tail_pexpr_acc binders) es)
+```
+
+All other cases change `Some`/`None` to `Leaf(Some ...)`/`Leaf None`.
+
+### `match_pat_tree`
+
+New function that walks a pattern and a `pexpr_tree` in lock-step, returning
+`(bindings, new_pattern)`:
+
+| Pattern            | Tree                      | Result                            |
+|--------------------|---------------------------|-----------------------------------|
+| `CaseBase(Some s)` | `Leaf(Some pe)`           | `s → pe`, pattern wildcarded      |
+| `CaseBase(Some s)` | `Leaf None` or `Node _`   | no extraction                     |
+| `CaseBase(None)`   | any                       | no extraction                     |
+| `CaseCtor(Ctuple)` | `Node trees` (same arity) | recurse element-wise              |
+| `CaseCtor(Ctuple)` | `Leaf(Some PEctor(Ctuple, pes))` (same arity) | decompose element-wise |
+| anything else      | anything else             | no extraction (fallthrough)       |
+
+The `Leaf(Some PEctor(Ctuple,...))` case handles `Elet` with a pure-tuple RHS.
+
+### Updated `propagate_expr` catch-alls
+
+The three catch-all arms for `Ewseq`, `Esseq`, and `Elet` now use
+`match_pat_tree` for partial tuple extraction:
+
+```ocaml
+| Ewseq (pat, e1, body) ->
+    let e1' = propagate_expr env e1 in
+    let (bindings, new_pat) = match_pat_tree pat (tail_pexpr e1') in
+    let env' = extend_env_list env bindings in
+    Expr (annots, Ewseq (new_pat, e1', propagate_expr env' body))
+```
+
+(Symmetric for `Esseq`. For `Elet`, `Leaf(Some pe1')` is passed instead of
+`tail_pexpr e1'`.)
+
+The specific `CaseBase(Some alias)` arms for `Ewseq`/`Esseq` (which fire
+first) are updated to match against `Leaf(Some pe_tail)` / `_` instead of
+`Some pe_tail` / `None`.
+
+---
+
+## Correctness notes
+
+- `pexpr_safe` is unchanged; it still guards against hoisting expressions whose
+  free variables are locally bound along the chain.
+- `binders_of_pat` is unchanged; it handles both `CaseBase` and `CaseCtor`.
+- Extraction is **partial**: positions where the tree gives `Leaf None` retain
+  their original names.
+- The binding node is always preserved (pattern element replaced by wildcard,
+  not dropped), so source-location annotations are not lost.
+- `Eunseq` introduces no new binders; the accumulator is unchanged when
+  recursing into `Eunseq` arms.
+
+---
+
+## Example walkthrough (`do_uninit.c`)
+
+Input:
+```
+Ewseq(CaseCtor(Ctuple, [CaseBase(Some a_516); CaseBase(Some a_517)]),
+      Eunseq([e_load, Epure(Specified(0))]),
+      body)
+```
+
+1. `e1' = propagate_expr env (Eunseq([e_load, Epure(Specified(0))]))`
+2. `tail_pexpr e1' = Node([Leaf None, Leaf(Some Specified(0))])`
+3. `match_pat_tree (a_516, a_517) (Node([Leaf None, Leaf(Some ...)]))`
+   → `bindings = [(a_517, Specified(0))]`, `new_pat = (a_516, _)`
+4. `env' = env ∪ {a_517 → Specified(0)}`
+5. `propagate_expr env' body` → `PEsym a_517` replaced by `Specified(0)`
+
+---
+
+## Post-implementation addendum
+
+During testing, a Core typechecker bug was exposed: the typechecker incorrectly
+rejected certain `loaded object` / `loaded pointer` expressions that are
+semantically equivalent. This was fixed in the typechecker independently;
+the copy-propagation pass itself is correct.
+
+All 208 CI tests pass with `--sw copy_prop` (phase 1 regression), and all 208
+pass without the switch (full CI suite).

--- a/doc/history/2026-03-27_copy-prop-pattern-aware.md
+++ b/doc/history/2026-03-27_copy-prop-pattern-aware.md
@@ -1,0 +1,320 @@
+# Copy-Propagation: Pattern-Aware Analysis
+
+**Date:** 2026-03-27
+**Branch:** mem2reg
+**Status:** Plan (pre-implementation)
+
+---
+
+## Problem Statement
+
+The current `copy_propagation.ml` decides whether to replace a tail expression with
+`unit` based solely on the expression's shape (`can_prop_and_rm`), without consulting
+the pattern the value will be bound to. This produces type-incoherent output.
+
+### Concrete Bug
+
+Consider elaborated Core like:
+
+```core
+let Specified(x) = pure(Specified(ptr)) in body
+```
+
+Here `ptr` is a propagatable sym (no local binders). The current two-phase flow is:
+
+1. **`split_tuple`** sees `PEctor(Cspecified, [PEsym ptr])`.
+   Not a `Ctuple`, so falls to `prop_and_rm`.
+   `can_prop_and_rm` returns `true` (all sub-expressions are free of local binders).
+   Replaces expression with `PEval Vunit`. Returns `Leaf(Some PEctor(Cspecified, [PEsym ptr]))`.
+
+2. **`match_pat_tree`** sees pattern `CaseCtor(Cspecified, [CaseBase(Some x, _)])` vs
+   `Leaf(Some …)`.
+   The only `Leaf` arms handle `CaseBase(Some s, _)` and `CaseBase(None, _)`.
+   Falls to `_ -> ([], pat)` — no bindings extracted, original pattern kept.
+
+3. **Net result:**
+   - Expression has already been rewritten to `unit`.
+   - Pattern is still `Cspecified(x)`.
+   - Output: `let Cspecified(x) = pure(unit) in body` — **type error**.
+   - `x` is **not** substituted for `ptr` in `body`.
+
+The same kind of mismatch can arise for any `CaseCtor` that wraps propagatable content
+but is not a `Ctuple`.
+
+---
+
+## High-Level Plan
+
+Replace the existing two-phase (build `pexpr_tree` + `match_pat_tree`) approach with a
+**single-pass pattern-aware analysis**. The analysis takes both the binding pattern and
+the expression/pexpr simultaneously, and returns a coherent triple:
+
+```
+(bindings : (sym * pexpr) list, new_pat : pattern, new_pe/e : …)
+```
+
+where `new_pe` and `new_pat` are guaranteed to be type-compatible with each other.
+
+The `pexpr_tree` type and its associated build/match functions (`split_tuple`,
+`prop_and_rm`, `eventually_pure`, `tail_pexpr`, `match_pat_tree`) are **removed**.
+Two new functions replace them:
+
+| New function | Replaces |
+|---|---|
+| `analyze_pat_pexpr` | `split_tuple` + `match_pat_tree` (pure case) |
+| `analyze_pat_expr`  | `eventually_pure`/`tail_pexpr` + `match_pat_tree` (effectful case) |
+
+Call sites (`Ewseq`, `Esseq`, `Elet` in `propagate_expr`; `PElet` in `propagate_pexpr`)
+switch to using the new functions.
+
+### Architectural defect analysis
+
+| Concern | Assessment |
+|---|---|
+| Backwards compatibility of pattern rewriting | Safe: the `CaseBase` cases are preserved exactly as before. The only new behaviour is for previously-missed `CaseCtor` patterns. |
+| Arity mismatch between `Ctuple` pat and `PEctor(Ctuple, pes)` | Defensive: if lengths differ, fall through to the conservative `([], pat, pe)` case. |
+| `Eunseq` arity mismatch with tuple pattern | Same: fall through to conservative. |
+| `can_prop_and_rm binders` correctness inside nested patterns | The `binders` list is passed down through `analyze_pat_expr` as we cross sequential binders, preserving the invariant from the original code. |
+| Type annotation on residual `CaseBase` | When replacing a `CaseBase(Some s, bty)` or `CaseBase(None, bty)` with a wildcard, we use `BTy_unit` for the residual as before. When wrapping in `Cspecified`, we keep the inner residual type. |
+
+No fundamental architectural problem identified.
+
+---
+
+## Detailed Design
+
+### 1. Keep: `can_prop_and_rm`
+
+No changes. Signature and semantics unchanged:
+
+```ocaml
+val can_prop_and_rm : Symbol.sym list -> pexpr -> bool
+```
+
+Returns `true` iff the pexpr has no free occurrences of the given locally-bound syms and
+is safe to hoist.
+
+### 2. Keep: `binders_of_pat`
+
+No changes.
+
+### 3. Remove
+
+- `pexpr_tree` type
+- `prop_and_rm`
+- `split_tuple`
+- `eventually_pure`
+- `tail_pexpr`
+- `match_pat_tree`
+
+### 4. New: `analyze_pat_pexpr`
+
+```ocaml
+val analyze_pat_pexpr
+  :  Symbol.sym list      (* locally-bound syms, must not escape *)
+  -> pattern              (* binding pattern *)
+  -> pexpr                (* RHS pure expression *)
+  -> (Symbol.sym * pexpr) list * pattern * pexpr
+  (* (bindings, new_pat, new_pe) *)
+```
+
+Cases:
+
+```
+CaseBase(Some s, _),  pe   when can_prop_and_rm binders pe
+  → ([(s, pe)], CaseBase(None, BTy_unit), PEval Vunit)
+
+CaseBase(None, _),    pe   when can_prop_and_rm binders pe
+  → ([],        CaseBase(None, BTy_unit), PEval Vunit)
+
+CaseBase(_, _),       pe   (* not propagatable *)
+  → ([],        pat,                     pe)
+
+CaseCtor(Ctuple, pats), PEctor(Ctuple, pes)   (* same arity *)
+  → recurse element-wise via List.map2 analyze_pat_pexpr
+    combine bindings; rebuild Ctuple pat and expr
+
+CaseCtor(Cspecified, [inner_pat]), PEctor(Cspecified, [inner_pe])
+  → (bindings', CaseCtor(Cspecified, [new_inner_pat]),
+                PEctor(Cspecified, [new_inner_pe]))
+    where (bindings', new_inner_pat, new_inner_pe) =
+      analyze_pat_pexpr binders inner_pat inner_pe
+
+(* Conservative fallthrough *)
+_, _
+  → ([], pat, pe)
+```
+
+**Design note:** `Cunspecified` (`PEctor(Cunspecified, [])`) carries no sub-expressions
+to propagate, so the conservative fallthrough handles it correctly with no special case
+needed. `Cnil` and other ctors similarly fall through.
+
+### 5. New: `analyze_pat_expr`
+
+```ocaml
+val analyze_pat_expr
+  :  Symbol.sym list      (* locally-bound syms *)
+  -> pattern              (* the *outer* binding pattern, not the inner chain pats *)
+  -> expr
+  -> (Symbol.sym * pexpr) list * pattern * expr
+```
+
+This descends through sequential chains (`Esseq`, `Ewseq`, `Elet`, `Ebound`, `Eannot`)
+to find the tail, then delegates to `analyze_pat_pexpr` for the pure case.
+
+```
+Epure pe
+  → let (bs, new_pat, new_pe) = analyze_pat_pexpr binders pat pe in
+    (bs, new_pat, Epure new_pe)
+
+Eunseq es
+  → match pat with
+    | CaseCtor(Ctuple, pats) when List.length pats = List.length es →
+        recurse element-wise: analyze_pat_expr binders pats_i es_i
+        combine; rebuild Ctuple pat and Eunseq
+    | _ → conservative: ([], pat, expr)
+
+Ewseq(inner_pat, e1, e2)
+  → let binders' = binders_of_pat inner_pat @ binders in
+    let (bs, new_outer_pat, new_e2) = analyze_pat_expr binders' pat e2 in
+    (bs, new_outer_pat, Ewseq(inner_pat, e1, new_e2))
+    (* Note: inner_pat / e1 are NOT rewritten here — that is the job of
+       propagate_expr when it processes e1 as its own binding site *)
+
+Esseq(inner_pat, e1, e2)
+  → analogous to Ewseq
+
+Elet(inner_pat, pe1, e2)
+  → let binders' = binders_of_pat inner_pat @ binders in
+    let (bs, new_outer_pat, new_e2) = analyze_pat_expr binders' pat e2 in
+    (bs, new_outer_pat, Elet(inner_pat, pe1, new_e2))
+
+Ebound e
+  → let (bs, new_pat, new_e) = analyze_pat_expr binders pat e in
+    (bs, new_pat, Ebound new_e)
+
+Eannot(al, e)
+  → analogous to Ebound
+
+(* Conservative fallthrough for Eif, Ecase, Eccall, Eaction, … *)
+_
+  → ([], pat, expr)
+```
+
+**Critical invariant:** `analyze_pat_expr` only rewrites the *tail* of the chain (the
+`e2` in Esseq/Ewseq/Elet, or the final `Epure`). It does **not** rewrite `e1` — that is
+propagated separately by `propagate_expr`'s own recursive call.
+
+### 6. Updated call sites in `propagate_expr`
+
+```ocaml
+| Ewseq (pat, e1, body) ->
+    let e1' = propagate_expr env e1 in
+    let (bindings, new_pat, e1'') = analyze_pat_expr [] pat e1' in
+    let env' = extend_env_list env bindings in
+    Expr (annots, Ewseq (new_pat, e1'', propagate_expr env' body))
+
+| Esseq (pat, e1, body) ->
+    (* analogous *)
+
+| Elet (pat, pe1, body) ->
+    let pe1' = propagate_pexpr env pe1 in
+    let (bindings, new_pat, pe1'') = analyze_pat_pexpr [] pat pe1' in
+    let env' = extend_env_list env bindings in
+    Expr (annots, Elet (new_pat, pe1'', propagate_expr env' body))
+```
+
+And in `propagate_pexpr` for `PElet`:
+
+```ocaml
+| PElet (pat, pe1, pe2) ->
+    let pe1' = propagate_pexpr env pe1 in
+    let (bindings, new_pat, pe1'') = analyze_pat_pexpr [] pat pe1' in
+    let env' = extend_env_list env bindings in
+    Pexpr (annots, bty, PElet (new_pat, pe1'', propagate_pexpr env' pe2))
+```
+
+### 7. Detailed design defect analysis
+
+| Concern | Assessment |
+|---|---|
+| `analyze_pat_expr` rewrites the tail expr (inner chain) but not `e1` | Correct by design: `e1` is the action / other expression being sequenced; its tail is what `body` is bound to. Only the tail pure value can be extracted. The `propagate_expr` call on `e1` handles its own internals. |
+| Binders passed as `[]` to `analyze_pat_expr` at call sites | Safe: `analyze_pat_expr` re-accumulates binders as it descends through the chain. The outer call always starts fresh. |
+| `Eunseq` within `analyze_pat_expr` — does it arise in practice? | Yes: `Ewseq(tuple_pat, Eunseq([e1;e2]), body)` is generated by the elaboration of parallel operations. The handling mirrors the existing `Node` case. |
+| Propagating `PEsym` inside `Cspecified` wrapper — annotations preserved? | Yes: destructure `Pexpr(outer_annots, outer_bty, PEctor(Cspecified, [inner_pe]))` and reuse `outer_annots`/`outer_bty` in the rebuilt node. |
+| `analyze_pat_expr` for Esseq/Ewseq: `inner_pat` is NOT rewritten | Correct: rewriting `inner_pat` would affect the binding between `e1` and `e2`, which is separate from the outer binding between the whole Esseq and `body`. |
+
+### 8. Annotation preservation for reconstructed `PEctor`
+
+In `analyze_pat_pexpr`, when handling `CaseCtor(Cspecified, [inner_pat])` vs
+`PEctor(Cspecified, [inner_pe])`, we reconstruct the outer `PEctor`. We must preserve
+the `Pexpr(outer_annots, outer_bty, …)` wrapper. The cleanest way: destructure the
+incoming `pexpr` as `Pexpr(outer_annots, outer_bty, PEctor(Cspecified, [inner_pe]))` in
+the match arm, and use `outer_annots`/`outer_bty` for the reconstruction.
+
+Similarly for `Ctuple`: destructure and reuse `outer_annots`/`outer_bty` from the
+original pexpr.
+
+No fundamental flaw — just a detail to attend to in implementation.
+
+---
+
+## Summary of Changes
+
+| File | Change |
+|---|---|
+| `ocaml_frontend/rewriters/copy_propagation.ml` | Remove `pexpr_tree`, `prop_and_rm`, `split_tuple`, `eventually_pure`, `tail_pexpr`, `match_pat_tree`; add `analyze_pat_pexpr`, `analyze_pat_expr`; update `propagate_expr` and `propagate_pexpr` call sites |
+
+No other files change.
+
+---
+
+## Testing
+
+The existing copy-prop test suite in `tests/` covers this change fully and should be run
+after every build.
+
+### Regression: Phase 1
+
+```sh
+cd tests
+USE_OPAM='' bash run-copy-prop-phase1.sh
+```
+
+Runs all CI tests (`0001`–`0365` and newer) with `--sw copy_prop` and checks that
+outputs match the committed `.expected` files. This guards against any change to the
+pass that silently alters execution results.
+
+The refactored code must pass Phase 1 with no new failures. Because the bug affected
+only bindings with `CaseCtor` outer patterns (not `CaseBase`), most existing tests will
+be unaffected; but the regression suite confirms nothing regressed.
+
+### Elimination: Phase 2
+
+```sh
+cd tests
+USE_OPAM='' bash run-copy-prop-phase2.sh
+```
+
+Checks that `--sw copy_prop` leaves the expected number of `create()` calls in the
+pretty-printed Core IR for the dedicated copy-prop tests (`0366`–`0373`). Also runs the
+`0373` integration test with both `--sw copy_prop --sw mem2reg`.
+
+The expected `create()` counts in Phase 2 were set for the `CaseBase` propagation case.
+If the fix causes additional propagation through `Cspecified` wrappers, the counts for
+some tests may need to be updated — this is expected and correct behaviour.
+
+### Full CI
+
+```sh
+cd tests
+USE_OPAM='' bash run-ci.sh
+```
+
+Run the full CI subset after the phase scripts pass to confirm no wider regressions.
+
+---
+
+## Post-Implementation Addendum
+
+*(To be filled after implementation, testing, and user feedback.)*

--- a/doc/mem2reg_analysis.md
+++ b/doc/mem2reg_analysis.md
@@ -1,0 +1,64 @@
+Let's replace `check_definitely_init` and `no_mixed_unseq_uses` (and
+`expr_writes_sym`) with one function `sequentialisable`. Make a plan for this
+as per CLAUDE.md and make sure the first step is to write that plan to
+doc/history/. Make sure to also include a note to add an addendum to the same
+plan after implementing and testing with any changes updates learned during
+that process.
+
+The function will have a similar shape to `check_definitely_init`, but instead
+of `strongly_init` it will have a `env` which will be either `Uninit | Init
+of pexpr | Killed`, and instead of `Write_kind.t` we'll have a `Mem_event.t
+list`, where a `Mem_event.t` will either be a `Pos_store of pexpr | Neg_store
+of pexpr | Load | Kill`. It will also be able to throw an exception
+`Not_sequentialisable`. Its return values will all be wrapped in an option,
+because the Erun case will always return None, and all other cases some.
+All recursion on subterms will thus happen inside an option monad (define 
+and use let* to write such code).
+
+The basic idea is that it's an abstract interpretation. After recursing on a
+subexpression, it will update the environment appropriately or throw an
+exception if it can't, and then recurse on other subexpressions. For branching
+ones like if and case, the env passed in will be the same, and the constructed
+value will be a pure if and case respectively. The non-load events need to be
+combinable: all kills, or all stores, where one `Neg_store` means the whole
+expression is treated as a `Neg_store` of the constructed value.
+
+The strong sequencing is easy enough, and the weak-sequencing needs to make
+sure that negative store from e1 is unsequenced with events from e2, with the
+resulting env and events combined or an exception thrown. Unseq will be
+similar, except branches need to be either all reads, or at most one write.
+
+Esaves and is treated similar to now, but there's no need to memoize 
+anything, it will recurse in the body with respect to the corresponding
+aliased parameter if there is one (and skipped otherwise). Eruns will
+just return a None.
+
+---
+
+We will need a helper function `update_env env1 events1`, which will return
+an `abs_env option`.
+
+That function will filter out all the Load events from the set (call it events')
+and then check the cardinality of what's left:
+- If it's empty, then `env1` will be returned as is.
+- If it's a singleton, and it has a `Kill` then the returned value will be
+  `Some (Killed, events')`.
+- If it's a singleton, and it has a `Pos_store pexpr | Neg_store pexpr`, the
+  returned value will be `Some (Init pexpr, events')`.
+- If it's got more than one element, the function will return `None`.
+
+Back to `sequentialisable`. For the sseq case, the `sequentialisable` will
+recurse on e1, and will have a `(env1, events1)`. It will then call
+`update_abs_env env1 events1` to get an `env_opt`. If it's None, the
+function will throw the `Not_sequentialisable` exception. Otherwise, it'll
+unwrap the `Some (env2, _)` and pass it into recursing on the second expression.
+
+For weak-sequencing, the function will recurse on `e1` similarly. But it will
+call a `weak_update_env` helper function, which will be like `update_env` but
+which returns an extra boolean flag inside the `Some` case signaling whether
+the update was strong or weak. Similarly to sseq, the None case will raise an
+exception, but the `Some (env2, events1')` will be used as follows.
+`env2' = if is_weak_store events1' then env1 else env2`, and that will be
+used to recurse on `e2`. We'll now have `(env1, events1)` and `(env2,
+events2)`.
+

--- a/doc/mem2reg_transform.md
+++ b/doc/mem2reg_transform.md
@@ -1,0 +1,130 @@
+Let's iterate on a plan (strictly as per CLAUDE.md) to implement the transform
+step for mem2reg.
+
+Inputs: 
+- expression to transform
+- set/list of promotable variables (from the analysis)
+- memo table for the saves
+- environment mapping symbols to symbol options
+- set of symbols which have been written so far
+
+Outputs:
+- transformed expressions
+- set of symbols which have been written (for pattern matching)
+
+First thing it needs to do is to combine and return both seq_memo from the
+analysis to construct a map from label_sym to (param_sym * bool) list. The
+boolean represents whether the parameter is promoted or not, based on whether
+use_memo has has a Use_other for that parameter in its cached result. The
+boolean should be true if it has the entry and no Use_other, and false
+otherwise.
+
+Memory actions will be transformed as follows. I use let* to mean either
+Ewseq, or Esseq.
+
+let* x: pointer = create(..) in e2 ==>
+    e2'                            
+    where env'(x) = None if x is promotable
+    and e2' is the result of recursing on e2
+
+let* v: ty = load(x) in e2 ==>
+    let* v: ty = Specified(pexpr) in e2'
+    where env(x) = Some (pexpr),
+    and e2' is the result from recursing
+
+let* _: unit = store(x, pexpr) in e2 ==>
+    e2'
+    env(x) exists and is updated so that env'(x) = Some pexpr
+    and x is added to the set of variables which is written
+    and e2' is the result from recursing,
+
+let* _: unit = kill(x) in e2 ==>
+    e2'
+    env(x) is removed
+    x is removed from the set of variables which is written
+    and e2' is the result from recursing
+
+Handle seqrmw based on the above (remember that it's binds a variable mentioned
+in its updated expression).
+
+For the expressions:
+
+pure(pe) ==>
+    pure((pe,pe1,..,pen))
+    where env(x1) = Some pe1, .., env(xn) = Some pen
+    x1, .., xn in set of written variables
+    (sorted to ensure a consistent order)
+
+Ememop, Eccall, Eproc, need to be handled similarly
+
+Eexcluded can be skipped/assert false - it's a runtime only construct
+
+let* pat = e1 in e2 ==>
+    let* (pat, y1 : storable, .., yn : storable) = e1' in e2'
+    where y1, .., yn are fresh variables
+    where recursing on e1 first gives e1' and..
+    - the set of variable written (x1, .., xn)
+    - the updated environment env
+    env is udpated extended/modified so that
+    env(x1) = Some (y1), .., env(xn) = Some (yn)
+    (sorted to ensure consistent order)
+    all of which is used to recurse on e2'
+    the resulting env and written var set is passed up as a whole
+
+if pe then e1 else e2 ==>
+    if pe then
+        let (y1 : st, .., yk : st) = e1' in
+        pure(pet1, y1, .., petm, yk)
+    else
+        (let z1 : str, .., zm : st) = e2' in
+        pure(z1, pef1, .., zm, pefk)
+    - where y1, .., yk bind all the variables written by e1
+            (x1, .., xk)
+      and   z1, .., zm bind all the variables written by e2
+            (w1, .., wm)
+    - pet1, .., petm are env(w1) = pet1, .. env(wm) = petm
+    - pef1, .., pefk are env(x1) = pef1, .. env(xk) = pefk
+    - the set of written variables is the union
+    - the big tuple is ordered correspondingly
+    - env1 is updated so that env1(x1) = Some y1, .., env1(xk) = Some yk
+    - env2 is updated so that env2(w1) = Some z1, .., env2(wm) = Some zm 
+    - env1 and env2 are combined (if they modify the same value, then None
+      is fine, since it will be overwritten later, when the if expression is
+      bound by a let)
+
+Similarly for case-expressions
+
+unseq(e1, .., en) ==>
+    let ((a1, y1, ..), .., (an, z1, ..)) =
+        unseq(e1', .., en') in
+    - pure((a1, .., an), y1, .., z1, ..)
+    - where e1', .., en' are all recursed
+    - the environments are combined (should be no overlap)
+    - and updated so that env(x1) = Some y1, .. env(w1) = Some z1
+    - where x1, .. w1, .. and from the written var sets of each expression
+    - the written var sets are all unioned
+
+par is handled similarly
+
+nd can be skipped entirely (it's always got pure values true and false inside)
+
+bound(e) ==> bound(e')
+    env and written vars unchanged
+
+same with Eannot, Elet
+
+---
+
+Let's iterate on a plan (strictly as per CLAUDE.md) to implement the transform
+step for mem2reg.  The transform for Esaves will always occur within the context
+of a let strong _: unit = save (..) in E, into let strong (v1, v2, ..) :
+(storable, storable, ..)  = save (..) in E, where v1, v2 are variables
+representing the values in the promoted variables. Every control-flow path
+within an Esave will end either in a unit or in a run, and the body of the save
+will need to change each to supply the values of the promoted variables. After
+the Esave's been tranformed, the environment for each promoted variable which
+was passed in as a default argument will need to be updated to point to hold v1
+v2 etc. respectively. The transform will return for each expression a set of
+variables which have been modified; these will be sorted and used for
+pattern-matching the new values and the new bound variables will be used to
+update the environment. At the base case for any pure expression,

--- a/doc/todos.md
+++ b/doc/todos.md
@@ -3,11 +3,6 @@
 - Started on mem2reg transform, but got stuck with save!
 - Started fixing save mem2reg analysis, but realised it needs simultaneous sym
   analysis avoid locally bound symbols escaping in the env.
-- Came up with an example to demonstrate the possibility, but then copy
-  propagation is not strong enough to trigger it.
-  + copy-prop does expressions
-  + copy-prop handles save properly
-  + copy-prop handles tuples and unseq
 
 ```c
 int main()

--- a/doc/todos.md
+++ b/doc/todos.md
@@ -4,6 +4,8 @@ Support createReadOnly?
 
 Think about the mem2reg transform? At least as a sanity check.
 
+Parallelise sequentialisable e.g. analyses collection of syms simultaneously?
+
 Check that mem2reg works equally well with both calling conventions.
 
 Check whether the invariant of Esave being closed is true if the inner-arg

--- a/doc/todos.md
+++ b/doc/todos.md
@@ -1,8 +1,10 @@
 # Todos
 
-TODOs marked in core_mem2reg.ml - Support createReadOnl; think about
-how to detect and reject races (weak, unseq) more carefully.
+Support createReadOnly?
+
+Think about the mem2reg transform? At least as a sanity check.
 
 Check that mem2reg works equally well with both calling conventions.
+
 Check whether the invariant of Esave being closed is true if the inner-arg
-calling convention is used.
+calling convention is used?

--- a/doc/todos.md
+++ b/doc/todos.md
@@ -1,5 +1,53 @@
 # Todos
 
+- Started on mem2reg transform, but got stuck with save!
+- Started fixing save mem2reg analysis, but realised it needs simultaneous sym
+  analysis avoid locally bound symbols escaping in the env.
+- Came up with an example to demonstrate the possibility, but then copy
+  propagation is not strong enough to trigger it.
+  + copy-prop does expressions
+  + copy-prop handles save properly
+  + copy-prop handles tuples and unseq
+
+```c
+int main()
+{
+    void *p;
+    int houdini;
+escape:
+    p = &houdini;
+    return 0;
+}
+```
+
+```ocaml
+proc main (): eff loaded integer :=
+  let strong p: pointer = create(Ivalignof('void*'), 'void*') in
+  let strong houdini: pointer = create(Ivalignof('signed int'), 'signed int') in
+  store('void*', p, Unspecified('void*')) ;
+  store('signed int', houdini, Unspecified('signed int')) ;
+  save escape: unit (p: pointer:= p, houdini: pointer:= houdini) in
+    let strong _: loaded pointer =
+      bound(
+        let weak a_509: pointer = pure(p) in
+        let weak a_511: loaded pointer =
+          let weak _: pointer = pure(houdini) in
+          pure(Specified(houdini)) in
+        let weak _: unit = neg(store('void*', a_509, a_511)) in
+        pure(a_511)
+      ) in
+    pure(Unit) ;
+  let strong a_512: loaded integer = bound(pure(Specified(0))) in
+  kill('void*', p) ;
+  kill('signed int', houdini) ;
+  run ret_508(conv_loaded_int('signed int', a_512)) ;
+  kill('void*', p) ;
+  kill('signed int', houdini) ;
+  pure(Unit) ;
+  save ret_508: loaded integer (a_513: loaded integer:= Specified(0)) in
+    pure(a_513)
+```
+
 Support createReadOnly?
 
 Think about the mem2reg transform? At least as a sanity check.

--- a/doc/todos.md
+++ b/doc/todos.md
@@ -1,8 +1,8 @@
 # Todos
 
-- Started on mem2reg transform, but got stuck with save!
-- Started fixing save mem2reg analysis, but realised it needs simultaneous sym
-  analysis avoid locally bound symbols escaping in the env.
+- think more about analysis for Eif and Ecase
+- simplify nd() to take no args, and rename to nd_bool()
+- actually update analysis to handle nd like that
 
 ```c
 int main()

--- a/doc/todos.md
+++ b/doc/todos.md
@@ -1,7 +1,7 @@
 # Todos
 
-TODOs marked in core_mem2reg.ml - failing on unsupported memory actions, and
-handling negative memory actions correctly.
+TODOs marked in core_mem2reg.ml - Support createReadOnl; think about
+how to detect and reject races (weak, unseq) more carefully.
 
 Check that mem2reg works equally well with both calling conventions.
 Check whether the invariant of Esave being closed is true if the inner-arg

--- a/doc/todos.md
+++ b/doc/todos.md
@@ -1,0 +1,8 @@
+# Todos
+
+TODOs marked in core_mem2reg.ml - failing on unsupported memory actions, and
+handling negative memory actions correctly.
+
+Check that mem2reg works equally well with both calling conventions.
+Check whether the invariant of Esave being closed is true if the inner-arg
+calling convention is used.

--- a/frontend/model/core.lem
+++ b/frontend/model/core.lem
@@ -349,7 +349,7 @@ type generic_impl 'bty = map Implementation.implementation_constant (generic_imp
 
 type generic_fun_map_decl 'bty 'a =
   | Fun of core_base_type * list (Symbol.sym * core_base_type) * generic_pexpr 'bty Symbol.sym
-  | Proc of Loc.t * maybe nat (* marker env *) * core_base_type * list (Symbol.sym * core_base_type) * generic_expr 'a 'bty Symbol.sym
+  | Proc of Loc.t * maybe nat (* marker env *) * core_base_type * list (Symbol.sym * core_base_type) * generic_expr 'a 'bty Symbol.sym * list Symbol.sym
   | ProcDecl of Loc.t * core_base_type * list core_base_type
   | BuiltinDecl of Loc.t * core_base_type * list core_base_type
 

--- a/frontend/model/core_aux.lem
+++ b/frontend/model/core_aux.lem
@@ -1872,8 +1872,8 @@ let unsafe_subst_sym_fun_map sym pe' funs =
         ProcDecl loc bTy params
     | BuiltinDecl loc bTy params ->
         BuiltinDecl loc bTy params
-    | Proc loc mrk bTy params e ->
-        Proc loc mrk bTy params (unsafe_subst_sym_expr sym pe' e)
+    | Proc loc mrk bTy params e promotable ->
+        Proc loc mrk bTy params (unsafe_subst_sym_expr sym pe' e) promotable
   end) funs
 
 
@@ -2387,7 +2387,7 @@ let collect_labeled_continuations_NEW file =
           acc
       | BuiltinDecl _ _ _ ->
           acc
-      | Proc _ _ _ _ e ->
+      | Proc _ _ _ _ e _ ->
           Map.insert fun_sym (collect_saves e) acc
     end
   ) (Map.(union) file.stdlib file.funs) Map.empty

--- a/frontend/model/core_eval.lem
+++ b/frontend/model/core_eval.lem
@@ -158,7 +158,7 @@ let call_function file f_nm arg_cvals =
         error "Core_eval.call_function, called on a ProcDecl"
     | BuiltinDecl _ _ _ ->
         error "Core_eval.call_function, called on a BuiltinDecl"
-    | Proc _ _ _ _ _ ->
+    | Proc _ _ _ _ _ _ ->
         error "Core_eval.call_function, called on a Proc"
   end
 
@@ -576,7 +576,7 @@ let rec step_eval_pexpr n loc parent_call_loc_opt core_extern env mem_st_opt fil
           | Nothing ->
               (* NOTE: check if it is a procedure pointer *)
               match Map.lookup sym file.funs with
-                | Just (Proc _ _ _ _ _) ->
+                | Just (Proc _ _ _ _ _ _) ->
                     EU.return (PEval (Vobject (OVpointer (Mem.null_ptrval (Ctype.Ctype [] Ctype.Void)))))
                 | _ ->
                     EU.fail (Unresolved_symbol loc sym)

--- a/frontend/model/core_eval.lem
+++ b/frontend/model/core_eval.lem
@@ -1090,15 +1090,17 @@ KKK:              EU.return (PEval (Vloaded (LVspecified (OVstruct tag_sym xs)))
     | PEare_compatible pe1 pe2 ->
         self pe1 >>= fun pe1 ->
         self pe2 >>= fun pe2 ->
-        match (Caux.valueFromPexpr pe1, Caux.valueFromPexpr pe2) with
-          | (Just (Vctype ty1), Just (Vctype ty2)) ->
+        match (pe1, pe2) with
+          | (Pexpr _ _ (PEval (Vctype ty1)), Pexpr _ _ (PEval (Vctype ty2))) ->
               let are_compatible =
                 AilTypesAux.are_compatible
                   (Ctype.no_qualifiers, ty1)
                   (Ctype.no_qualifiers, ty2) in
               EU.return $ PEval (if are_compatible then Vtrue else Vfalse)
-          | (_, _) ->
+          | (Pexpr _ _ (PEval _), Pexpr _ _ (PEval _)) ->
               EU.fail $ Illformed_program "PEare_compatible: the operands should be ctypes"
+          | (_, _) ->
+              EU.return $ PEare_compatible pe1 pe2
         end
   end
   end

--- a/frontend/model/core_rewrite.lem
+++ b/frontend/model/core_rewrite.lem
@@ -1478,8 +1478,8 @@ let rewrite_fun_map fun_map =
         ProcDecl loc ty params
     | BuiltinDecl loc ty params ->
         BuiltinDecl loc ty params
-    | Proc loc mrk ty params e ->
-        Proc loc mrk ty params (rewrite_expr e)
+    | Proc loc mrk ty params e promotable ->
+        Proc loc mrk ty params (rewrite_expr e) promotable
   end) fun_map
 
 

--- a/frontend/model/core_run.lem
+++ b/frontend/model/core_run.lem
@@ -36,7 +36,7 @@ let call_proc core_extern file psym cvals =
     (* NOTE: the order of lookups implies that user procedure cannot hide the
        ones from stdlib, do we really want that? *)
     match Map.lookup psym file.stdlib with
-      | Just (Proc _ _ bTy params body) ->
+      | Just (Proc _ _ bTy params body _) ->
           Just (bTy, params, body)
       | _ ->
           let core_sym = match Map.lookup psym core_extern with
@@ -44,7 +44,7 @@ let call_proc core_extern file psym cvals =
             | Nothing -> psym
           end in
           match Map.lookup core_sym file.funs with
-            | Just (Proc _ _ bTy params body) ->
+            | Just (Proc _ _ bTy params body _) ->
                 Just (bTy, params, body)
             | _ ->
                 Nothing

--- a/frontend/model/core_run_aux.lem
+++ b/frontend/model/core_run_aux.lem
@@ -687,8 +687,8 @@ let convert_file file =
         ProcDecl loc bTy params
     | BuiltinDecl loc bTy params ->
         BuiltinDecl loc bTy params
-    | Proc loc mrk bTy params e ->
-        Proc loc mrk bTy params (convert_expr e)
+    | Proc loc mrk bTy params e  promotable ->
+        Proc loc mrk bTy params (convert_expr e) promotable
   end in
 
  <|

--- a/frontend/model/core_sequentialise.lem
+++ b/frontend/model/core_sequentialise.lem
@@ -69,8 +69,8 @@ let rec sequentialise_expr (Expr annot expr_) =
 val sequentialise_file: typed_file unit -> typed_file unit
 let sequentialise_file file =
   <| file with funs= Map.map (function
-       | Proc loc mrk bTy params e ->
-           Proc loc mrk bTy params (sequentialise_expr e)
+       | Proc loc mrk bTy params e promotable ->
+           Proc loc mrk bTy params (sequentialise_expr e) promotable
        | ProcDecl loc bTy params ->
            ProcDecl loc bTy params
        | BuiltinDecl loc bTy params ->

--- a/frontend/model/core_typing.lem
+++ b/frontend/model/core_typing.lem
@@ -1876,7 +1876,7 @@ let typecheck_program file =
             insert_tdecl (Sym sym) (TDfun bTy (List.map snd sym_bTys)) acc
         | ProcDecl _ bTy bTys ->
             insert_tdecl (Sym sym) (TDproc bTy bTys) acc
-        | Proc _ _ bTy sym_bTys _ ->
+        | Proc _ _ bTy sym_bTys _ _ ->
             insert_tdecl (Sym sym) (TDproc bTy (List.map snd sym_bTys)) acc
         | BuiltinDecl _ bTy bTys ->
             let name = match sym with
@@ -1903,10 +1903,11 @@ let typecheck_program file =
             E.return (ProcDecl loc bTy bTys)
         | BuiltinDecl loc bTy bTys ->
             E.return (BuiltinDecl loc bTy bTys)
-        | Proc loc mrk bTy sym_bTys e ->
+        | Proc loc mrk bTy sym_bTys e promotable ->
             let env' = List.foldr (fun (sym, bTy) acc -> insert_tdecl (Sym sym) (TDsym bTy) acc) env sym_bTys in
             collect_labels env' e >>= fun env' ->
-            Proc loc mrk bTy sym_bTys <$> typecheck_expr env' bTy e
+            typecheck_expr env' bTy e >>= fun e ->
+            E.return (Proc loc mrk bTy sym_bTys e promotable)
       end) file.stdlib >>= fun stdlib' ->
     
     (* Typechecking of the impl constants *)
@@ -1943,7 +1944,7 @@ let typecheck_program file =
               | _ -> error "typecheck_program: BuiltinDecl"
             end in
             insert_tdecl (Impl (I.BuiltinFunction name)) (TDproc bTy bTys) acc
-        | Proc _ _ bTy sym_bTys _ ->
+        | Proc _ _ bTy sym_bTys _ _ ->
             insert_tdecl (Sym sym) (TDproc bTy (List.map snd sym_bTys)) acc
       end) file.funs env in
     (* and typechecking them *)
@@ -1956,10 +1957,11 @@ let typecheck_program file =
             E.return (ProcDecl loc bTy bTys)
         | BuiltinDecl loc bTy bTys ->
             E.return (BuiltinDecl loc bTy bTys)
-        | Proc loc mrk bTy sym_bTys e ->
+        | Proc loc mrk bTy sym_bTys e promotable ->
             let env' = List.foldr (fun (sym, bTy) acc -> insert_tdecl (Sym sym) (TDsym bTy) acc) env sym_bTys in
             collect_labels env' e >>= fun env' ->
-            Proc loc mrk bTy sym_bTys <$> typecheck_expr env' bTy e
+            typecheck_expr env' bTy e >>= fun e ->
+            E.return (Proc loc mrk bTy sym_bTys e promotable)
       end) file.funs >>= fun funs' ->
     
     E.return <|

--- a/frontend/model/core_typing.lem
+++ b/frontend/model/core_typing.lem
@@ -929,7 +929,16 @@ and typecheck_pexpr tagDefs (env: typing_env) (bTy: core_base_type) (Pexpr annot
               E.fail loc (Mismatch "CivXOR" bTy (BTy_object OTy_integer))
           | (Cspecified, BTy_loaded oTy, [pe]) ->
               ret_ctor Cspecified <$> typecheck_pexpr tagDefs env (BTy_object oTy) pe
-          | (Cspecified, _, _) ->
+          | (Cspecified, BTy_storable, [pe]) ->
+              (* based on the infer_pexpr case for Cspecified, and the above *)
+              infer_pexpr tagDefs env pe >>= fun (Pexpr _ infer _ as pe') ->
+              match infer with
+                | InferredType_object oTy ->
+                    E.return (ret_ctor Cspecified pe')
+                | _ ->
+                    E.fail loc TooGeneral
+              end
+          | (Cspecified, _, pes) ->
               E.fail loc (MismatchExpected "Cspecified" bTy "loaded object")
           | (Cunspecified, BTy_loaded _, [pe]) ->
               ret_ctor Cunspecified <$> typecheck_pexpr tagDefs env BTy_ctype pe

--- a/frontend/model/core_unstruct.lem
+++ b/frontend/model/core_unstruct.lem
@@ -346,8 +346,8 @@ let rec explode_expr env (Expr annot expr_ as expr) =
 val explode_fun_map: typed_fun_map unit -> typed_fun_map unit
 let explode_fun_map funs =
   Map.map (function
-    | Proc loc mrk bTy xs e ->
-        Proc loc mrk bTy xs (explode_expr Map.empty e)
+    | Proc loc mrk bTy xs e promotable ->
+        Proc loc mrk bTy xs (explode_expr Map.empty e) promotable
     | z ->
         z
   end) funs

--- a/frontend/model/driver.lem
+++ b/frontend/model/driver.lem
@@ -1729,7 +1729,7 @@ let drive (with_concurrency: bool) file (arg_strs: list string) =
               ND.kill (ND.Other (DErr_other "the startup function has no definition"))
           | Core.BuiltinDecl _ _ _ ->
               ND.kill (ND.Other (DErr_other "the startup function has no definition"))
-          | Core.Proc loc _ _ params e ->
+          | Core.Proc loc _ _ params e _ ->
               ND.return (loc, params, e)
         end >>= fun (loc, params, expr) ->
         

--- a/frontend/model/translation.lem
+++ b/frontend/model/translation.lem
@@ -4446,6 +4446,7 @@ let translate_program stdlib (startup_sym_opt, sigm) =
                      (C.Proc loc (Just mrk) ret_bTy
                              ((*is_used_arg_type :: *)List.zip param_syms param_bTys ++ variadic_arg_type)
                              (Caux.mk_sseq_e (Caux.mk_empty_pat C.BTy_unit) (add_prelude_and_epilogue core_body) core_return)
+                             []
                      ) facc
                   , Map.insert sym finfo finfoacc )
           end

--- a/ocaml_frontend/core_remove_unused_functions.ml
+++ b/ocaml_frontend/core_remove_unused_functions.ml
@@ -416,7 +416,7 @@ let do_fun_map definitely_keep (fmap : ('bty,'a) generic_fun_map) =
            name_collector.names_in_core_base_type cbt
          ) >>
        name_collector.names_in_pexpr pe
-    | Proc (_loc, _mrk, cbt, args, e) -> 
+    | Proc (_loc, _mrk, cbt, args, e, promotable) -> 
        name_collector.names_in_core_base_type cbt >>
        iterate args (fun (sym,cbt) ->
            record_dep (Sym fn) (Sym sym) >>

--- a/ocaml_frontend/milicore.ml
+++ b/ocaml_frontend/milicore.ml
@@ -18,7 +18,7 @@ type 'TY mi_label_defs = (symbol, ('TY mi_label_def)) Pmap.map
 
 type 'TY mi_fun_map_decl =
   | Mi_Fun of bt * (symbol * bt) list * Core.pexpr
-  | Mi_Proc of Cerb_location.t * int option * bt * (symbol * bt) list * 'TY Core.expr * 'TY mi_label_defs
+  | Mi_Proc of Cerb_location.t * int option * bt * (symbol * bt) list * 'TY Core.expr * 'TY mi_label_defs * symbol list
   | Mi_ProcDecl of Cerb_location.t * bt * bt list
   | Mi_BuiltinDecl of Cerb_location.t * bt * bt list
 
@@ -92,7 +92,7 @@ let core_to_micore__funmap_decl update_loc = function
   | Core.Fun (bt, args, pe) -> Mi_Fun (bt, args, pe)
   | Core.ProcDecl (loc, bt, bts) -> Mi_ProcDecl (loc, bt, bts)
   | Core.BuiltinDecl (loc, bt, bts) -> Mi_BuiltinDecl (loc, bt, bts)
-  | Core.Proc (loc, mrk, bt, args, e) ->
+  | Core.Proc (loc, mrk, bt, args, e, promotable) ->
      let saves =
        Pmap.map (fun (_,params,body,annots) ->
            let param_tys = 
@@ -125,7 +125,7 @@ let core_to_micore__funmap_decl update_loc = function
            else Mi_Label (lloc, param_tys, params, remove_save body, annots)
          ) (Core_aux.m_collect_saves e)
      in
-     Mi_Proc(loc, mrk, bt, args, remove_save e, saves)
+     Mi_Proc(loc, mrk, bt, args, remove_save e, saves, promotable)
 
 
 

--- a/ocaml_frontend/milicore_label_inline.ml
+++ b/ocaml_frontend/milicore_label_inline.ml
@@ -105,7 +105,7 @@ let rec inline_label_labels_and_body ~to_inline ~to_keep body =
 
 
 let rewrite_fun_map_decl = function
-  | Mi_Proc (loc, mrk, rbt, arg_bts, body, label_defs) -> 
+  | Mi_Proc (loc, mrk, rbt, arg_bts, body, label_defs, promotable) -> 
      let to_keep, to_inline = 
        Pmap.fold (fun label def (to_keep, to_inline) ->
            match def with
@@ -121,7 +121,7 @@ let rewrite_fun_map_decl = function
          (Pmap.empty Symbol.symbol_compare, [])
      in
      let (label_defs, body) = inline_label_labels_and_body ~to_inline ~to_keep body in
-     Mi_Proc (loc, mrk, rbt, arg_bts, body, label_defs)
+     Mi_Proc (loc, mrk, rbt, arg_bts, body, label_defs, promotable)
   | d -> d
 
 

--- a/ocaml_frontend/pprinters/pp_core.ml
+++ b/ocaml_frontend/pprinters/pp_core.ml
@@ -786,7 +786,7 @@ let pp_fun_map funs =
       | BuiltinDecl (loc, bTy, bTys) ->
           pp_cond loc @@
           pp_keyword "builtin" ^^^ pp_symbol sym ^^^ P.parens (comma_list pp_core_base_type bTys) ^^ P.hardline ^^ P.hardline
-      | Proc (loc, _mrk, bTy, params, e) ->
+      | Proc (loc, _mrk, bTy, params, e, _promotable) ->
           pp_cond loc @@
           pp_keyword "proc" ^^^ pp_symbol sym ^^^ pp_params params ^^ P.colon ^^^ pp_keyword "eff" ^^^ pp_core_base_type bTy ^^^
           P.colon ^^ P.equals ^^

--- a/ocaml_frontend/pprinters/pp_core_ast.ml
+++ b/ocaml_frontend/pprinters/pp_core_ast.ml
@@ -489,10 +489,12 @@ let dtree_of_funs xs =
           Dnode ( pp_field "Fun" ^^^ pp_symbol sym ^^ P.colon ^^^ Pp_core.Basic.pp_core_base_type bTy
                 , [ Dnode (pp_field ".params", List.map dtree_of_param params)
                   ; Dnode (pp_field ".body", [dtree_of_pexpr pe]) ] )
-      | Proc (loc, _mrk, bTy, params, e) ->
+      | Proc (loc, _mrk, bTy, params, e, promotable) ->
           Dnode ( pp_field "Proc" ^^^ pp_symbol sym ^^ P.colon ^^^ Pp_core.Basic.pp_core_base_type bTy
                 , [ Dnode (pp_field ".params", List.map dtree_of_param params)
-                  ; Dnode (pp_field ".body", [dtree_of_expr e]) ] )
+                  ; Dnode (pp_field ".body", [dtree_of_expr e]) 
+                  ; Dnode (pp_field ".promotable", [
+                        Dleaf (P.braces (P.separate_map (P.comma ^^ P.space) pp_symbol promotable)) ] ) ] )
       | ProcDecl (loc, ret_bTy, params_bTys) ->
           (* TODO: loc*)
           Dleaf ( pp_field "ProcDecl" ^^^ pp_symbol sym ^^ P.colon ^^^

--- a/ocaml_frontend/rewriters/copy_propagation.ml
+++ b/ocaml_frontend/rewriters/copy_propagation.ml
@@ -78,11 +78,45 @@ let rec binders_of_pat (Pattern (_, pat_)) =
 (* new_pat and new_pe are type-compatible with each other.           *)
 (* ------------------------------------------------------------------ *)
 
+let is_integer_annot = function
+  | Annot.Avalue (Ainteger ity) -> Some ity
+  | _ -> None
+
+let remove_integer_annot annots =
+  List.filter (fun a -> Option.is_none (is_integer_annot a)) annots
+
+(* integer annotations are used to figure out bit-vector (checking)
+ * types for pure expressions, of various kinds, so must be removed
+ * from units *)
 let unit_pexpr (Pexpr (annots, bty, _)) =
-  Pexpr (annots, bty, PEval Vunit)
+  Pexpr (remove_integer_annot annots, bty, PEval Vunit)
 
 let wildcard_pat (Pattern (p_annots, _)) =
   Pattern (p_annots, CaseBase (None, BTy_unit))
+
+let unit_pat_pe pat pe =
+  let Pattern (p_annots, pat_) = pat in
+  let Pexpr (annots, bty, pe_) = pe in
+  match pat_, pe_ with
+  | CaseBase (_, BTy_unit), PEval Vunit ->
+    true
+  | _ ->
+    false
+
+(* integer annotations are sometimes placed on the outside of an
+ * expression, such as
+ * {- cn_value: signed int -}pure(Specified(4))
+ *
+ * during pattern matching and substitution, these must be pushed
+ * in so that the substitution expression also carries the same *)
+let push_integer_annot annot pexpr =
+  match List.filter_map is_integer_annot annot with
+  | [] -> pexpr
+  | _ :: _ as itys ->
+    let annots = List.map (fun x -> Annot.Avalue (Ainteger x)) itys in
+    (* see https://github.com/rems-project/cerberus/issues/1000 *)
+    let Pexpr (inner_annots, inner_bty, inner_pe_) = pexpr in
+    Pexpr (annots @ inner_annots, inner_bty, inner_pe_)
 
 let rec analyze_pat_pexpr binders pat pe =
   let Pattern (p_annots, pat_) = pat in
@@ -109,14 +143,34 @@ let rec analyze_pat_pexpr binders pat pe =
 
   | CaseCtor (Cspecified, [inner_pat]),
     Pexpr (pe_annots, pe_bty, PEctor (Cspecified, [inner_pe])) ->
-      let (bindings, new_inner_pat, new_inner_pe) =
-        analyze_pat_pexpr binders inner_pat inner_pe in
-      ( bindings
-      , Pattern (p_annots, CaseCtor (Cspecified, [new_inner_pat]))
-      , Pexpr (pe_annots, pe_bty, PEctor (Cspecified, [new_inner_pe])) )
+      analyse_specified_pat_expr binders (p_annots, inner_pat) (pe_annots, pe_bty, inner_pe)
+
+  | CaseCtor (Cspecified, [inner_pat]),
+    Pexpr (pe_annots, pe_bty, PEval (Vloaded (LVspecified ov))) ->
+      let inner_pe = Pexpr (pe_annots, pe_bty, PEval (Vobject ov)) in
+      analyse_specified_pat_expr binders (p_annots, inner_pat) (pe_annots, pe_bty, inner_pe)
 
   | _ ->
       ([], pat, pe)
+
+and analyse_specified_pat_expr binders (p_annots, inner_pat) (pe_annots, pe_bty, inner_pe) =
+  (* so that the subsitution gets any annotations *)
+  let inner_pe = push_integer_annot pe_annots inner_pe in
+  let (bindings, new_inner_pat, new_inner_pe) =
+    analyze_pat_pexpr binders inner_pat inner_pe in
+  if unit_pat_pe new_inner_pat new_inner_pe then
+    let Pexpr (inner_annots, inner_bty, inner_pe_) = new_inner_pe in
+    (* but unit values have such annotations removed *)
+    let annots = remove_integer_annot (pe_annots @ inner_annots) in
+    let new_inner_pe = Pexpr (annots, inner_bty, inner_pe_) in
+    ( bindings , new_inner_pat , new_inner_pe )
+  else
+    (* if it's already been pushed inside, the outer will duplicate it *)
+    let pe_annots = remove_integer_annot pe_annots in
+    ( bindings
+    , Pattern (p_annots, CaseCtor (Cspecified, [new_inner_pat]))
+    , Pexpr (pe_annots, pe_bty, PEctor (Cspecified, [new_inner_pe])) )
+
 
 (* ------------------------------------------------------------------ *)
 (* analyze_pat_expr: pattern-aware single-pass analysis for exprs    *)
@@ -126,12 +180,24 @@ let rec analyze_pat_pexpr binders pat pe =
 (* where new_pat and new_e are type-compatible.                       *)
 (* ------------------------------------------------------------------ *)
 
+let push_loc_annot annot pexpr =
+  match List.filter (function Annot.Aloc _ -> true | _ -> false)  annot with
+  | [] -> pexpr
+  | [ loc ] ->
+    let Pexpr (inner_annots, inner_bty, inner_pe_) = pexpr in
+    Pexpr (loc :: inner_annots, inner_bty, inner_pe_)
+  | _ :: _ :: _ -> assert (false)
+
 let rec analyze_pat_expr binders pat (Expr (annot, e_) as expr) =
   let ret_e e_ = Expr (annot, e_) in
   match e_ with
   | Epure pe ->
+      (* so that the subsitution gets any annotations *)
+      let pe = push_integer_annot annot pe in
+      let pe = push_loc_annot annot pe in
       let (bs, new_pat, new_pe) = analyze_pat_pexpr binders pat pe in
-      (bs, new_pat, ret_e (Epure new_pe))
+      (* if it's already been pushed inside, the outer will duplicate it *)
+      (bs, new_pat, Expr (remove_integer_annot annot, Epure new_pe))
 
   | Eunseq es ->
       let Pattern (p_annots, pat_) = pat in

--- a/ocaml_frontend/rewriters/copy_propagation.ml
+++ b/ocaml_frontend/rewriters/copy_propagation.ml
@@ -10,6 +10,9 @@ let empty_env : env = Pmap.empty Symbol.compare_sym
 
 let extend_env env alias pe = Pmap.add alias pe env
 
+let extend_env_list env bindings =
+  List.fold_left (fun acc (s, pe) -> extend_env acc s pe) env bindings
+
 (* ------------------------------------------------------------------ *)
 (* pexpr_safe: conservative free-variable check                       *)
 (*                                                                    *)
@@ -64,25 +67,38 @@ let rec binders_of_pat (Pattern (_, pat_)) =
   | CaseCtor (_, pats)   -> List.concat_map binders_of_pat pats
 
 (* ------------------------------------------------------------------ *)
-(* tail_pexpr: find the tail pure expression of an expression         *)
+(* pexpr_tree: rose tree of pexpr option mirroring Eunseq structure  *)
 (*                                                                    *)
-(* Returns [Some pe] when the expression's tail is [pure(pe)]        *)
-(* AND no free symbol of [pe] appears in the binders accumulated      *)
-(* along the linear chain leading to the tail.                        *)
+(* Leaf(Some pe) — this position has a known, safe-to-hoist pexpr.  *)
+(* Leaf None     — this position is opaque (action, unsafe, etc.).   *)
+(* Node ts       — this position is an Eunseq with children ts.      *)
+(* ------------------------------------------------------------------ *)
+
+type pexpr_tree =
+  | Leaf of pexpr option
+  | Node of pexpr_tree list
+
+(* ------------------------------------------------------------------ *)
+(* tail_pexpr: compute the pexpr_tree for the tail of an expression  *)
 (*                                                                    *)
-(* The accumulator [binders] collects every symbol introduced by a   *)
-(* binding pattern along the traversed chain.  At the leaf, if any  *)
-(* free symbol of [pe] is in [binders] it was defined locally and    *)
-(* must not escape.                                                   *)
+(* At [Epure pe]: returns Leaf(Some pe) when pe is safe to hoist     *)
+(* (no free symbol of pe appears in binders along the chain), else   *)
+(* Leaf None.                                                         *)
 (*                                                                    *)
-(* Returns [None] for branching nodes (Eif, Ecase, Eunseq, Esave,   *)
-(* Erun), actions, or when the tail pexpr is not safe to hoist.      *)
+(* At [Eunseq es]: returns Node(map tail_pexpr es), preserving the   *)
+(* nesting structure so that tuple patterns can be matched against    *)
+(* it element-wise.                                                   *)
+(*                                                                    *)
+(* Along binding chains (Ewseq/Esseq/Elet): accumulates binders and  *)
+(* recurses into the continuation.                                    *)
 (* ------------------------------------------------------------------ *)
 
 let rec tail_pexpr_acc binders (Expr (_, e_)) =
   match e_ with
   | Epure pe ->
-      if pexpr_safe binders pe then Some pe else None
+      Leaf (if pexpr_safe binders pe then Some pe else None)
+  | Eunseq es ->
+      Node (List.map (tail_pexpr_acc binders) es)
   | Ewseq (pat, _, e2) | Esseq (pat, _, e2) ->
       tail_pexpr_acc (binders_of_pat pat @ binders) e2
   | Elet (pat, _, e2) ->
@@ -90,9 +106,51 @@ let rec tail_pexpr_acc binders (Expr (_, e_)) =
   | Ebound e | Eannot (_, e) ->
       tail_pexpr_acc binders e
   | _ ->
-      None
+      Leaf None
 
 let tail_pexpr e = tail_pexpr_acc [] e
+
+(* ------------------------------------------------------------------ *)
+(* match_pat_tree: extract bindings by walking pattern and tree       *)
+(*                                                                    *)
+(* Returns (bindings, new_pattern) where:                             *)
+(*   bindings    — (sym, pexpr) pairs for extractable positions       *)
+(*   new_pattern — pattern with extracted positions wildcarded        *)
+(*                                                                    *)
+(* Partial: positions where the tree has Leaf None are left named.   *)
+(* ------------------------------------------------------------------ *)
+
+let rec match_pat_tree pat tree =
+  match pat, tree with
+
+  | Pattern (p_annots, CaseBase (Some s, cbty)), Leaf (Some pe) ->
+      ([(s, pe)], Pattern (p_annots, CaseBase (None, cbty)))
+
+  | Pattern (_, CaseBase (Some _, _)), (Leaf None | Node _) ->
+      ([], pat)
+
+  | Pattern (_, CaseBase (None, _)), _ ->
+      ([], pat)
+
+  (* Tuple pattern vs a matching-arity Node (Eunseq): recurse element-wise *)
+  | Pattern (p_annots, CaseCtor (Ctuple, pats)), Node trees
+    when List.length pats = List.length trees ->
+      let results = List.map2 match_pat_tree pats trees in
+      let bindings = List.concat_map fst results in
+      let new_pats = List.map snd results in
+      (bindings, Pattern (p_annots, CaseCtor (Ctuple, new_pats)))
+
+  (* Tuple pattern vs pure-tuple leaf: decompose the pexpr element-wise *)
+  | Pattern (p_annots, CaseCtor (Ctuple, pats)),
+    Leaf (Some (Pexpr (_, _, PEctor (Ctuple, pes))))
+    when List.length pats = List.length pes ->
+      let results = List.map2 (fun p pe -> match_pat_tree p (Leaf (Some pe))) pats pes in
+      let bindings = List.concat_map fst results in
+      let new_pats = List.map snd results in
+      (bindings, Pattern (p_annots, CaseCtor (Ctuple, new_pats)))
+
+  | _ ->
+      ([], pat)
 
 (* ------------------------------------------------------------------ *)
 (* Mutually recursive propagation functions.                          *)
@@ -239,12 +297,12 @@ and propagate_expr env (Expr (annots, e_) as expr) =
   | Ewseq (Pattern (p_annots, CaseBase (Some alias, cbty)), e1, body) ->
       let e1' = propagate_expr env e1 in
       begin match tail_pexpr e1' with
-      | Some pe_tail ->
+      | Leaf (Some pe_tail) ->
           Expr (annots,
             Ewseq (Pattern (p_annots, CaseBase (None, cbty)),
                    e1',
                    propagate_expr (extend_env env alias pe_tail) body))
-      | None ->
+      | _ ->
           Expr (annots,
             Ewseq (Pattern (p_annots, CaseBase (Some alias, cbty)),
                    e1',
@@ -254,12 +312,12 @@ and propagate_expr env (Expr (annots, e_) as expr) =
   | Esseq (Pattern (p_annots, CaseBase (Some alias, cbty)), e1, body) ->
       let e1' = propagate_expr env e1 in
       begin match tail_pexpr e1' with
-      | Some pe_tail ->
+      | Leaf (Some pe_tail) ->
           Expr (annots,
             Esseq (Pattern (p_annots, CaseBase (None, cbty)),
                    e1',
                    propagate_expr (extend_env env alias pe_tail) body))
-      | None ->
+      | _ ->
           Expr (annots,
             Esseq (Pattern (p_annots, CaseBase (Some alias, cbty)),
                    e1',
@@ -283,13 +341,24 @@ and propagate_expr env (Expr (annots, e_) as expr) =
                   propagate_expr env body))
       end
 
-  (* ---- Recurse into non-matching Ewseq/Esseq/Elet nodes ---- *)
-  | Ewseq (pat, e1, e2) ->
-      Expr (annots, Ewseq (pat, pe e1, pe e2))
-  | Esseq (pat, e1, e2) ->
-      Expr (annots, Esseq (pat, pe e1, pe e2))
-  | Elet (pat, pe1, e2) ->
-      Expr (annots, Elet (pat, pp pe1, pe e2))
+  (* ---- Catch-all Ewseq/Esseq/Elet: try tuple extraction via match_pat_tree ---- *)
+  | Ewseq (pat, e1, body) ->
+      let e1' = propagate_expr env e1 in
+      let (bindings, new_pat) = match_pat_tree pat (tail_pexpr e1') in
+      let env' = extend_env_list env bindings in
+      Expr (annots, Ewseq (new_pat, e1', propagate_expr env' body))
+
+  | Esseq (pat, e1, body) ->
+      let e1' = propagate_expr env e1 in
+      let (bindings, new_pat) = match_pat_tree pat (tail_pexpr e1') in
+      let env' = extend_env_list env bindings in
+      Expr (annots, Esseq (new_pat, e1', propagate_expr env' body))
+
+  | Elet (pat, pe1, body) ->
+      let pe1' = propagate_pexpr env pe1 in
+      let (bindings, new_pat) = match_pat_tree pat (Leaf (Some pe1')) in
+      let env' = extend_env_list env bindings in
+      Expr (annots, Elet (new_pat, pe1', propagate_expr env' body))
 
   (* ---- Other expression forms: recurse ---- *)
   | Epure pe1 ->

--- a/ocaml_frontend/rewriters/copy_propagation.ml
+++ b/ocaml_frontend/rewriters/copy_propagation.ml
@@ -1,70 +1,113 @@
 open Core
 
 (* ------------------------------------------------------------------ *)
-(* Environment: symbol → symbol renaming map                          *)
+(* Environment: symbol → pexpr map                                    *)
 (* ------------------------------------------------------------------ *)
 
-type env = (Symbol.sym, Symbol.sym) Pmap.map
+type env = (Symbol.sym, pexpr) Pmap.map
 
 let empty_env : env = Pmap.empty Symbol.compare_sym
 
-(* Follow the env: if [s] is mapped, return its target; else return [s]. *)
-let apply_env env s =
-  match Pmap.lookup s env with
-  | Some s' -> s'
-  | None    -> s
-
-let extend_env env alias src = Pmap.add alias src env
+let extend_env env alias pe = Pmap.add alias pe env
 
 (* ------------------------------------------------------------------ *)
-(* tail_sym: find the tail pure(sym) of an expression, if outer      *)
+(* pexpr_safe: conservative free-variable check                       *)
 (*                                                                    *)
-(* Returns [Some s] when the expression's tail is [pure(PEsym s)]    *)
-(* AND [s] is not bound along the linear chain leading to the tail   *)
-(* (i.e. [s] is an outer variable, safe to reference in the body).  *)
+(* Returns [true] when none of [pe]'s free symbols appear in         *)
+(* [binders].  Complex forms (PEif, PElet, PEcase, PEconstrained)    *)
+(* return [false] conservatively to avoid a full free-variable        *)
+(* analysis.                                                          *)
+(* ------------------------------------------------------------------ *)
+
+let sym_in binders s =
+  List.exists (fun b -> Symbol.compare_sym s b = 0) binders
+
+let rec pexpr_safe binders (Pexpr (_, _, pe_)) =
+  match pe_ with
+  | PEsym s ->
+      not (sym_in binders s)
+  | PEval _ | PEimpl _ | PEundef _ | PEerror _ ->
+      true
+  | PEctor (_, pes) ->
+      List.for_all (pexpr_safe binders) pes
+  | PEnot pe1 ->
+      pexpr_safe binders pe1
+  | PEop (_, pe1, pe2)
+  | PEwrapI (_, _, pe1, pe2)
+  | PEcatch_exceptional_condition (_, _, pe1, pe2)
+  | PEare_compatible (pe1, pe2)
+  | PEarray_shift (pe1, _, pe2) ->
+      pexpr_safe binders pe1 && pexpr_safe binders pe2
+  | PEmemberof (_, _, pe1)
+  | PEmember_shift (pe1, _, _)
+  | PEconv_int (_, pe1)
+  | PEis_scalar pe1 | PEis_integer pe1
+  | PEis_signed pe1 | PEis_unsigned pe1
+  | PEbmc_assume pe1 | PEcfunction pe1
+  | PEunion (_, _, pe1) ->
+      pexpr_safe binders pe1
+  | PEmemop (_, pes) | PEcall (_, pes) ->
+      List.for_all (pexpr_safe binders) pes
+  | PEstruct (_, fields) ->
+      List.for_all (fun (_, pe1) -> pexpr_safe binders pe1) fields
+  | PEif _ | PElet _ | PEcase _ | PEconstrained _ ->
+      false  (* conservative *)
+
+(* ------------------------------------------------------------------ *)
+(* binders_of_pat: collect all named symbols in a pattern             *)
+(* ------------------------------------------------------------------ *)
+
+let rec binders_of_pat (Pattern (_, pat_)) =
+  match pat_ with
+  | CaseBase (None, _)   -> []
+  | CaseBase (Some s, _) -> [s]
+  | CaseCtor (_, pats)   -> List.concat_map binders_of_pat pats
+
+(* ------------------------------------------------------------------ *)
+(* tail_pexpr: find the tail pure expression of an expression         *)
+(*                                                                    *)
+(* Returns [Some pe] when the expression's tail is [pure(pe)]        *)
+(* AND no free symbol of [pe] appears in the binders accumulated      *)
+(* along the linear chain leading to the tail.                        *)
 (*                                                                    *)
 (* The accumulator [binders] collects every symbol introduced by a   *)
-(* binding pattern along the traversed chain.  At the leaf, if [s]  *)
-(* appears in [binders] it was defined locally and must not escape.  *)
+(* binding pattern along the traversed chain.  At the leaf, if any  *)
+(* free symbol of [pe] is in [binders] it was defined locally and    *)
+(* must not escape.                                                   *)
 (*                                                                    *)
 (* Returns [None] for branching nodes (Eif, Ecase, Eunseq, Esave,   *)
-(* Erun), actions, or when the tail sym is locally bound.            *)
+(* Erun), actions, or when the tail pexpr is not safe to hoist.      *)
 (* ------------------------------------------------------------------ *)
 
-let rec tail_sym_acc binders (Expr (_, e_)) =
+let rec tail_pexpr_acc binders (Expr (_, e_)) =
   match e_ with
-  | Epure (Pexpr (_, _, PEsym s)) ->
-      if List.exists (fun b -> Symbol.compare_sym s b = 0) binders
-      then None
-      else Some s
-  | Ewseq (Pattern (_, CaseBase (Some s, _)), _, e2)
-  | Esseq (Pattern (_, CaseBase (Some s, _)), _, e2) ->
-      tail_sym_acc (s :: binders) e2
-  | Ewseq (_, _, e2) | Esseq (_, _, e2) ->
-      tail_sym_acc binders e2
-  | Elet (Pattern (_, CaseBase (Some s, _)), _, e2) ->
-      tail_sym_acc (s :: binders) e2
-  | Elet (_, _, e2) ->
-      tail_sym_acc binders e2
+  | Epure pe ->
+      if pexpr_safe binders pe then Some pe else None
+  | Ewseq (pat, _, e2) | Esseq (pat, _, e2) ->
+      tail_pexpr_acc (binders_of_pat pat @ binders) e2
+  | Elet (pat, _, e2) ->
+      tail_pexpr_acc (binders_of_pat pat @ binders) e2
   | Ebound e | Eannot (_, e) ->
-      tail_sym_acc binders e
+      tail_pexpr_acc binders e
   | _ ->
       None
 
-let tail_sym e = tail_sym_acc [] e
+let tail_pexpr e = tail_pexpr_acc [] e
 
 (* ------------------------------------------------------------------ *)
 (* Mutually recursive propagation functions.                          *)
 (*                                                                    *)
 (* propagate_pexpr, propagate_action, propagate_expr thread an env   *)
-(* (alias → canonical sym) through the Core IR in a single top-down  *)
-(* pass, rewriting PEsym occurrences and dropping trivial bindings.  *)
+(* (alias → pexpr) through the Core IR in a single top-down pass,   *)
+(* rewriting PEsym occurrences and dropping trivial bindings.        *)
 (* ------------------------------------------------------------------ *)
 
 let rec propagate_pexpr env (Pexpr (annots, bty, pe_) as pe) =
   match pe_ with
   | PEsym s ->
-      Pexpr (annots, bty, PEsym (apply_env env s))
+      (match Pmap.lookup s env with
+       | Some pe' -> pe'
+       | None     -> Pexpr (annots, bty, PEsym s))
   | PEval _ | PEimpl _ | PEundef _ | PEerror _ | PEconstrained _ ->
       pe
 
@@ -72,11 +115,13 @@ let rec propagate_pexpr env (Pexpr (annots, bty, pe_) as pe) =
   | PElet (Pattern (p_annots, CaseBase (Some alias, cbty)),
            (Pexpr (_, _, PEsym src) as rhs),
            body) ->
-      let src' = apply_env env src in
+      let pe_src = match Pmap.lookup src env with
+                   | Some pe' -> pe'
+                   | None     -> rhs in
       Pexpr (annots, bty,
         PElet (Pattern (p_annots, CaseBase (None, cbty)),
                propagate_pexpr env rhs,
-               propagate_pexpr (extend_env env alias src') body))
+               propagate_pexpr (extend_env env alias pe_src) body))
 
   | PElet (pat, pe1, pe2) ->
       Pexpr (annots, bty, PElet (pat,
@@ -184,50 +229,53 @@ and propagate_expr env (Expr (annots, e_) as expr) =
   match e_ with
 
   (* ---- CaseBase bindings with a named pattern.
-     tail_sym handles both the bare pure(sym) case and the effectful-RHS
-     case (where the tail is pure(sym) with src not locally bound inside e1).
+     tail_pexpr handles both the bare pure(pe) case and the effectful-RHS
+     case (where the tail is pure(pe) with all free syms of pe not locally
+     bound inside e1).
      When it succeeds: replace the pattern with a wildcard, extend env, and
      propagate body.  The binding node is always preserved so that its
      annotations (source locations) are not lost.
      For Elet the RHS is a pexpr, so we match directly on PEsym.          ---- *)
   | Ewseq (Pattern (p_annots, CaseBase (Some alias, cbty)), e1, body) ->
-      begin match tail_sym e1 with
-      | Some src ->
-          let src' = apply_env env src in
+      let e1' = propagate_expr env e1 in
+      begin match tail_pexpr e1' with
+      | Some pe_tail ->
           Expr (annots,
             Ewseq (Pattern (p_annots, CaseBase (None, cbty)),
-                   propagate_expr env e1,
-                   propagate_expr (extend_env env alias src') body))
+                   e1',
+                   propagate_expr (extend_env env alias pe_tail) body))
       | None ->
           Expr (annots,
             Ewseq (Pattern (p_annots, CaseBase (Some alias, cbty)),
-                   propagate_expr env e1,
+                   e1',
                    propagate_expr env body))
       end
 
   | Esseq (Pattern (p_annots, CaseBase (Some alias, cbty)), e1, body) ->
-      begin match tail_sym e1 with
-      | Some src ->
-          let src' = apply_env env src in
+      let e1' = propagate_expr env e1 in
+      begin match tail_pexpr e1' with
+      | Some pe_tail ->
           Expr (annots,
             Esseq (Pattern (p_annots, CaseBase (None, cbty)),
-                   propagate_expr env e1,
-                   propagate_expr (extend_env env alias src') body))
+                   e1',
+                   propagate_expr (extend_env env alias pe_tail) body))
       | None ->
           Expr (annots,
             Esseq (Pattern (p_annots, CaseBase (Some alias, cbty)),
-                   propagate_expr env e1,
+                   e1',
                    propagate_expr env body))
       end
 
   | Elet (Pattern (p_annots, CaseBase (Some alias, cbty)), pe1, body) ->
       begin match pe1 with
       | Pexpr (_, _, PEsym src) ->
-          let src' = apply_env env src in
+          let pe_src = match Pmap.lookup src env with
+                       | Some pe' -> pe'
+                       | None     -> pe1 in
           Expr (annots,
             Elet (Pattern (p_annots, CaseBase (None, cbty)),
                   propagate_pexpr env pe1,
-                  propagate_expr (extend_env env alias src') body))
+                  propagate_expr (extend_env env alias pe_src) body))
       | _ ->
           Expr (annots,
             Elet (Pattern (p_annots, CaseBase (Some alias, cbty)),

--- a/ocaml_frontend/rewriters/copy_propagation.ml
+++ b/ocaml_frontend/rewriters/copy_propagation.ml
@@ -1,0 +1,304 @@
+open Core
+
+(* ------------------------------------------------------------------ *)
+(* Environment: symbol → symbol renaming map                          *)
+(* ------------------------------------------------------------------ *)
+
+type env = (Symbol.sym, Symbol.sym) Pmap.map
+
+let empty_env : env = Pmap.empty Symbol.compare_sym
+
+(* Follow the env: if [s] is mapped, return its target; else return [s]. *)
+let apply_env env s =
+  match Pmap.lookup s env with
+  | Some s' -> s'
+  | None    -> s
+
+let extend_env env alias src = Pmap.add alias src env
+
+(* ------------------------------------------------------------------ *)
+(* tail_sym: find the tail pure(sym) of an expression, if outer      *)
+(*                                                                    *)
+(* Returns [Some s] when the expression's tail is [pure(PEsym s)]    *)
+(* AND [s] is not bound along the linear chain leading to the tail   *)
+(* (i.e. [s] is an outer variable, safe to reference in the body).  *)
+(*                                                                    *)
+(* The accumulator [binders] collects every symbol introduced by a   *)
+(* binding pattern along the traversed chain.  At the leaf, if [s]  *)
+(* appears in [binders] it was defined locally and must not escape.  *)
+(*                                                                    *)
+(* Returns [None] for branching nodes (Eif, Ecase, Eunseq, Esave,   *)
+(* Erun), actions, or when the tail sym is locally bound.            *)
+(* ------------------------------------------------------------------ *)
+
+let rec tail_sym_acc binders (Expr (_, e_)) =
+  match e_ with
+  | Epure (Pexpr (_, _, PEsym s)) ->
+      if List.exists (fun b -> Symbol.compare_sym s b = 0) binders
+      then None
+      else Some s
+  | Ewseq (Pattern (_, CaseBase (Some s, _)), _, e2)
+  | Esseq (Pattern (_, CaseBase (Some s, _)), _, e2) ->
+      tail_sym_acc (s :: binders) e2
+  | Ewseq (_, _, e2) | Esseq (_, _, e2) ->
+      tail_sym_acc binders e2
+  | Elet (Pattern (_, CaseBase (Some s, _)), _, e2) ->
+      tail_sym_acc (s :: binders) e2
+  | Elet (_, _, e2) ->
+      tail_sym_acc binders e2
+  | Ebound e | Eannot (_, e) ->
+      tail_sym_acc binders e
+  | _ ->
+      None
+
+let tail_sym e = tail_sym_acc [] e
+
+(* ------------------------------------------------------------------ *)
+(* Mutually recursive propagation functions.                          *)
+(*                                                                    *)
+(* propagate_pexpr, propagate_action, propagate_expr thread an env   *)
+(* (alias → canonical sym) through the Core IR in a single top-down  *)
+(* pass, rewriting PEsym occurrences and dropping trivial bindings.  *)
+(* ------------------------------------------------------------------ *)
+
+let rec propagate_pexpr env (Pexpr (annots, bty, pe_) as pe) =
+  match pe_ with
+  | PEsym s ->
+      Pexpr (annots, bty, PEsym (apply_env env s))
+  | PEval _ | PEimpl _ | PEundef _ | PEerror _ | PEconstrained _ ->
+      pe
+
+  (* Replace named pattern with wildcard, extend env; node is preserved. *)
+  | PElet (Pattern (p_annots, CaseBase (Some alias, cbty)),
+           (Pexpr (_, _, PEsym src) as rhs),
+           body) ->
+      let src' = apply_env env src in
+      Pexpr (annots, bty,
+        PElet (Pattern (p_annots, CaseBase (None, cbty)),
+               propagate_pexpr env rhs,
+               propagate_pexpr (extend_env env alias src') body))
+
+  | PElet (pat, pe1, pe2) ->
+      Pexpr (annots, bty, PElet (pat,
+        propagate_pexpr env pe1,
+        propagate_pexpr env pe2))
+  | PEctor (c, pes) ->
+      Pexpr (annots, bty, PEctor (c, List.map (propagate_pexpr env) pes))
+  | PEcase (pe1, arms) ->
+      Pexpr (annots, bty, PEcase (propagate_pexpr env pe1,
+        List.map (fun (pat, pe2) -> (pat, propagate_pexpr env pe2)) arms))
+  | PEarray_shift (pe1, cty, pe2) ->
+      Pexpr (annots, bty,
+        PEarray_shift (propagate_pexpr env pe1, cty, propagate_pexpr env pe2))
+  | PEmember_shift (pe1, sym, id) ->
+      Pexpr (annots, bty, PEmember_shift (propagate_pexpr env pe1, sym, id))
+  | PEmemop (op, pes) ->
+      Pexpr (annots, bty, PEmemop (op, List.map (propagate_pexpr env) pes))
+  | PEnot pe1 ->
+      Pexpr (annots, bty, PEnot (propagate_pexpr env pe1))
+  | PEop (op, pe1, pe2) ->
+      Pexpr (annots, bty,
+        PEop (op, propagate_pexpr env pe1, propagate_pexpr env pe2))
+  | PEconv_int (ity, pe1) ->
+      Pexpr (annots, bty, PEconv_int (ity, propagate_pexpr env pe1))
+  | PEwrapI (ity, iop, pe1, pe2) ->
+      Pexpr (annots, bty,
+        PEwrapI (ity, iop, propagate_pexpr env pe1, propagate_pexpr env pe2))
+  | PEcatch_exceptional_condition (ity, iop, pe1, pe2) ->
+      Pexpr (annots, bty,
+        PEcatch_exceptional_condition (ity, iop,
+          propagate_pexpr env pe1,
+          propagate_pexpr env pe2))
+  | PEstruct (sym, fields) ->
+      Pexpr (annots, bty,
+        PEstruct (sym,
+          List.map (fun (id, pe1) -> (id, propagate_pexpr env pe1)) fields))
+  | PEunion (sym, id, pe1) ->
+      Pexpr (annots, bty, PEunion (sym, id, propagate_pexpr env pe1))
+  | PEcfunction pe1 ->
+      Pexpr (annots, bty, PEcfunction (propagate_pexpr env pe1))
+  | PEmemberof (sym, id, pe1) ->
+      Pexpr (annots, bty, PEmemberof (sym, id, propagate_pexpr env pe1))
+  | PEcall (name, pes) ->
+      Pexpr (annots, bty, PEcall (name, List.map (propagate_pexpr env) pes))
+  | PEif (pe1, pe2, pe3) ->
+      Pexpr (annots, bty, PEif (
+        propagate_pexpr env pe1,
+        propagate_pexpr env pe2,
+        propagate_pexpr env pe3))
+  | PEis_scalar pe1 ->
+      Pexpr (annots, bty, PEis_scalar (propagate_pexpr env pe1))
+  | PEis_integer pe1 ->
+      Pexpr (annots, bty, PEis_integer (propagate_pexpr env pe1))
+  | PEis_signed pe1 ->
+      Pexpr (annots, bty, PEis_signed (propagate_pexpr env pe1))
+  | PEis_unsigned pe1 ->
+      Pexpr (annots, bty, PEis_unsigned (propagate_pexpr env pe1))
+  | PEbmc_assume pe1 ->
+      Pexpr (annots, bty, PEbmc_assume (propagate_pexpr env pe1))
+  | PEare_compatible (pe1, pe2) ->
+      Pexpr (annots, bty,
+        PEare_compatible (propagate_pexpr env pe1, propagate_pexpr env pe2))
+
+(* Propagate env into all pexprs inside an action. *)
+and propagate_action env (Paction (pol, Action (loc, a, act_))) =
+  let pp = propagate_pexpr env in
+  let act_' = match act_ with
+    | Create (pe1, pe2, prefix) ->
+        Create (pp pe1, pp pe2, prefix)
+    | CreateReadOnly (pe1, pe2, pe3, prefix) ->
+        CreateReadOnly (pp pe1, pp pe2, pp pe3, prefix)
+    | Alloc0 (pe1, pe2, prefix) ->
+        Alloc0 (pp pe1, pp pe2, prefix)
+    | Kill (kind, pe1) ->
+        Kill (kind, pp pe1)
+    | Store0 (lk, pe1, pe2, pe3, mo) ->
+        Store0 (lk, pp pe1, pp pe2, pp pe3, mo)
+    | Load0 (pe1, pe2, mo) ->
+        Load0 (pp pe1, pp pe2, mo)
+    | SeqRMW (lk, pe1, pe2, sym, pe3) ->
+        SeqRMW (lk, pp pe1, pp pe2, sym, pp pe3)
+    | RMW0 (pe1, pe2, pe3, pe4, mo1, mo2) ->
+        RMW0 (pp pe1, pp pe2, pp pe3, pp pe4, mo1, mo2)
+    | Fence0 mo ->
+        Fence0 mo
+    | CompareExchangeStrong (pe1, pe2, pe3, pe4, mo1, mo2) ->
+        CompareExchangeStrong (pp pe1, pp pe2, pp pe3, pp pe4, mo1, mo2)
+    | CompareExchangeWeak (pe1, pe2, pe3, pe4, mo1, mo2) ->
+        CompareExchangeWeak (pp pe1, pp pe2, pp pe3, pp pe4, mo1, mo2)
+    | LinuxFence mo ->
+        LinuxFence mo
+    | LinuxLoad (pe1, pe2, mo) ->
+        LinuxLoad (pp pe1, pp pe2, mo)
+    | LinuxStore (pe1, pe2, pe3, mo) ->
+        LinuxStore (pp pe1, pp pe2, pp pe3, mo)
+    | LinuxRMW (pe1, pe2, pe3, mo) ->
+        LinuxRMW (pp pe1, pp pe2, pp pe3, mo)
+  in
+  Paction (pol, Action (loc, a, act_'))
+
+(* Single top-down pass threading the env through exprs *)
+and propagate_expr env (Expr (annots, e_) as expr) =
+  let pp = propagate_pexpr env in
+  let pe = propagate_expr  env in
+  match e_ with
+
+  (* ---- CaseBase bindings with a named pattern.
+     tail_sym handles both the bare pure(sym) case and the effectful-RHS
+     case (where the tail is pure(sym) with src not locally bound inside e1).
+     When it succeeds: replace the pattern with a wildcard, extend env, and
+     propagate body.  The binding node is always preserved so that its
+     annotations (source locations) are not lost.
+     For Elet the RHS is a pexpr, so we match directly on PEsym.          ---- *)
+  | Ewseq (Pattern (p_annots, CaseBase (Some alias, cbty)), e1, body) ->
+      begin match tail_sym e1 with
+      | Some src ->
+          let src' = apply_env env src in
+          Expr (annots,
+            Ewseq (Pattern (p_annots, CaseBase (None, cbty)),
+                   propagate_expr env e1,
+                   propagate_expr (extend_env env alias src') body))
+      | None ->
+          Expr (annots,
+            Ewseq (Pattern (p_annots, CaseBase (Some alias, cbty)),
+                   propagate_expr env e1,
+                   propagate_expr env body))
+      end
+
+  | Esseq (Pattern (p_annots, CaseBase (Some alias, cbty)), e1, body) ->
+      begin match tail_sym e1 with
+      | Some src ->
+          let src' = apply_env env src in
+          Expr (annots,
+            Esseq (Pattern (p_annots, CaseBase (None, cbty)),
+                   propagate_expr env e1,
+                   propagate_expr (extend_env env alias src') body))
+      | None ->
+          Expr (annots,
+            Esseq (Pattern (p_annots, CaseBase (Some alias, cbty)),
+                   propagate_expr env e1,
+                   propagate_expr env body))
+      end
+
+  | Elet (Pattern (p_annots, CaseBase (Some alias, cbty)), pe1, body) ->
+      begin match pe1 with
+      | Pexpr (_, _, PEsym src) ->
+          let src' = apply_env env src in
+          Expr (annots,
+            Elet (Pattern (p_annots, CaseBase (None, cbty)),
+                  propagate_pexpr env pe1,
+                  propagate_expr (extend_env env alias src') body))
+      | _ ->
+          Expr (annots,
+            Elet (Pattern (p_annots, CaseBase (Some alias, cbty)),
+                  propagate_pexpr env pe1,
+                  propagate_expr env body))
+      end
+
+  (* ---- Recurse into non-matching Ewseq/Esseq/Elet nodes ---- *)
+  | Ewseq (pat, e1, e2) ->
+      Expr (annots, Ewseq (pat, pe e1, pe e2))
+  | Esseq (pat, e1, e2) ->
+      Expr (annots, Esseq (pat, pe e1, pe e2))
+  | Elet (pat, pe1, e2) ->
+      Expr (annots, Elet (pat, pp pe1, pe e2))
+
+  (* ---- Other expression forms: recurse ---- *)
+  | Epure pe1 ->
+      Expr (annots, Epure (pp pe1))
+  | Ememop (op, pes) ->
+      Expr (annots, Ememop (op, List.map pp pes))
+  | Eaction pact ->
+      Expr (annots, Eaction (propagate_action env pact))
+  | Ecase (pe1, arms) ->
+      Expr (annots, Ecase (pp pe1,
+        List.map (fun (pat, e2) -> (pat, pe e2)) arms))
+  | Eif (pe1, e1, e2) ->
+      Expr (annots, Eif (pp pe1, pe e1, pe e2))
+  | Eccall (a, pe1, pe2, pes) ->
+      Expr (annots, Eccall (a, pp pe1, pp pe2, List.map pp pes))
+  | Eproc (a, name, pes) ->
+      Expr (annots, Eproc (a, name, List.map pp pes))
+  | Eunseq es ->
+      Expr (annots, Eunseq (List.map pe es))
+  | Esave (sym_bty, args, body) ->
+      Expr (annots, Esave (sym_bty,
+        List.map (fun (s, (type_info, pe1)) -> (s, (type_info, pp pe1))) args,
+        pe body))
+  | Erun (a, lbl, pes) ->
+      Expr (annots, Erun (a, lbl, List.map pp pes))
+  | Ebound e ->
+      Expr (annots, Ebound (pe e))
+  | Eannot (fps, e) ->
+      Expr (annots, Eannot (fps, pe e))
+  | End es ->
+      Expr (annots, End (List.map pe es))
+  | Epar es ->
+      Expr (annots, Epar (List.map pe es))
+  | Ewait _ ->
+      expr
+  | Eexcluded _ ->
+      expr
+
+(* ------------------------------------------------------------------ *)
+(* Top-level file transform                                           *)
+(* ------------------------------------------------------------------ *)
+
+let transform_file file =
+  let pr e  = propagate_expr  empty_env e in
+  let pp pe = propagate_pexpr empty_env pe in
+  let rewrite_impl_decl = function
+    | Def (bty, pe)        -> Def (bty, pp pe)
+    | IFun (bty, args, pe) -> IFun (bty, args, pp pe) in
+  let rewrite_fun_map_decl = function
+    | Fun (bty, args, pe)            -> Fun (bty, args, pp pe)
+    | Proc (loc, mrk, bty, args, e) -> Proc (loc, mrk, bty, args, pr e)
+    | decl                           -> decl in
+  let rewrite_globs = function
+    | GlobalDef (bty_cty, e) -> GlobalDef (bty_cty, pr e)
+    | decl                   -> decl in
+  { file with
+    stdlib = Pmap.map rewrite_fun_map_decl file.stdlib
+  ; impl   = Pmap.map rewrite_impl_decl   file.impl
+  ; globs  = List.map (fun (sym, g) -> (sym, rewrite_globs g)) file.globs
+  ; funs   = Pmap.map rewrite_fun_map_decl file.funs }

--- a/ocaml_frontend/rewriters/copy_propagation.ml
+++ b/ocaml_frontend/rewriters/copy_propagation.ml
@@ -13,34 +13,40 @@ let extend_env env alias pe = Pmap.add alias pe env
 let extend_env_list env bindings =
   List.fold_left (fun acc (s, pe) -> extend_env acc s pe) env bindings
 
-(* ------------------------------------------------------------------ *)
-(* pexpr_safe: conservative free-variable check                       *)
-(*                                                                    *)
-(* Returns [true] when none of [pe]'s free symbols appear in         *)
-(* [binders].  Complex forms (PEif, PElet, PEcase, PEconstrained)    *)
-(* return [false] conservatively to avoid a full free-variable        *)
-(* analysis.                                                          *)
-(* ------------------------------------------------------------------ *)
+(* a conservative free-variable and replaceable-with-unit check
+ *
+ * no free variables because the expression will be substituted (propagated)
+ * into other contexts so needs to be well-formed
+ *
+ * replaceable with unit so that other analyses (like mem2reg) don't
+ * see mentions of the propagated value even though it's just rebound
+ * to a wildcard pattern
+ *
+ * cfunction returns a tuple when evaluated so should not be replaced with
+ * unit; ccall in practice does not, but could so is also left alone
+ *
+ * if, let and case could be checked more precisely but not worth the
+ * complexity *)
 
 let sym_in binders s =
   List.exists (fun b -> Symbol.compare_sym s b = 0) binders
 
-let rec pexpr_safe binders (Pexpr (_, _, pe_)) =
+let rec can_prop_and_rm binders (Pexpr (_, _, pe_)) =
   match pe_ with
   | PEsym s ->
       not (sym_in binders s)
   | PEval _ | PEimpl _ | PEundef _ | PEerror _ ->
       true
   | PEctor (_, pes) ->
-      List.for_all (pexpr_safe binders) pes
+      List.for_all (can_prop_and_rm binders) pes
   | PEnot pe1 ->
-      pexpr_safe binders pe1
+      can_prop_and_rm binders pe1
   | PEop (_, pe1, pe2)
   | PEwrapI (_, _, pe1, pe2)
   | PEcatch_exceptional_condition (_, _, pe1, pe2)
   | PEare_compatible (pe1, pe2)
   | PEarray_shift (pe1, _, pe2) ->
-      pexpr_safe binders pe1 && pexpr_safe binders pe2
+      can_prop_and_rm binders pe1 && can_prop_and_rm binders pe2
   | PEmemberof (_, _, pe1)
   | PEmember_shift (pe1, _, _)
   | PEconv_int (_, pe1)
@@ -48,25 +54,31 @@ let rec pexpr_safe binders (Pexpr (_, _, pe_)) =
   | PEis_signed pe1 | PEis_unsigned pe1
   | PEbmc_assume pe1
   | PEunion (_, _, pe1) ->
-      pexpr_safe binders pe1
-  | PEmemop (_, pes) | PEcall (_, pes) ->
-      List.for_all (pexpr_safe binders) pes
+      can_prop_and_rm binders pe1
+  | PEmemop (_, pes) ->
+      List.for_all (can_prop_and_rm binders) pes
   | PEstruct (_, fields) ->
-      List.for_all (fun (_, pe1) -> pexpr_safe binders pe1) fields
+      List.for_all (fun (_, pe1) -> can_prop_and_rm binders pe1) fields
   | PEif _ | PElet _ | PEcase _ | PEconstrained _ ->
-      false  (* conservative *)
-  | PEcfunction _ ->
-    false
-
-(* ------------------------------------------------------------------ *)
-(* binders_of_pat: collect all named symbols in a pattern             *)
-(* ------------------------------------------------------------------ *)
+      false  (* not worth extra complexity *)
+   | PEcall _ | PEcfunction _ ->
+     false (* unsafe to replace with unit *)
 
 let rec binders_of_pat (Pattern (_, pat_)) =
   match pat_ with
   | CaseBase (None, _)   -> []
   | CaseBase (Some s, _) -> [s]
   | CaseCtor (_, pats)   -> List.concat_map binders_of_pat pats
+
+let prop_and_rm binders pe =
+  let ret_pe ~new_ ~old:(Pexpr (annot, a, _)) = Pexpr (annot, a, new_) in
+  let unit_pe = ret_pe ~new_:(PEval Vunit) ~old:pe in
+  let (tail, pe) =
+    if can_prop_and_rm binders pe then
+      (Some pe, unit_pe)
+    else
+      (None, pe) in
+  (tail, pe)
 
 (* ------------------------------------------------------------------ *)
 (* pexpr_tree: rose tree of pexpr option mirroring Eunseq structure  *)
@@ -80,68 +92,64 @@ type pexpr_tree =
   | Leaf of pexpr option
   | Node of pexpr_tree list
 
-(* ------------------------------------------------------------------ *)
-(* tail_pexpr: compute the pexpr_tree for the tail of an expression  *)
-(*                                                                    *)
-(* At [Epure pe]: returns Leaf(Some pe) when pe is safe to hoist     *)
-(* (no free symbol of pe appears in binders along the chain), else   *)
-(* Leaf None.                                                         *)
-(*                                                                    *)
-(* At [Eunseq es]: returns Node(map tail_pexpr es), preserving the   *)
-(* nesting structure so that tuple patterns can be matched against    *)
-(* it element-wise.                                                   *)
-(*                                                                    *)
-(* Along binding chains (Ewseq/Esseq/Elet): accumulates binders and  *)
-(* recurses into the continuation.                                    *)
-(* ------------------------------------------------------------------ *)
+(* this is important to allow for fine-grained copy-prop inside
+ * elements of a tuple *)
+let rec split_tuple binders = function
+  | Pexpr (annot, ty, PEctor (Ctuple, pes)) ->
+    let (tails, pes') = List.split @@ List.map (split_tuple binders) pes in
+    (Node tails, Pexpr (annot, ty, PEctor (Ctuple, pes')))
+  | pe ->
+    let (tail, pe) = prop_and_rm binders pe in
+    (Leaf tail, pe)
 
-let safe_pexpr binders pe =
-  let ret_pe ~new_ ~old:(Pexpr (annot, a, _)) = Pexpr (annot, a, new_) in
-  let unit_pe = ret_pe ~new_:(PEval Vunit) ~old:pe in
-  let (tail, pe) =
-    if pexpr_safe binders pe then
-      (Some pe, unit_pe)
-    else
-      (None, pe) in
-  (tail, pe)
-
-let rec tail_pexpr_acc binders (Expr (annot, e_)) =
+(* A common pattern in elaborated Core is something like
+ * let pat = e1 in let pat e2 in .. pure(pe) or
+ * let pat = e1 in let pat e2 in .. unseq(pure(pe), ..)
+ * i.e. chains of bindings that eventually end in a pure value,
+ * which can be removed (replaced with a unit), and propagated
+ * under the conditions of can_prop_and_rm
+ *
+ * Hence, this function constructs the tuple-nesting structure,
+ * used later to match against nested tuple pattern matches,
+ * and also returns the expression but with the pure value
+ * replaced with a unit *)
+let rec eventually_pure binders (Expr (annot, e_)) =
   let ret_e e_ = (Expr (annot, e_)) in
   match e_ with
   | Epure pe ->
-    let (tail, pe) = safe_pexpr binders pe in
-    (Leaf tail, ret_e (Epure pe))
+    let (tail, pe) = split_tuple binders pe in
+    (tail, ret_e (Epure pe))
   | Eunseq es ->
-    let (tails, es') = List.split @@ List.map (tail_pexpr_acc binders) es in
+    let (tails, es') = List.split @@ List.map (eventually_pure binders) es in
     (Node tails, ret_e (Eunseq es'))
   | Ewseq (pat, e1, e2) ->
-    let (tail, e2) = tail_pexpr_acc (binders_of_pat pat @ binders) e2 in
+    let (tail, e2) = eventually_pure (binders_of_pat pat @ binders) e2 in
     (tail, ret_e (Ewseq (pat, e1, e2)))
   | Esseq (pat, e1, e2) ->
-    let (tail, e2) = tail_pexpr_acc (binders_of_pat pat @ binders) e2 in
+    let (tail, e2) = eventually_pure (binders_of_pat pat @ binders) e2 in
     (tail, ret_e (Esseq (pat, e1, e2)))
   | Elet (pat, pe1, e2) ->
-    let (tail, e2) = tail_pexpr_acc (binders_of_pat pat @ binders) e2 in
+    let (tail, e2) = eventually_pure (binders_of_pat pat @ binders) e2 in
     (tail, ret_e (Elet (pat, pe1, e2)))
   | Ebound e ->
-      let (tail, e) = tail_pexpr_acc binders e in
+      let (tail, e) = eventually_pure binders e in
       (tail, ret_e (Ebound e))
   | Eannot (al, e) ->
-      let (tail, e) = tail_pexpr_acc binders e in
+      let (tail, e) = eventually_pure binders e in
       (tail, ret_e (Eannot (al, e)))
   | _ ->
       (Leaf None, ret_e e_)
 
-let tail_pexpr e = tail_pexpr_acc [] e
+let tail_pexpr e = eventually_pure [] e
 
 (* ------------------------------------------------------------------ *)
 (* match_pat_tree: extract bindings by walking pattern and tree       *)
 (*                                                                    *)
 (* Returns (bindings, new_pattern) where:                             *)
 (*   bindings    — (sym, pexpr) pairs for extractable positions       *)
-(*   new_pattern — pattern with extracted positions wildcarded        *)
+(*   new_pattern — pattern with extracted positions as wildcard units *)
 (*                                                                    *)
-(* Partial: positions where the tree has Leaf None are left named.   *)
+(* Partial: positions where the tree has Leaf None are left named.    *)
 (* ------------------------------------------------------------------ *)
 
 let rec match_pat_tree pat tree =
@@ -153,28 +161,14 @@ let rec match_pat_tree pat tree =
   | Pattern (p_annots, CaseBase (None, _)), Leaf (Some _) ->
       ([], Pattern (p_annots, CaseBase (None, BTy_unit)))
 
-  | Pattern (_, CaseBase (Some _, _)), (Leaf None | Node _) ->
-      ([], pat)
-
-  | Pattern (_, CaseBase (None, _)), _ ->
-      ([], pat)
-
   (* Tuple pattern vs a matching-arity Node (Eunseq): recurse element-wise *)
-  | Pattern (p_annots, CaseCtor (Ctuple, pats)), Node trees
-    when List.length pats = List.length trees ->
-      let results = List.map2 match_pat_tree pats trees in
-      let bindings = List.concat_map fst results in
-      let new_pats = List.map snd results in
-      (bindings, Pattern (p_annots, CaseCtor (Ctuple, new_pats)))
-
-  (* Tuple pattern vs pure-tuple leaf: decompose the pexpr element-wise *)
-  | Pattern (p_annots, CaseCtor (Ctuple, pats)),
-    Leaf (Some (Pexpr (_, _, PEctor (Ctuple, pes))))
-    when List.length pats = List.length pes ->
-      let results = List.map2 (fun p pe -> match_pat_tree p (Leaf (Some pe))) pats pes in
-      let bindings = List.concat_map fst results in
-      let new_pats = List.map snd results in
-      (bindings, Pattern (p_annots, CaseCtor (Ctuple, new_pats)))
+  | Pattern (p_annots, CaseCtor (Ctuple, pats)), Node trees ->
+    (* they should have the same length otherwise there's a bug in the tree
+     * construction or the elaboration *)
+    let results = List.map2 match_pat_tree pats trees in
+    let bindings = List.concat_map fst results in
+    let new_pats = List.map snd results in
+    (bindings, Pattern (p_annots, CaseCtor (Ctuple, new_pats)))
 
   | _ ->
       ([], pat)
@@ -195,28 +189,12 @@ let rec propagate_pexpr env (Pexpr (annots, bty, pe_) as pe) =
        | None     -> Pexpr (annots, bty, PEsym s))
   | PEval _ | PEimpl _ | PEundef _ | PEerror _ | PEconstrained _ ->
       pe
-
-  (* Replace named pattern with wildcard, extend env; node is preserved. *)
-  | PElet (Pattern (p_annots, CaseBase (Some alias, cbty)),
-           (Pexpr (_, _, PEsym src) as rhs),
-           body) ->
-      let pe_src = match Pmap.lookup src env with
-                   | Some pe' -> pe'
-                   | None     -> rhs in
-      Pexpr (annots, bty,
-        PElet (Pattern (p_annots, CaseBase (None, cbty)),
-               propagate_pexpr env rhs,
-               propagate_pexpr (extend_env env alias pe_src) body))
-
   | PElet (pat, pe1, pe2) ->
-      (* let pe1' = propagate_pexpr env pe1 in *)
-      (* let (tail, pe1') = safe_pexpr [] pe1' in *)
-      (* let (bindings, new_pat) = match_pat_tree pat (Leaf tail) in *)
-      (* let env' = extend_env_list env bindings in *)
-      (* Pexpr (annots, bty, PElet (new_pat, pe1', propagate_expr env' body)) *)
-      Pexpr (annots, bty, PElet (pat,
-        propagate_pexpr env pe1,
-        propagate_pexpr env pe2))
+      let pe1' = propagate_pexpr env pe1 in
+      let (tail, pe1') = split_tuple [] pe1' in
+      let (bindings, new_pat) = match_pat_tree pat tail in
+      let env' = extend_env_list env bindings in
+      Pexpr (annots, bty, PElet (new_pat, pe1', propagate_pexpr env' pe2))
   | PEctor (c, pes) ->
       Pexpr (annots, bty, PEctor (c, List.map (propagate_pexpr env) pes))
   | PEcase (pe1, arms) ->
@@ -276,7 +254,7 @@ let rec propagate_pexpr env (Pexpr (annots, bty, pe_) as pe) =
         PEare_compatible (propagate_pexpr env pe1, propagate_pexpr env pe2))
 
 (* Propagate env into all pexprs inside an action. *)
-and propagate_action env (Paction (pol, Action (loc, a, act_))) =
+let propagate_action env (Paction (pol, Action (loc, a, act_))) =
   let pp = propagate_pexpr env in
   let act_' = match act_ with
     | Create (pe1, pe2, prefix) ->
@@ -313,19 +291,10 @@ and propagate_action env (Paction (pol, Action (loc, a, act_))) =
   Paction (pol, Action (loc, a, act_'))
 
 (* Single top-down pass threading the env through exprs *)
-and propagate_expr env (Expr (annots, e_) as expr) =
+let rec propagate_expr env (Expr (annots, e_) as expr) =
   let pp = propagate_pexpr env in
   let pe = propagate_expr  env in
   match e_ with
-
-  (* ---- CaseBase bindings with a named pattern.
-     tail_pexpr handles both the bare pure(pe) case and the effectful-RHS
-     case (where the tail is pure(pe) with all free syms of pe not locally
-     bound inside e1).
-     When it succeeds: replace the pattern with a wildcard, extend env, and
-     propagate body.  The binding node is always preserved so that its
-     annotations (source locations) are not lost.
-     For Elet the RHS is a pexpr, so we match directly on PEsym.          ---- *)
   | Ewseq (pat, e1, body) ->
       let e1' = propagate_expr env e1 in
       let (tail, e1') = tail_pexpr e1' in
@@ -342,8 +311,8 @@ and propagate_expr env (Expr (annots, e_) as expr) =
 
   | Elet (pat, pe1, body) ->
       let pe1' = propagate_pexpr env pe1 in
-      let (tail, pe1') = safe_pexpr [] pe1' in
-      let (bindings, new_pat) = match_pat_tree pat (Leaf tail) in
+      let (tail, pe1') = split_tuple [] pe1' in
+      let (bindings, new_pat) = match_pat_tree pat tail in
       let env' = extend_env_list env bindings in
       Expr (annots, Elet (new_pat, pe1', propagate_expr env' body))
 

--- a/ocaml_frontend/rewriters/copy_propagation.ml
+++ b/ocaml_frontend/rewriters/copy_propagation.ml
@@ -70,108 +70,108 @@ let rec binders_of_pat (Pattern (_, pat_)) =
   | CaseBase (Some s, _) -> [s]
   | CaseCtor (_, pats)   -> List.concat_map binders_of_pat pats
 
-let prop_and_rm binders pe =
-  let ret_pe ~new_ ~old:(Pexpr (annot, a, _)) = Pexpr (annot, a, new_) in
-  let unit_pe = ret_pe ~new_:(PEval Vunit) ~old:pe in
-  let (tail, pe) =
-    if can_prop_and_rm binders pe then
-      (Some pe, unit_pe)
-    else
-      (None, pe) in
-  (tail, pe)
-
 (* ------------------------------------------------------------------ *)
-(* pexpr_tree: rose tree of pexpr option mirroring Eunseq structure  *)
+(* analyze_pat_pexpr: pattern-aware single-pass analysis for pexprs  *)
 (*                                                                    *)
-(* Leaf(Some pe) — this position has a known, safe-to-hoist pexpr.  *)
-(* Leaf None     — this position is opaque (action, unsafe, etc.).   *)
-(* Node ts       — this position is an Eunseq with children ts.      *)
+(* Takes the binding pattern alongside the RHS pure expression and   *)
+(* returns a coherent triple (bindings, new_pat, new_pe) where       *)
+(* new_pat and new_pe are type-compatible with each other.           *)
 (* ------------------------------------------------------------------ *)
 
-type pexpr_tree =
-  | Leaf of pexpr option
-  | Node of pexpr_tree list
+let unit_pexpr (Pexpr (annots, bty, _)) =
+  Pexpr (annots, bty, PEval Vunit)
 
-(* this is important to allow for fine-grained copy-prop inside
- * elements of a tuple *)
-let rec split_tuple binders = function
-  | Pexpr (annot, ty, PEctor (Ctuple, pes)) ->
-    let (tails, pes') = List.split @@ List.map (split_tuple binders) pes in
-    (Node tails, Pexpr (annot, ty, PEctor (Ctuple, pes')))
-  | pe ->
-    let (tail, pe) = prop_and_rm binders pe in
-    (Leaf tail, pe)
+let wildcard_pat (Pattern (p_annots, _)) =
+  Pattern (p_annots, CaseBase (None, BTy_unit))
 
-(* A common pattern in elaborated Core is something like
- * let pat = e1 in let pat e2 in .. pure(pe) or
- * let pat = e1 in let pat e2 in .. unseq(pure(pe), ..)
- * i.e. chains of bindings that eventually end in a pure value,
- * which can be removed (replaced with a unit), and propagated
- * under the conditions of can_prop_and_rm
- *
- * Hence, this function constructs the tuple-nesting structure,
- * used later to match against nested tuple pattern matches,
- * and also returns the expression but with the pure value
- * replaced with a unit *)
-let rec eventually_pure binders (Expr (annot, e_)) =
-  let ret_e e_ = (Expr (annot, e_)) in
+let rec analyze_pat_pexpr binders pat pe =
+  let Pattern (p_annots, pat_) = pat in
+  match pat_, pe with
+
+  | CaseBase (Some s, _), _ when can_prop_and_rm binders pe ->
+      ([(s, pe)], wildcard_pat pat, unit_pexpr pe)
+
+  | CaseBase (None, _), _ when can_prop_and_rm binders pe ->
+      ([], wildcard_pat pat, unit_pexpr pe)
+
+  | CaseBase (_, _), _ ->
+      ([], pat, pe)
+
+  | CaseCtor (Ctuple, pats), Pexpr (pe_annots, pe_bty, PEctor (Ctuple, pes))
+    when List.length pats = List.length pes ->
+      let results = List.map2 (analyze_pat_pexpr binders) pats pes in
+      let bindings  = List.concat_map (fun (bs, _, _) -> bs) results in
+      let new_pats  = List.map (fun (_, p, _) -> p) results in
+      let new_pes   = List.map (fun (_, _, e) -> e) results in
+      ( bindings
+      , Pattern (p_annots, CaseCtor (Ctuple, new_pats))
+      , Pexpr (pe_annots, pe_bty, PEctor (Ctuple, new_pes)) )
+
+  | CaseCtor (Cspecified, [inner_pat]),
+    Pexpr (pe_annots, pe_bty, PEctor (Cspecified, [inner_pe])) ->
+      let (bindings, new_inner_pat, new_inner_pe) =
+        analyze_pat_pexpr binders inner_pat inner_pe in
+      ( bindings
+      , Pattern (p_annots, CaseCtor (Cspecified, [new_inner_pat]))
+      , Pexpr (pe_annots, pe_bty, PEctor (Cspecified, [new_inner_pe])) )
+
+  | _ ->
+      ([], pat, pe)
+
+(* ------------------------------------------------------------------ *)
+(* analyze_pat_expr: pattern-aware single-pass analysis for exprs    *)
+(*                                                                    *)
+(* Descends through sequential chains to find the tail Epure, then   *)
+(* delegates to analyze_pat_pexpr. Returns (bindings, new_pat, new_e *)
+(* where new_pat and new_e are type-compatible.                       *)
+(* ------------------------------------------------------------------ *)
+
+let rec analyze_pat_expr binders pat (Expr (annot, e_) as expr) =
+  let ret_e e_ = Expr (annot, e_) in
   match e_ with
   | Epure pe ->
-    let (tail, pe) = split_tuple binders pe in
-    (tail, ret_e (Epure pe))
+      let (bs, new_pat, new_pe) = analyze_pat_pexpr binders pat pe in
+      (bs, new_pat, ret_e (Epure new_pe))
+
   | Eunseq es ->
-    let (tails, es') = List.split @@ List.map (eventually_pure binders) es in
-    (Node tails, ret_e (Eunseq es'))
-  | Ewseq (pat, e1, e2) ->
-    let (tail, e2) = eventually_pure (binders_of_pat pat @ binders) e2 in
-    (tail, ret_e (Ewseq (pat, e1, e2)))
-  | Esseq (pat, e1, e2) ->
-    let (tail, e2) = eventually_pure (binders_of_pat pat @ binders) e2 in
-    (tail, ret_e (Esseq (pat, e1, e2)))
-  | Elet (pat, pe1, e2) ->
-    let (tail, e2) = eventually_pure (binders_of_pat pat @ binders) e2 in
-    (tail, ret_e (Elet (pat, pe1, e2)))
+      let Pattern (p_annots, pat_) = pat in
+      (match pat_ with
+       | CaseCtor (Ctuple, pats) when List.length pats = List.length es ->
+           let results = List.map2 (analyze_pat_expr binders) pats es in
+           let bindings = List.concat_map (fun (bs, _, _) -> bs) results in
+           let new_pats = List.map (fun (_, p, _) -> p) results in
+           let new_es   = List.map (fun (_, _, e) -> e) results in
+           ( bindings
+           , Pattern (p_annots, CaseCtor (Ctuple, new_pats))
+           , ret_e (Eunseq new_es) )
+       | _ ->
+           ([], pat, expr))
+
+  | Ewseq (inner_pat, e1, e2) ->
+      let binders' = binders_of_pat inner_pat @ binders in
+      let (bs, new_outer_pat, new_e2) = analyze_pat_expr binders' pat e2 in
+      (bs, new_outer_pat, ret_e (Ewseq (inner_pat, e1, new_e2)))
+
+  | Esseq (inner_pat, e1, e2) ->
+      let binders' = binders_of_pat inner_pat @ binders in
+      let (bs, new_outer_pat, new_e2) = analyze_pat_expr binders' pat e2 in
+      (bs, new_outer_pat, ret_e (Esseq (inner_pat, e1, new_e2)))
+
+  | Elet (inner_pat, pe1, e2) ->
+      let binders' = binders_of_pat inner_pat @ binders in
+      let (bs, new_outer_pat, new_e2) = analyze_pat_expr binders' pat e2 in
+      (bs, new_outer_pat, ret_e (Elet (inner_pat, pe1, new_e2)))
+
   | Ebound e ->
-      let (tail, e) = eventually_pure binders e in
-      (tail, ret_e (Ebound e))
+      let (bs, new_pat, new_e) = analyze_pat_expr binders pat e in
+      (bs, new_pat, ret_e (Ebound new_e))
+
   | Eannot (al, e) ->
-      let (tail, e) = eventually_pure binders e in
-      (tail, ret_e (Eannot (al, e)))
-  | _ ->
-      (Leaf None, ret_e e_)
-
-let tail_pexpr e = eventually_pure [] e
-
-(* ------------------------------------------------------------------ *)
-(* match_pat_tree: extract bindings by walking pattern and tree       *)
-(*                                                                    *)
-(* Returns (bindings, new_pattern) where:                             *)
-(*   bindings    — (sym, pexpr) pairs for extractable positions       *)
-(*   new_pattern — pattern with extracted positions as wildcard units *)
-(*                                                                    *)
-(* Partial: positions where the tree has Leaf None are left named.    *)
-(* ------------------------------------------------------------------ *)
-
-let rec match_pat_tree pat tree =
-  match pat, tree with
-
-  | Pattern (p_annots, CaseBase (Some s, cbty)), Leaf (Some pe) ->
-      ([(s, pe)], Pattern (p_annots, CaseBase (None, BTy_unit)))
-
-  | Pattern (p_annots, CaseBase (None, _)), Leaf (Some _) ->
-      ([], Pattern (p_annots, CaseBase (None, BTy_unit)))
-
-  (* Tuple pattern vs a matching-arity Node (Eunseq): recurse element-wise *)
-  | Pattern (p_annots, CaseCtor (Ctuple, pats)), Node trees ->
-    (* they should have the same length otherwise there's a bug in the tree
-     * construction or the elaboration *)
-    let results = List.map2 match_pat_tree pats trees in
-    let bindings = List.concat_map fst results in
-    let new_pats = List.map snd results in
-    (bindings, Pattern (p_annots, CaseCtor (Ctuple, new_pats)))
+      let (bs, new_pat, new_e) = analyze_pat_expr binders pat e in
+      (bs, new_pat, ret_e (Eannot (al, new_e)))
 
   | _ ->
-      ([], pat)
+      ([], pat, expr)
 
 (* ------------------------------------------------------------------ *)
 (* Mutually recursive propagation functions.                          *)
@@ -191,10 +191,9 @@ let rec propagate_pexpr env (Pexpr (annots, bty, pe_) as pe) =
       pe
   | PElet (pat, pe1, pe2) ->
       let pe1' = propagate_pexpr env pe1 in
-      let (tail, pe1') = split_tuple [] pe1' in
-      let (bindings, new_pat) = match_pat_tree pat tail in
+      let (bindings, new_pat, pe1'') = analyze_pat_pexpr [] pat pe1' in
       let env' = extend_env_list env bindings in
-      Pexpr (annots, bty, PElet (new_pat, pe1', propagate_pexpr env' pe2))
+      Pexpr (annots, bty, PElet (new_pat, pe1'', propagate_pexpr env' pe2))
   | PEctor (c, pes) ->
       Pexpr (annots, bty, PEctor (c, List.map (propagate_pexpr env) pes))
   | PEcase (pe1, arms) ->
@@ -297,24 +296,21 @@ let rec propagate_expr env (Expr (annots, e_) as expr) =
   match e_ with
   | Ewseq (pat, e1, body) ->
       let e1' = propagate_expr env e1 in
-      let (tail, e1') = tail_pexpr e1' in
-      let (bindings, new_pat) = match_pat_tree pat tail in
+      let (bindings, new_pat, e1'') = analyze_pat_expr [] pat e1' in
       let env' = extend_env_list env bindings in
-      Expr (annots, Ewseq (new_pat, e1', propagate_expr env' body))
+      Expr (annots, Ewseq (new_pat, e1'', propagate_expr env' body))
 
   | Esseq (pat, e1, body) ->
       let e1' = propagate_expr env e1 in
-      let (tail, e1') = tail_pexpr e1' in
-      let (bindings, new_pat) = match_pat_tree pat tail in
+      let (bindings, new_pat, e1'') = analyze_pat_expr [] pat e1' in
       let env' = extend_env_list env bindings in
-      Expr (annots, Esseq (new_pat, e1', propagate_expr env' body))
+      Expr (annots, Esseq (new_pat, e1'', propagate_expr env' body))
 
   | Elet (pat, pe1, body) ->
       let pe1' = propagate_pexpr env pe1 in
-      let (tail, pe1') = split_tuple [] pe1' in
-      let (bindings, new_pat) = match_pat_tree pat tail in
+      let (bindings, new_pat, pe1'') = analyze_pat_pexpr [] pat pe1' in
       let env' = extend_env_list env bindings in
-      Expr (annots, Elet (new_pat, pe1', propagate_expr env' body))
+      Expr (annots, Elet (new_pat, pe1'', propagate_expr env' body))
 
   (* ---- Other expression forms: recurse ---- *)
   | Epure pe1 ->

--- a/ocaml_frontend/rewriters/copy_propagation.ml
+++ b/ocaml_frontend/rewriters/copy_propagation.ml
@@ -46,7 +46,7 @@ let rec pexpr_safe binders (Pexpr (_, _, pe_)) =
   | PEconv_int (_, pe1)
   | PEis_scalar pe1 | PEis_integer pe1
   | PEis_signed pe1 | PEis_unsigned pe1
-  | PEbmc_assume pe1 | PEcfunction pe1
+  | PEbmc_assume pe1
   | PEunion (_, _, pe1) ->
       pexpr_safe binders pe1
   | PEmemop (_, pes) | PEcall (_, pes) ->
@@ -55,6 +55,8 @@ let rec pexpr_safe binders (Pexpr (_, _, pe_)) =
       List.for_all (fun (_, pe1) -> pexpr_safe binders pe1) fields
   | PEif _ | PElet _ | PEcase _ | PEconstrained _ ->
       false  (* conservative *)
+  | PEcfunction _ ->
+    false
 
 (* ------------------------------------------------------------------ *)
 (* binders_of_pat: collect all named symbols in a pattern             *)
@@ -93,20 +95,42 @@ type pexpr_tree =
 (* recurses into the continuation.                                    *)
 (* ------------------------------------------------------------------ *)
 
-let rec tail_pexpr_acc binders (Expr (_, e_)) =
+let safe_pexpr binders pe =
+  let ret_pe ~new_ ~old:(Pexpr (annot, a, _)) = Pexpr (annot, a, new_) in
+  let unit_pe = ret_pe ~new_:(PEval Vunit) ~old:pe in
+  let (tail, pe) =
+    if pexpr_safe binders pe then
+      (Some pe, unit_pe)
+    else
+      (None, pe) in
+  (tail, pe)
+
+let rec tail_pexpr_acc binders (Expr (annot, e_)) =
+  let ret_e e_ = (Expr (annot, e_)) in
   match e_ with
   | Epure pe ->
-      Leaf (if pexpr_safe binders pe then Some pe else None)
+    let (tail, pe) = safe_pexpr binders pe in
+    (Leaf tail, ret_e (Epure pe))
   | Eunseq es ->
-      Node (List.map (tail_pexpr_acc binders) es)
-  | Ewseq (pat, _, e2) | Esseq (pat, _, e2) ->
-      tail_pexpr_acc (binders_of_pat pat @ binders) e2
-  | Elet (pat, _, e2) ->
-      tail_pexpr_acc (binders_of_pat pat @ binders) e2
-  | Ebound e | Eannot (_, e) ->
-      tail_pexpr_acc binders e
+    let (tails, es') = List.split @@ List.map (tail_pexpr_acc binders) es in
+    (Node tails, ret_e (Eunseq es'))
+  | Ewseq (pat, e1, e2) ->
+    let (tail, e2) = tail_pexpr_acc (binders_of_pat pat @ binders) e2 in
+    (tail, ret_e (Ewseq (pat, e1, e2)))
+  | Esseq (pat, e1, e2) ->
+    let (tail, e2) = tail_pexpr_acc (binders_of_pat pat @ binders) e2 in
+    (tail, ret_e (Esseq (pat, e1, e2)))
+  | Elet (pat, pe1, e2) ->
+    let (tail, e2) = tail_pexpr_acc (binders_of_pat pat @ binders) e2 in
+    (tail, ret_e (Elet (pat, pe1, e2)))
+  | Ebound e ->
+      let (tail, e) = tail_pexpr_acc binders e in
+      (tail, ret_e (Ebound e))
+  | Eannot (al, e) ->
+      let (tail, e) = tail_pexpr_acc binders e in
+      (tail, ret_e (Eannot (al, e)))
   | _ ->
-      Leaf None
+      (Leaf None, ret_e e_)
 
 let tail_pexpr e = tail_pexpr_acc [] e
 
@@ -124,7 +148,10 @@ let rec match_pat_tree pat tree =
   match pat, tree with
 
   | Pattern (p_annots, CaseBase (Some s, cbty)), Leaf (Some pe) ->
-      ([(s, pe)], Pattern (p_annots, CaseBase (None, cbty)))
+      ([(s, pe)], Pattern (p_annots, CaseBase (None, BTy_unit)))
+
+  | Pattern (p_annots, CaseBase (None, _)), Leaf (Some _) ->
+      ([], Pattern (p_annots, CaseBase (None, BTy_unit)))
 
   | Pattern (_, CaseBase (Some _, _)), (Leaf None | Node _) ->
       ([], pat)
@@ -182,6 +209,11 @@ let rec propagate_pexpr env (Pexpr (annots, bty, pe_) as pe) =
                propagate_pexpr (extend_env env alias pe_src) body))
 
   | PElet (pat, pe1, pe2) ->
+      (* let pe1' = propagate_pexpr env pe1 in *)
+      (* let (tail, pe1') = safe_pexpr [] pe1' in *)
+      (* let (bindings, new_pat) = match_pat_tree pat (Leaf tail) in *)
+      (* let env' = extend_env_list env bindings in *)
+      (* Pexpr (annots, bty, PElet (new_pat, pe1', propagate_expr env' body)) *)
       Pexpr (annots, bty, PElet (pat,
         propagate_pexpr env pe1,
         propagate_pexpr env pe2))
@@ -294,69 +326,24 @@ and propagate_expr env (Expr (annots, e_) as expr) =
      propagate body.  The binding node is always preserved so that its
      annotations (source locations) are not lost.
      For Elet the RHS is a pexpr, so we match directly on PEsym.          ---- *)
-  | Ewseq (Pattern (p_annots, CaseBase (Some alias, cbty)), e1, body) ->
-      let e1' = propagate_expr env e1 in
-      begin match tail_pexpr e1' with
-      | Leaf (Some pe_tail) ->
-          Expr (annots,
-            Ewseq (Pattern (p_annots, CaseBase (None, cbty)),
-                   e1',
-                   propagate_expr (extend_env env alias pe_tail) body))
-      | _ ->
-          Expr (annots,
-            Ewseq (Pattern (p_annots, CaseBase (Some alias, cbty)),
-                   e1',
-                   propagate_expr env body))
-      end
-
-  | Esseq (Pattern (p_annots, CaseBase (Some alias, cbty)), e1, body) ->
-      let e1' = propagate_expr env e1 in
-      begin match tail_pexpr e1' with
-      | Leaf (Some pe_tail) ->
-          Expr (annots,
-            Esseq (Pattern (p_annots, CaseBase (None, cbty)),
-                   e1',
-                   propagate_expr (extend_env env alias pe_tail) body))
-      | _ ->
-          Expr (annots,
-            Esseq (Pattern (p_annots, CaseBase (Some alias, cbty)),
-                   e1',
-                   propagate_expr env body))
-      end
-
-  | Elet (Pattern (p_annots, CaseBase (Some alias, cbty)), pe1, body) ->
-      begin match pe1 with
-      | Pexpr (_, _, PEsym src) ->
-          let pe_src = match Pmap.lookup src env with
-                       | Some pe' -> pe'
-                       | None     -> pe1 in
-          Expr (annots,
-            Elet (Pattern (p_annots, CaseBase (None, cbty)),
-                  propagate_pexpr env pe1,
-                  propagate_expr (extend_env env alias pe_src) body))
-      | _ ->
-          Expr (annots,
-            Elet (Pattern (p_annots, CaseBase (Some alias, cbty)),
-                  propagate_pexpr env pe1,
-                  propagate_expr env body))
-      end
-
-  (* ---- Catch-all Ewseq/Esseq/Elet: try tuple extraction via match_pat_tree ---- *)
   | Ewseq (pat, e1, body) ->
       let e1' = propagate_expr env e1 in
-      let (bindings, new_pat) = match_pat_tree pat (tail_pexpr e1') in
+      let (tail, e1') = tail_pexpr e1' in
+      let (bindings, new_pat) = match_pat_tree pat tail in
       let env' = extend_env_list env bindings in
       Expr (annots, Ewseq (new_pat, e1', propagate_expr env' body))
 
   | Esseq (pat, e1, body) ->
       let e1' = propagate_expr env e1 in
-      let (bindings, new_pat) = match_pat_tree pat (tail_pexpr e1') in
+      let (tail, e1') = tail_pexpr e1' in
+      let (bindings, new_pat) = match_pat_tree pat tail in
       let env' = extend_env_list env bindings in
       Expr (annots, Esseq (new_pat, e1', propagate_expr env' body))
 
   | Elet (pat, pe1, body) ->
       let pe1' = propagate_pexpr env pe1 in
-      let (bindings, new_pat) = match_pat_tree pat (Leaf (Some pe1')) in
+      let (tail, pe1') = safe_pexpr [] pe1' in
+      let (bindings, new_pat) = match_pat_tree pat (Leaf tail) in
       let env' = extend_env_list env bindings in
       Expr (annots, Elet (new_pat, pe1', propagate_expr env' body))
 

--- a/ocaml_frontend/rewriters/copy_propagation.ml
+++ b/ocaml_frontend/rewriters/copy_propagation.ml
@@ -365,7 +365,7 @@ let transform_file file =
     | IFun (bty, args, pe) -> IFun (bty, args, pp pe) in
   let rewrite_fun_map_decl = function
     | Fun (bty, args, pe)            -> Fun (bty, args, pp pe)
-    | Proc (loc, mrk, bty, args, e) -> Proc (loc, mrk, bty, args, pr e)
+    | Proc (loc, mrk, bty, args, e, promotable) -> Proc (loc, mrk, bty, args, pr e, promotable)
     | decl                           -> decl in
   let rewrite_globs = function
     | GlobalDef (bty_cty, e) -> GlobalDef (bty_cty, pr e)

--- a/ocaml_frontend/rewriters/copy_propagation.mli
+++ b/ocaml_frontend/rewriters/copy_propagation.mli
@@ -1,12 +1,15 @@
-(** Pure symbol rebinding elimination.
+(** Pure expression rebinding elimination.
 
-    Eliminates bindings of the form [let alias = pure(sym) in body]
-    by substituting [sym] for [alias] throughout [body] and dropping
-    the binding.  No memory events, sequencing, or values are changed.
+    Eliminates bindings of the form [let alias = pure(e) in body] by
+    substituting [e] for [alias] throughout [body].  The binding node is
+    preserved (pattern replaced by a wildcard) so that source-location
+    annotations are not lost.
 
-    Also handles the extended case: if a binding has an effectful RHS
-    whose tail expression is [pure(sym)], the binding is kept (for its
-    side effects) but the pattern is changed to a wildcard and [alias]
-    is substituted with [sym] in the body. *)
+    Handles:
+    - {b Single named bindings} ([CaseBase(Some alias, _)]) against
+      [pure(sym)] (pure let) or effectful RHS whose tail is [pure(e)].
+      The tail [e] may be any pure expression, not just a symbol alias.
+
+    No memory events, sequencing, or values are changed. *)
 
 val transform_file : unit Core.file -> unit Core.file

--- a/ocaml_frontend/rewriters/copy_propagation.mli
+++ b/ocaml_frontend/rewriters/copy_propagation.mli
@@ -6,9 +6,13 @@
     annotations are not lost.
 
     Handles:
-    - {b Single named bindings} ([CaseBase(Some alias, _)]) against
-      [pure(sym)] (pure let) or effectful RHS whose tail is [pure(e)].
-      The tail [e] may be any pure expression, not just a symbol alias.
+    - {b Single named bindings} ([CaseBase(Some alias, _)]) against any
+      effectful RHS whose tail is [pure(e)], or [pure(sym)] (pure let).
+    - {b Tuple patterns} ([CaseCtor(Ctuple, pats)]) against [Eunseq(es)]
+      (effectful) or [PEctor(Ctuple, pes)] (pure), decomposed element-wise.
+      Nested [Eunseq] / [PEctor(Ctuple)] structures are handled recursively.
+      Extraction is partial: only elements with a known tail value are
+      wildcarded; others retain their name.
 
     No memory events, sequencing, or values are changed. *)
 

--- a/ocaml_frontend/rewriters/copy_propagation.mli
+++ b/ocaml_frontend/rewriters/copy_propagation.mli
@@ -1,0 +1,12 @@
+(** Pure symbol rebinding elimination.
+
+    Eliminates bindings of the form [let alias = pure(sym) in body]
+    by substituting [sym] for [alias] throughout [body] and dropping
+    the binding.  No memory events, sequencing, or values are changed.
+
+    Also handles the extended case: if a binding has an effectful RHS
+    whose tail expression is [pure(sym)], the binding is kept (for its
+    side effects) but the pattern is changed to a wildcard and [alias]
+    is substituted with [sym] in the body. *)
+
+val transform_file : unit Core.file -> unit Core.file

--- a/ocaml_frontend/rewriters/core_mem2reg.ml
+++ b/ocaml_frontend/rewriters/core_mem2reg.ml
@@ -164,42 +164,132 @@ let classify_action sym act_ : use list =
       if sym_occurs_in_action sym act_ then [Use_other] else []
 
 (* ------------------------------------------------------------------ *)
+(* Esave memo tables                                                   *)
+(*                                                                     *)
+(* Both collect_uses and check_definitely_init need to analyse Esave  *)
+(* bodies: once via the default args and once per Erun call site.     *)
+(* Results are memoised per (label_sym, param_sym) to avoid redundant *)
+(* traversals and to terminate on back-edge Eruns.                    *)
+(* ------------------------------------------------------------------ *)
+
+type 'a esave_memo_entry = {
+  params  : (Symbol.sym * pexpr) list;            (* (param_sym, default_pe) by position *)
+  body    : (unit, unit, Symbol.sym) generic_expr;
+  results : (Symbol.sym, 'a) Pmap.map ref;        (* param_sym -> cached result, filled lazily *)
+}
+
+(* 'a = use list        for collect_uses                                    *)
+(* 'a = bool * bool     for check_definitely_init  (safe_uninit, inits_param) *)
+(*   safe_uninit:   fst (check_definitely_init ... param_sym false body)    *)
+(*   inits_param:   snd (check_definitely_init ... param_sym false body)    *)
+type 'a memo_save_info = (Symbol.sym, 'a esave_memo_entry) Pmap.map
+
+(* find_single_direct_alias sym pairs:
+   Given an association list of (param_sym, pe) pairs, returns:
+     None           — sym does not appear as a bare PEsym in any pe
+     Some param_sym — sym appears as a bare PEsym in exactly one pe
+   Raises failwith if sym appears in more than one pe (invariant violation). *)
+let find_single_direct_alias sym pairs =
+  match List.filter_map (fun (param_sym, pe) ->
+    if is_pesym sym pe then Some param_sym else None) pairs
+  with
+  | []          -> None
+  | [param_sym] -> Some param_sym
+  | _           -> failwith "Core_mem2reg: multiple direct aliases for the same sym"
+
+(* collect_esave_defs: pre-walk the function body collecting all Esave
+   definitions into a memo table.
+
+   Key invariant (guaranteed by elaboration): for any CREATE-bound local
+   pointer sym `s`, if `s` appears in an Esave body, then `s` is passed as
+   a direct PEsym default arg to that Esave.  This means the NoAlias case
+   (`find_single_direct_alias` returns None) is sound: if `s` is not in any
+   param, it cannot appear in the body as an address of a Load/Store/Kill.
+
+   Non-pointer syms (e.g., function parameters) may appear freely in Esave
+   bodies and are not mem2reg candidates; they do not affect this analysis. *)
+let collect_esave_defs body =
+  (* Pre-walk: collect all Esave definitions *)
+  let memo = ref (Pmap.empty Symbol.compare_sym) in
+  let rec walk (Expr (_, e_)) =
+    match e_ with
+    | Esave ((label_sym, _), params, esave_body) ->
+        let entry = {
+          params  = List.map (fun (s, (_, pe)) -> (s, pe)) params;
+          body    = esave_body;
+          results = ref (Pmap.empty Symbol.compare_sym);
+        } in
+        memo := Pmap.add label_sym entry !memo;
+        walk esave_body
+    | Ewseq (_, e1, e2) | Esseq (_, e1, e2) -> walk e1; walk e2
+    | Eif (_, e1, e2)                        -> walk e1; walk e2
+    | Ecase (_, arms)   -> List.iter (fun (_, e) -> walk e) arms
+    | Elet (_, _, e) | Ebound e | Eannot (_, e) -> walk e
+    | Eunseq es | End es | Epar es           -> List.iter walk es
+    | Epure _ | Eaction _ | Ememop _ | Eccall _ | Eproc _
+    | Erun _ | Ewait _ | Eexcluded _        -> ()
+  in
+  walk body;
+  !memo
+
+(* ------------------------------------------------------------------ *)
 (* collect_uses: gather all uses of sym in an expression              *)
 (* ------------------------------------------------------------------ *)
 
-let rec collect_uses sym (Expr (_, e_)) : use list =
+let rec collect_uses use_memo sym (Expr (_, e_)) : use list =
   match e_ with
   | Eaction (Paction (_, Action (_, _, act_))) ->
       classify_action sym act_
-  | Esave (_, args, body) ->
-      (* Conservative: any occurrence inside an Esave is Use_other,
-         since loop bodies may re-enter and store to the variable. *)
-      let in_args =
-        List.exists (fun (_, (_, pe)) -> sym_occurs_in_pexpr sym pe) args
-      in
-      let in_body = sym_occurs_in_expr sym body in
-      if in_args || in_body then [Use_other] else []
+  | Esave ((label_sym, _), params, _body) ->
+      (* All default args are bare PEsym by the closedness check.
+         Closedness also guarantees sym is not free in body unless it is a param. *)
+      let entry = Pmap.find label_sym use_memo in
+      (match find_single_direct_alias sym
+               (List.map (fun (p, (_, pe)) -> (p, pe)) params) with
+      | None           -> []  (* NoAlias: by closedness, not in body *)
+      | Some param_sym ->
+          (match Pmap.lookup param_sym !(entry.results) with
+          | Some cached -> cached
+          | None ->
+              entry.results := Pmap.add param_sym [] !(entry.results);  (* sentinel *)
+              let result = collect_uses use_memo param_sym entry.body in
+              entry.results := Pmap.add param_sym result !(entry.results);
+              result))
+  | Erun (_, label_sym, args) ->
+      (* Closedness guarantees args matching sym are direct PEsym aliases. *)
+      let entry = Pmap.find label_sym use_memo in
+      (match find_single_direct_alias sym
+               (List.combine (List.map fst entry.params) args) with
+      | None           -> []
+      | Some param_sym ->
+          (match Pmap.lookup param_sym !(entry.results) with
+          | Some cached -> cached
+          | None ->
+              entry.results := Pmap.add param_sym [] !(entry.results);
+              let result = collect_uses use_memo param_sym entry.body in
+              entry.results := Pmap.add param_sym result !(entry.results);
+              result))
   | Epure pe ->
       if sym_occurs_in_pexpr sym pe then [Use_other] else []
   | Ememop (_, pes) ->
       if List.exists (sym_occurs_in_pexpr sym) pes then [Use_other] else []
   | Elet (_, pe, e) ->
       (if sym_occurs_in_pexpr sym pe then [Use_other] else [])
-      @ collect_uses sym e
+      @ collect_uses use_memo sym e
   | Ecase (pe, arms) ->
       (if sym_occurs_in_pexpr sym pe then [Use_other] else [])
-      @ List.concat_map (fun (_, e) -> collect_uses sym e) arms
+      @ List.concat_map (fun (_, e) -> collect_uses use_memo sym e) arms
   | Eif (pe, e1, e2) ->
       (if sym_occurs_in_pexpr sym pe then [Use_other] else [])
-      @ collect_uses sym e1
-      @ collect_uses sym e2
+      @ collect_uses use_memo sym e1
+      @ collect_uses use_memo sym e2
   | Eccall (_, fn_pe, arg_pe, pes) ->
       if List.exists (sym_occurs_in_pexpr sym) (fn_pe :: arg_pe :: pes)
       then [Use_other] else []
-  | Eproc (_, _, pes) | Erun (_, _, pes) ->
+  | Eproc (_, _, pes) ->
       if List.exists (sym_occurs_in_pexpr sym) pes then [Use_other] else []
   | Eunseq es | End es | Epar es ->
-      List.concat_map (collect_uses sym) es
+      List.concat_map (collect_uses use_memo sym) es
   | Ewseq (
       Pattern (_, CaseBase (Some alias_sym, _)),
       Expr (_, Epure (Pexpr (_, _, PEsym src_sym))),
@@ -208,11 +298,11 @@ let rec collect_uses sym (Expr (_, e_)) : use list =
       (* Core pattern: let weak alias = pure(sym) in body.
          sym is being used as a pointer value to be copied into alias.
          Classify sym's use here based on how alias is used in body. *)
-      collect_uses alias_sym body
-      @ collect_uses sym body
+      collect_uses use_memo alias_sym body
+      @ collect_uses use_memo sym body
   | Ewseq (_, e1, e2) | Esseq (_, e1, e2) ->
-      collect_uses sym e1 @ collect_uses sym e2
-  | Ebound e | Eannot (_, e) -> collect_uses sym e
+      collect_uses use_memo sym e1 @ collect_uses use_memo sym e2
+  | Ebound e | Eannot (_, e) -> collect_uses use_memo sym e
   | Ewait _ | Eexcluded _ -> []
 
 (* collect_creates finds Create-bound syms that are candidates for
@@ -259,7 +349,7 @@ let rec collect_creates ~also_fun_args (Expr (_, e_)) : Symbol.sym list =
 (*                has occurred (so a subsequent load would be safe)    *)
 (* ------------------------------------------------------------------ *)
 
-let rec check_definitely_init sym already_init (Expr (_, e_)) =
+let rec check_definitely_init init_memo sym already_init (Expr (_, e_)) =
   match e_ with
   | Eaction (Paction (_, Action (_, _, act_))) ->
       begin match act_ with
@@ -274,43 +364,105 @@ let rec check_definitely_init sym already_init (Expr (_, e_)) =
              initialises after. *)
           (already_init, true)
       | _ ->
+          (* TODO: revist this. Negative actions (stores) are not handled at
+             all, and this would affect weak-sequencing. Constructs I don't
+             care about should be handled conservatively (like a load?). *)
           (true, already_init)
       end
   | Esseq (_, e1, e2) ->
-      let (s1, ia1) = check_definitely_init sym already_init e1 in
-      let (s2, ia2) = check_definitely_init sym ia1 e2 in
+      let (s1, ia1) = check_definitely_init init_memo sym already_init e1 in
+      let (s2, ia2) = check_definitely_init init_memo sym ia1 e2 in
       (s1 && s2, ia2)
   | Ewseq (_, e1, e2) ->
       (* Neg actions in e1 are NOT sequenced before e2, so e2 cannot
          rely on stores in e1.  Pass already_init (not ia1) to e2. *)
-      let (s1, ia1) = check_definitely_init sym already_init e1 in
-      let (s2, ia2) = check_definitely_init sym already_init e2 in
+      let (s1, ia1) = check_definitely_init init_memo sym already_init e1 in
+      let (s2, ia2) = check_definitely_init init_memo sym already_init e2 in
       (s1 && s2, ia1 || ia2)
   | Eunseq arms ->
       (* No arm's result is visible to any sibling arm. *)
-      let results = List.map (check_definitely_init sym already_init) arms in
+      let results = List.map (check_definitely_init init_memo sym already_init) arms in
       let safe      = List.for_all (fun (s, _) -> s) results in
       let init_after = List.for_all (fun (_, ia) -> ia) results in
       (safe, init_after)
   | Eif (_, et, ef) ->
-      let (st, iat) = check_definitely_init sym already_init et in
-      let (sf, iaf) = check_definitely_init sym already_init ef in
+      let (st, iat) = check_definitely_init init_memo sym already_init et in
+      let (sf, iaf) = check_definitely_init init_memo sym already_init ef in
       (st && sf, iat && iaf)
   | Ecase (_, arms) ->
       let results =
-        List.map (fun (_, e) -> check_definitely_init sym already_init e) arms
+        List.map (fun (_, e) -> check_definitely_init init_memo sym already_init e) arms
       in
       let safe       = List.for_all (fun (s, _) -> s) results in
       let init_after = List.for_all (fun (_, ia) -> ia) results in
       (safe, init_after)
-  | Esave (_, args, body) ->
-      (* Conservative: a loop may re-enter without re-running the store. *)
-      if List.exists (fun (_, (_, pe)) -> sym_occurs_in_pexpr sym pe) args
-         || sym_occurs_in_expr sym body
-      then (false, already_init)
-      else (true, already_init)
+  | Esave ((label_sym, _), params, _body) ->
+      let entry = Pmap.find label_sym init_memo in
+      (match find_single_direct_alias sym
+               (List.map (fun (p, (_, pe)) -> (p, pe)) params) with
+      | None           -> (true, already_init)  (* NoAlias: by closedness, not in body *)
+      | Some param_sym ->
+          let (safe_uninit, inits_param) =
+            match Pmap.lookup param_sym !(entry.results) with
+            | Some cached -> cached
+            | None ->
+                (* Sentinel (true, true): safe over-approximation for back-edge Eruns.
+                   Any load-before-store in the body is encountered sequentially
+                   *before* the back-edge Erun in the analysis.  That load sets
+                   safe=false, which propagates through && rules regardless of the
+                   sentinel.  The sentinel therefore cannot mask a real unsafety.
+                   Using (false,false) instead would over-conservatively reject safe
+                   loops; (true,true) is the minimal sound choice. *)
+                entry.results := Pmap.add param_sym (true, true) !(entry.results);
+                let r = check_definitely_init init_memo param_sym false entry.body in
+                entry.results := Pmap.add param_sym r !(entry.results);
+                r
+          in
+          (* already_init: the local var can be loaded during transform at this
+               default-arg use point (sym has been stored on all incoming paths).
+             safe_uninit: the parameter does not need to be initialized going in
+               (the body always stores before loading on every control-flow path).
+             The || says the transform can still proceed in either case:
+               - already_init → we can emit a Load here to pass the current value in
+               - safe_uninit  → we can drop this arg; the body self-initializes
+             inits_param: the body unconditionally writes param_sym before completion,
+               so sym's storage is definitely initialized after the Esave exits.
+             already_init || inits_param: sym is init after Esave if it was init
+               going in, or the body always initializes param_sym. *)
+          (already_init || safe_uninit, already_init || inits_param))
+  | Erun (_, label_sym, args) ->
+      (* Erun unconditionally jumps to Esave L's body.
+         init_after = true: the sequential continuation is unreachable.
+         Closedness guarantees all Erun args matching sym are direct PEsym aliases
+         (no structural occurrences), so no structural check is needed here. *)
+      let entry = Pmap.find label_sym init_memo in
+      let safe =
+        match find_single_direct_alias sym
+                (List.combine (List.map fst entry.params) args) with
+        | None           -> true   (* sym not in args; vacuously safe *)
+        | Some param_sym ->
+            let (safe_uninit, _) =
+              match Pmap.lookup param_sym !(entry.results) with
+              | Some cached -> cached
+              | None ->
+                  (* Sentinel (true, true): same reasoning as Esave case above. *)
+                  entry.results := Pmap.add param_sym (true, true) !(entry.results);
+                  let r = check_definitely_init init_memo param_sym false entry.body in
+                  entry.results := Pmap.add param_sym r !(entry.results);
+                  r
+            in
+            (* already_init: the local var can be loaded during transform at this
+                 Erun arg use point (sym has been stored on all incoming paths).
+               safe_uninit: the parameter does not need to be initialized going in.
+               The || says the transform can still proceed in either case:
+                 - already_init → we can emit a Load here to pass the current value
+                 - safe_uninit  → we can drop this arg; the body self-initializes
+               init_after = true: Erun is terminal; the continuation is unreachable. *)
+            already_init || safe_uninit
+      in
+      (safe, true)
   | Elet (_, _, e) | Ebound e | Eannot (_, e) ->
-      check_definitely_init sym already_init e
+      check_definitely_init init_memo sym already_init e
   | _ ->
       (true, already_init)
 
@@ -325,7 +477,9 @@ let rec expr_writes_sym sym (Expr (_, e_)) =
       begin match act_ with
       | Store0 (_, _, addr_pe, _, _) -> is_pesym sym addr_pe
       | SeqRMW (_, _, addr_pe, _, _) -> is_pesym sym addr_pe
-      | _ -> false
+      | _ -> (* TODO: revisit this. Negative actions are not handled at all.
+                And he constructs that I do not should be handled
+                conservatively - like a store? *) false
       end
   | Ewseq (_, e1, e2) | Esseq (_, e1, e2) ->
       expr_writes_sym sym e1 || expr_writes_sym sym e2
@@ -337,8 +491,11 @@ let rec expr_writes_sym sym (Expr (_, e_)) =
       List.exists (fun (_, e) -> expr_writes_sym sym e) arms
   | Elet (_, _, e) | Ebound e | Eannot (_, e) ->
       expr_writes_sym sym e
-  | Esave (_, _, body) ->
-      expr_writes_sym sym body
+  | Esave (_, params, body) ->
+      (match find_single_direct_alias sym
+               (List.map (fun (p, (_, pe)) -> (p, pe)) params) with
+      | None           -> false
+      | Some param_sym -> expr_writes_sym param_sym body)
   | _ -> false
 
 (* ------------------------------------------------------------------ *)
@@ -366,8 +523,11 @@ let rec no_mixed_unseq_uses sym (Expr (_, e_)) =
       List.for_all (fun (_, e) -> no_mixed_unseq_uses sym e) arms
   | Elet (_, _, e) | Ebound e | Eannot (_, e) ->
       no_mixed_unseq_uses sym e
-  | Esave (_, _, body) ->
-      no_mixed_unseq_uses sym body
+  | Esave (_, params, body) ->
+      (match find_single_direct_alias sym
+               (List.map (fun (p, (_, pe)) -> (p, pe)) params) with
+      | None           -> true
+      | Some param_sym -> no_mixed_unseq_uses param_sym body)
   | End es | Epar es ->
       List.for_all (no_mixed_unseq_uses sym) es
   | _ -> true
@@ -377,10 +537,14 @@ let rec no_mixed_unseq_uses sym (Expr (_, e_)) =
 (* ------------------------------------------------------------------ *)
 
 let find_promotable ~also_fun_args f_sym body : Symbol.sym list =
+  let use_memo  : use list memo_save_info = collect_esave_defs body in
+  let init_memo : (bool * bool) memo_save_info =
+    Pmap.map (fun { params; body; _ } ->
+      { params; body; results = ref (Pmap.empty Symbol.compare_sym) }) use_memo in
   let creates = collect_creates ~also_fun_args body in
   let is_promotable s =
-    List.for_all use_is_promotable (collect_uses s body)
-    && fst (check_definitely_init s false body)
+    List.for_all use_is_promotable (collect_uses use_memo s body)
+    && fst (check_definitely_init init_memo s false body)
     && no_mixed_unseq_uses s body
   in
   let promotable = List.filter is_promotable creates in

--- a/ocaml_frontend/rewriters/core_mem2reg.ml
+++ b/ocaml_frontend/rewriters/core_mem2reg.ml
@@ -1,3 +1,6 @@
+(* This file implements an analysis to find 'promotable' variables,
+ * stack variables which can be promoted out of memory operations and
+ * into pure Core expressions. *)
 open Core
 
 (* ------------------------------------------------------------------ *)
@@ -5,17 +8,18 @@ open Core
 (* ------------------------------------------------------------------ *)
 
 type use =
-  | Use_load   (* Load0(_, PEsym ptr, _)  — address argument *)
-  | Use_store  (* Store0(_, _, PEsym ptr, _, _) — address argument *)
-  | Use_kill   (* Kill(_, PEsym ptr) *)
-  | Use_other  (* any other occurrence *)
+  | Use_load    (* Load0(_, PEsym ptr, _)  — address argument *)
+  | Use_store   (* Store0(_, _, PEsym ptr, _, _) — address argument *)
+  | Use_kill    (* Kill(_, PEsym ptr) *)
+  | Use_seqrmw  (* SeqRMW(_, _, PEsym ptr, tmp, upd) — ptr is the address argument *)
+  | Use_other   (* any other occurrence *)
 
 let use_is_promotable = function
-  | Use_load | Use_store | Use_kill -> true
+  | Use_load | Use_store | Use_kill | Use_seqrmw -> true
   | Use_other -> false
 
 (* ------------------------------------------------------------------ *)
-(* Occurrence helpers                                                   *)
+(* Occurrence helpers                                                 *)
 (* ------------------------------------------------------------------ *)
 
 let is_pesym sym (Pexpr (_, _, pe_)) =
@@ -117,7 +121,9 @@ and sym_occurs_in_action sym act_ =
       List.exists (sym_occurs_in_pexpr sym) [pe1; pe2; pe3]
 
 (* ------------------------------------------------------------------ *)
-(* Classify a single action's uses of sym                              *)
+(* Classify a single action's uses of sym                             *)
+(* Only plain uses of the symbol are allowed - e.g. member shifts are *)
+(* counted as other uses and not promoted.                            *)
 (* ------------------------------------------------------------------ *)
 
 let classify_action sym act_ : use list =
@@ -140,6 +146,20 @@ let classify_action sym act_ : use list =
       if is_pesym sym addr_pe then [Use_kill]
       else if sym_occurs_in_pexpr sym addr_pe then [Use_other]
       else []
+  | SeqRMW (_, _ty_pe, addr_pe, _tmp_sym, upd_pe) ->
+      let addr_use =
+        if is_pesym sym addr_pe then
+          [Use_seqrmw]
+        else if sym_occurs_in_pexpr sym addr_pe then
+          (* I think the elaboration ensures this case is impossible *)
+          [Use_other]
+        else
+          []
+      in
+      let upd_use =
+        if sym_occurs_in_pexpr sym upd_pe then [Use_other] else []
+      in
+      addr_use @ upd_use
   | _ ->
       if sym_occurs_in_action sym act_ then [Use_other] else []
 
@@ -231,6 +251,128 @@ let rec collect_creates ~also_fun_args (Expr (_, e_)) : Symbol.sym list =
   | Erun _ | Ewait _ | Eexcluded _ -> []
 
 (* ------------------------------------------------------------------ *)
+(* check_definitely_init                                               *)
+(*                                                                     *)
+(* Returns (safe, init_after):                                         *)
+(*   safe       – no load-before-store on any syntactic path           *)
+(*   init_after – on ALL paths through expr, at least one store        *)
+(*                has occurred (so a subsequent load would be safe)    *)
+(* ------------------------------------------------------------------ *)
+
+let rec check_definitely_init sym already_init (Expr (_, e_)) =
+  match e_ with
+  | Eaction (Paction (_, Action (_, _, act_))) ->
+      begin match act_ with
+      | Store0 (_, _, addr_pe, _, _) when is_pesym sym addr_pe ->
+          (true, true)
+      | Load0 (_, addr_pe, _) when is_pesym sym addr_pe ->
+          (already_init, already_init)
+      | Kill (_, addr_pe) when is_pesym sym addr_pe ->
+          (true, false)
+      | SeqRMW (_, _, addr_pe, _, _) when is_pesym sym addr_pe ->
+          (* Atomically reads then writes: safe iff already_init; always
+             initialises after. *)
+          (already_init, true)
+      | _ ->
+          (true, already_init)
+      end
+  | Esseq (_, e1, e2) ->
+      let (s1, ia1) = check_definitely_init sym already_init e1 in
+      let (s2, ia2) = check_definitely_init sym ia1 e2 in
+      (s1 && s2, ia2)
+  | Ewseq (_, e1, e2) ->
+      (* Neg actions in e1 are NOT sequenced before e2, so e2 cannot
+         rely on stores in e1.  Pass already_init (not ia1) to e2. *)
+      let (s1, ia1) = check_definitely_init sym already_init e1 in
+      let (s2, ia2) = check_definitely_init sym already_init e2 in
+      (s1 && s2, ia1 || ia2)
+  | Eunseq arms ->
+      (* No arm's result is visible to any sibling arm. *)
+      let results = List.map (check_definitely_init sym already_init) arms in
+      let safe      = List.for_all (fun (s, _) -> s) results in
+      let init_after = List.for_all (fun (_, ia) -> ia) results in
+      (safe, init_after)
+  | Eif (_, et, ef) ->
+      let (st, iat) = check_definitely_init sym already_init et in
+      let (sf, iaf) = check_definitely_init sym already_init ef in
+      (st && sf, iat && iaf)
+  | Ecase (_, arms) ->
+      let results =
+        List.map (fun (_, e) -> check_definitely_init sym already_init e) arms
+      in
+      let safe       = List.for_all (fun (s, _) -> s) results in
+      let init_after = List.for_all (fun (_, ia) -> ia) results in
+      (safe, init_after)
+  | Esave (_, args, body) ->
+      (* Conservative: a loop may re-enter without re-running the store. *)
+      if List.exists (fun (_, (_, pe)) -> sym_occurs_in_pexpr sym pe) args
+         || sym_occurs_in_expr sym body
+      then (false, already_init)
+      else (true, already_init)
+  | Elet (_, _, e) | Ebound e | Eannot (_, e) ->
+      check_definitely_init sym already_init e
+  | _ ->
+      (true, already_init)
+
+(* ------------------------------------------------------------------ *)
+(* expr_writes_sym: does expr contain a Store0 or SeqRMW whose        *)
+(* address is directly PEsym sym?                                      *)
+(* ------------------------------------------------------------------ *)
+
+let rec expr_writes_sym sym (Expr (_, e_)) =
+  match e_ with
+  | Eaction (Paction (_, Action (_, _, act_))) ->
+      begin match act_ with
+      | Store0 (_, _, addr_pe, _, _) -> is_pesym sym addr_pe
+      | SeqRMW (_, _, addr_pe, _, _) -> is_pesym sym addr_pe
+      | _ -> false
+      end
+  | Ewseq (_, e1, e2) | Esseq (_, e1, e2) ->
+      expr_writes_sym sym e1 || expr_writes_sym sym e2
+  | Eunseq es | End es | Epar es ->
+      List.exists (expr_writes_sym sym) es
+  | Eif (_, e1, e2) ->
+      expr_writes_sym sym e1 || expr_writes_sym sym e2
+  | Ecase (_, arms) ->
+      List.exists (fun (_, e) -> expr_writes_sym sym e) arms
+  | Elet (_, _, e) | Ebound e | Eannot (_, e) ->
+      expr_writes_sym sym e
+  | Esave (_, _, body) ->
+      expr_writes_sym sym body
+  | _ -> false
+
+(* ------------------------------------------------------------------ *)
+(* no_mixed_unseq_uses                                                 *)
+(*                                                                     *)
+(* Returns false if sym appears in a write arm AND ≥2 arms of any     *)
+(* Eunseq mention sym — which would mean promoting sym silently        *)
+(* removes a Store0/SeqRMW that Cerberus's sequencing-violation        *)
+(* detector would otherwise see.                                       *)
+(* ------------------------------------------------------------------ *)
+
+let rec no_mixed_unseq_uses sym (Expr (_, e_)) =
+  match e_ with
+  | Eunseq arms ->
+      let writing_arms   = List.filter (expr_writes_sym sym) arms in
+      let mentioning_arms = List.filter (sym_occurs_in_expr sym) arms in
+      let conflict = (match writing_arms with [] -> false | _ -> true)
+                     && List.length mentioning_arms >= 2 in
+      (not conflict) && List.for_all (no_mixed_unseq_uses sym) arms
+  | Ewseq (_, e1, e2) | Esseq (_, e1, e2) ->
+      no_mixed_unseq_uses sym e1 && no_mixed_unseq_uses sym e2
+  | Eif (_, e1, e2) ->
+      no_mixed_unseq_uses sym e1 && no_mixed_unseq_uses sym e2
+  | Ecase (_, arms) ->
+      List.for_all (fun (_, e) -> no_mixed_unseq_uses sym e) arms
+  | Elet (_, _, e) | Ebound e | Eannot (_, e) ->
+      no_mixed_unseq_uses sym e
+  | Esave (_, _, body) ->
+      no_mixed_unseq_uses sym body
+  | End es | Epar es ->
+      List.for_all (no_mixed_unseq_uses sym) es
+  | _ -> true
+
+(* ------------------------------------------------------------------ *)
 (* Promotability analysis for a single procedure                       *)
 (* ------------------------------------------------------------------ *)
 
@@ -238,6 +380,8 @@ let find_promotable ~also_fun_args f_sym body : Symbol.sym list =
   let creates = collect_creates ~also_fun_args body in
   let is_promotable s =
     List.for_all use_is_promotable (collect_uses s body)
+    && fst (check_definitely_init s false body)
+    && no_mixed_unseq_uses s body
   in
   let promotable = List.filter is_promotable creates in
   Cerb_debug.print_debug 3 [] (fun () ->

--- a/ocaml_frontend/rewriters/core_mem2reg.ml
+++ b/ocaml_frontend/rewriters/core_mem2reg.ml
@@ -195,44 +195,38 @@ let rec collect_uses sym (Expr (_, e_)) : use list =
   | Ebound e | Eannot (_, e) -> collect_uses sym e
   | Ewait _ | Eexcluded _ -> []
 
-(* ------------------------------------------------------------------ *)
-(* collect_creates: find Create-bound ptr syms (PrefSource only)      *)
-(*                                                                     *)
-(* NOTE — calling-convention assumption: this pass only considers      *)
-(* Create(PrefSource _) bindings, i.e. C source-level local variables. *)
-(* It does NOT promote Proc parameter pointers, because under the      *)
-(* standard via-pointer argument-passing convention the caller owns    *)
-(* the argument slot and the callee merely receives a pointer to it.   *)
-(*                                                                     *)
-(* CN uses a value-passing convention instead: arguments are passed    *)
-(* directly as Core values, not as pointers.  Under that convention   *)
-(* a parameter whose address is never taken could also be promoted     *)
-(* here (its Create+Store preamble at function entry has exactly the   *)
-(* same Load/Store/Kill-only shape as a promotable local).  Extending  *)
-(* collect_creates to also yield PrefFunArg Create bindings would      *)
-(* enable that optimisation for CN.                                    *)
-(* ------------------------------------------------------------------ *)
+(* collect_creates finds Create-bound syms that are candidates for
+   promotion.  Under Normal_callconv only PrefSource (C local variables)
+   are considered; under Inner_arg_callconv PrefFunArg (callee-owned
+   parameter temporaries) are also included, since in that convention
+   the callee creates and owns the argument slot.                      *)
 
-let rec collect_creates (Expr (_, e_)) : Symbol.sym list =
+let rec collect_creates ~also_fun_args (Expr (_, e_)) : Symbol.sym list =
   match e_ with
   | Esseq (
       Pattern (_, CaseBase (Some ptr_sym, _)),
       Expr (_, Eaction (Paction (_, Action (_, _, Create (_, _, Symbol.PrefSource _))))),
       body
     ) ->
-      ptr_sym :: collect_creates body
+      ptr_sym :: collect_creates ~also_fun_args body
+  | Esseq (
+      Pattern (_, CaseBase (Some ptr_sym, _)),
+      Expr (_, Eaction (Paction (_, Action (_, _, Create (_, _, Symbol.PrefFunArg _))))),
+      body
+    ) when also_fun_args ->
+      ptr_sym :: collect_creates ~also_fun_args body
   | Ewseq (_, e1, e2) | Esseq (_, e1, e2) ->
-      collect_creates e1 @ collect_creates e2
+      collect_creates ~also_fun_args e1 @ collect_creates ~also_fun_args e2
   | Elet (_, _, e) | Ebound e | Eannot (_, e) ->
-      collect_creates e
+      collect_creates ~also_fun_args e
   | Eif (_, e1, e2) ->
-      collect_creates e1 @ collect_creates e2
+      collect_creates ~also_fun_args e1 @ collect_creates ~also_fun_args e2
   | Ecase (_, arms) ->
-      List.concat_map (fun (_, e) -> collect_creates e) arms
+      List.concat_map (fun (_, e) -> collect_creates ~also_fun_args e) arms
   | Esave (_, _, body) ->
-      collect_creates body
+      collect_creates ~also_fun_args body
   | Eunseq es | End es | Epar es ->
-      List.concat_map collect_creates es
+      List.concat_map (collect_creates ~also_fun_args) es
   | Epure _ | Eaction _ | Ememop _ | Eccall _ | Eproc _
   | Erun _ | Ewait _ | Eexcluded _ -> []
 
@@ -240,8 +234,8 @@ let rec collect_creates (Expr (_, e_)) : Symbol.sym list =
 (* Promotability analysis for a single procedure                       *)
 (* ------------------------------------------------------------------ *)
 
-let find_promotable f_sym body : Symbol.sym list =
-  let creates = collect_creates body in
+let find_promotable ~also_fun_args f_sym body : Symbol.sym list =
+  let creates = collect_creates ~also_fun_args body in
   let is_promotable s =
     List.for_all use_is_promotable (collect_uses s body)
   in
@@ -258,10 +252,14 @@ let find_promotable f_sym body : Symbol.sym list =
 (* ------------------------------------------------------------------ *)
 
 let transform_file file =
+  let also_fun_args = match file.calling_convention with
+    | Inner_arg_callconv -> true
+    | Normal_callconv    -> false
+  in
   List.iter (fun (f_sym, decl) ->
     match decl with
     | Proc (_, _, _, _, body) ->
-        ignore (find_promotable f_sym body)
+        ignore (find_promotable ~also_fun_args f_sym body)
     | Fun _ | ProcDecl _ | BuiltinDecl _ -> ()
   ) (Pmap.bindings_list file.funs);
   file

--- a/ocaml_frontend/rewriters/core_mem2reg.ml
+++ b/ocaml_frontend/rewriters/core_mem2reg.ml
@@ -332,74 +332,46 @@ module Event_set = Set.Make(Event)
 
 (* env: initialization state of sym at a given program point          *)
 (* Uninit      — no store observed yet on this path                   *)
-(* Init pe     — sym was last stored with committed value pe          *)
+(* Init        — sym was last stored with committed value pe          *)
 (* Killed      — sym's allocation was freed                           *)
-type env = Uninit | Init of pexpr | Killed
+type env = Uninit | Init | Killed
 let is_uninit = function Uninit -> true | _ -> false
 let is_killed = function Killed -> true | _ -> false
+let is_init   = function Init   -> true | _ -> false
 
 exception Not_sequentialisable
 exception Load_from_uninit
 
-let ( let* ) = Option.bind
-
-
-(* combine_branches pe_cond r1 r2: merge results from two branches.
-   pe_cond is used to construct PEif for the merged Init pexpr. *)
-let combine_branches pe_cond r1 r2 =
-  match r1, r2 with
-  | None, None -> None
-  | None, (Some _ as result) | (Some _ as result), None -> result
-  | Some (ev1, env1), Some (ev2, env2) ->
-    let combined_env = match env1, env2 with
-      | Uninit, Uninit -> Uninit
-      | Killed, Killed -> Killed
-      | Init pe1, Init pe2 ->
-          Init (Pexpr ([], (), PEif (pe_cond, pe1, pe2)))
-      | _ -> raise Not_sequentialisable
-    in
-    Some (Event_set.union ev1 ev2, combined_env)
-
-(* combine_case_branches pe arm_results:
-   Merges sequentialisable results from Ecase arms, building a PEcase node for
-   the Init env. pe is the case discriminant pexpr.
-   arm_results : (pattern * (Event_set.t * env) option) list
-
-   Note: arms whose result is None (all paths end in Erun) are handled as if
-   having no events and producing UB, for the sake of combining values into
-   one case-pexpr and retaining pattern-completeness. *)
-let combine_case_branches pe arm_results =
-  let here = Cerb_location.other __LOC__ in
-  let ub = Undefined.DUMMY "core_mem2reg: branch assumed to not return" in
-  let undef = Pexpr ([], (), PEundef (here, ub)) in
-  let branches =
-    List.map
-      (fun (pat, r) ->
-         match r with
-         | None -> (pat, (Event_set.empty, Init undef))
-         | Some x -> (pat, x))
-      arm_results in
-  let all_evs = List.map (fun (_, (ev, _)) -> ev) branches in
+(* merges sequentialisable results from Eif/Ecase arms if they all agree
+ * Note: this is fine for transforming too because we can use PEundef
+ * as values for non-returning branches *)
+let combine_branches arm_results =
+  let branches = List.filter_map Fun.id arm_results in
+  let all_evs, all_env = List.split branches in
   let all_evs = List.fold_left Event_set.union Event_set.empty all_evs in
-  let all_uninit = List.for_all (fun (_, (_, e)) -> is_uninit e) branches in
-  let all_killed = List.for_all (fun (_, (_, e)) -> is_killed e) branches in
   let combined_env =
-    if all_uninit then
+    if List.for_all is_uninit all_env then
       Uninit
-    else if all_killed then
+    else if List.for_all is_killed all_env then
       Killed
+    else if List.for_all is_init all_env then
+       Init
     else
-      let pe_arms =
-        List.map (fun (pat, (_, e)) ->
-            match e with
-            | Init pe2 -> (pat, pe2)
-            | _ -> raise Not_sequentialisable) branches in
-      Init (Pexpr ([], (), PEcase (pe, pe_arms))) in
-  Some (all_evs, combined_env)
+       raise Not_sequentialisable in
+  (all_evs, combined_env)
+
+let is_init_env needs_init ~param_env ~env =
+  if needs_init then
+    (match env with
+    | Killed -> raise Not_sequentialisable
+    | Uninit -> raise Load_from_uninit
+    | Init -> param_env)
+  else
+     param_env
 
 (* seq_memo: memoises sequentialisable results per (label_sym, param_sym).
    'a = bool * (Event_set.t * env) option
-     fst = init_needed: body requires Init _ env on entry (true) or
+     fst = init_needed: body requires Init env on entry (true) or
            self-initialises (false)
      snd = None while in progress or all paths end in Erun;
            Some (ev, env') otherwise *)
@@ -408,6 +380,10 @@ type seq_memo = (bool * (Event_set.t * env) option) memo_save_info
 let rec sequentialisable (seq_memo : seq_memo) sym env (Expr (_, e_))
     : (Event_set.t * env) option =
   let module Es = Event_set in
+  let ( let* ) = Option.bind in
+  let must_return = function
+    | None -> raise Not_sequentialisable
+    | Some (ev, env) -> (ev, env) in
   match e_ with
   | Eaction (Paction (polarity, Action (_, _, act_))) ->
       begin match act_ with
@@ -415,19 +391,17 @@ let rec sequentialisable (seq_memo : seq_memo) sym env (Expr (_, e_))
           let ev = match polarity with
             | Pos -> Event.Pos_store
             | Neg -> Event.Neg_store in
-        Some (Es.singleton ev, Init val_pe)
+        Some (Es.singleton ev, Init)
       | Load0 (_, addr_pe, _) when is_pesym sym addr_pe ->
           (match env with
-           | Init _ -> Some (Es.singleton Event.Load, env)
+           | Init   -> Some (Es.singleton Event.Load, env)
            | Uninit  -> raise Load_from_uninit
            | Killed  -> raise Not_sequentialisable)
       | Kill (_, addr_pe) when is_pesym sym addr_pe ->
           Some (Es.singleton Event.Kill, Killed)
       | SeqRMW (_, _, addr_pe, tmp_sym, upd_pe) when is_pesym sym addr_pe ->
           (match env with
-           | Init pe ->
-               let stored = Core_aux.unsafe_subst_sym_pexpr tmp_sym pe upd_pe in
-               Some (Es.of_list [Event.Load; Event.Pos_store], Init stored)
+           | Init -> Some (Es.of_list [Event.Load; Event.Pos_store], Init)
            | Uninit -> raise Load_from_uninit
            | Killed -> raise Not_sequentialisable)
       | _ ->
@@ -440,26 +414,30 @@ let rec sequentialisable (seq_memo : seq_memo) sym env (Expr (_, e_))
       let* (ev2, env2) = sequentialisable seq_memo sym env1 e2 in
       Some (Es.union ev1 ev2, env2)
   | Ewseq (_, e1, e2) ->
-      let* (ev1, env1) = sequentialisable seq_memo sym env e1 in
-      let* (ev2, env2) = sequentialisable seq_memo sym env1 e2 in
-      if Es.exists Event.is_neg_store ev1
-          && not (Es.is_empty ev2) then
-        raise Not_sequentialisable
-      else
-        Some (Es.union ev1 ev2, env2)
+      (* race-condition analysis is invalid if e1/e2 don't return
+       * or, assume definite race if either expression doesn't return *)
+    let (ev1, env1) = must_return @@ sequentialisable seq_memo sym env e1 in
+    let (ev2, env2) = must_return @@ sequentialisable seq_memo sym env1 e2 in
+    if Es.exists Event.is_neg_store ev1
+        && not (Es.is_empty ev2) then
+      raise Not_sequentialisable
+    else
+      Some (Es.union ev1 ev2, env2)
   | Eif (pe, et, ef) ->
       let rt = sequentialisable seq_memo sym env et in
       let rf = sequentialisable seq_memo sym env ef in
-      combine_branches pe rt rf
+      Some (combine_branches [rt; rf])
   | Ecase (pe, arms) ->
       let arm_results =
-        List.map (fun (pat, e) -> (pat, sequentialisable seq_memo sym env e)) arms
+        List.map (fun (_, e) -> sequentialisable seq_memo sym env e) arms
       in
-      combine_case_branches pe arm_results
+      Some (combine_branches arm_results)
   | End arms | Epar arms | Eunseq arms ->
       let eventful_arms = List.filter_map
         (fun arm ->
-          let* (ev, env') = sequentialisable seq_memo sym env arm in
+          (* race-condition analysis is invalid if e1/e2 don't return or,
+           * assume definite race if either expression doesn't return *)
+          let (ev, env') = must_return @@ sequentialisable seq_memo sym env arm in
           if Es.is_empty ev then None else Some (ev, env'))
         arms in
       let all_reads =
@@ -479,15 +457,23 @@ let rec sequentialisable (seq_memo : seq_memo) sym env (Expr (_, e_))
       (match find_single_direct_alias sym
                (List.map (fun (p, (_, pe)) -> (p, pe)) params) with
        | None           -> Some (Es.empty, env)
-       | Some param_sym -> save_param_needs_init seq_memo sym env label_sym param_sym)
+       | Some param_sym ->
+         let (needs_init, result) =
+             save_param_needs_init seq_memo sym label_sym param_sym in
+         let* (ev, param_env) = result in
+         Some (ev, is_init_env needs_init ~env ~param_env))
   | Erun (_, label_sym, args) ->
       let entry = Pmap.find label_sym seq_memo in
       (match find_single_direct_alias sym
                (List.combine (List.map fst entry.params) args) with
        | None           -> ()
        | Some param_sym ->
-           ignore (save_param_needs_init seq_memo sym env label_sym param_sym));
-      None
+         let (needs_init, result) =
+           save_param_needs_init seq_memo sym label_sym param_sym in
+         Option.iter (fun (ev, param_env) ->
+             ignore (is_init_env needs_init ~env ~param_env))
+           result);
+         None
   | Elet (_, _, e) | Eannot (_, e) ->
       sequentialisable seq_memo sym env e
   | Ebound e ->
@@ -504,33 +490,25 @@ let rec sequentialisable (seq_memo : seq_memo) sym env (Expr (_, e_))
    - Sentinel (false, None) is written before recursing so that back-edge
      Erun calls find the entry and do not loop.
    - If Load_from_uninit is raised (body reads sym before any store):
-       * If outer env = Init _: mark init_needed=true, re-run with outer env.
+       * If outer env = Init: mark init_needed=true, re-run with outer env.
        * Otherwise: re-raise Load_from_uninit.
-   - If already memoised with init_needed=true and env ≠ Init _: re-raise
+   - If already memoised with init_needed=true and env ≠ Init: re-raise
      Load_from_uninit. *)
-and save_param_needs_init seq_memo sym env label_sym param_sym
-    : (Event_set.t * env) option =
+and save_param_needs_init seq_memo sym label_sym param_sym
+    : bool * (Event_set.t * env) option =
   let entry = Pmap.find label_sym seq_memo in
   match Pmap.lookup param_sym !(entry.results) with
-  | Some (true, result) ->
-      (match env with
-       | Init _ -> result
-       | _      -> raise Load_from_uninit)
-  | Some (false, result) ->
-      result
+  | Some result -> result
   | None ->
       entry.results := Pmap.add param_sym (false, None) !(entry.results);
       (try
         let result = sequentialisable seq_memo param_sym Uninit entry.body in
         entry.results := Pmap.add param_sym (false, result) !(entry.results);
-        result
+        (false, result)
       with Load_from_uninit ->
-        match env with
-        | Init _ ->
-            let result = sequentialisable seq_memo param_sym env entry.body in
-            entry.results := Pmap.add param_sym (true, result) !(entry.results);
-            result
-        | _ -> raise Load_from_uninit)
+        let result = sequentialisable seq_memo param_sym Init entry.body in
+        entry.results := Pmap.add param_sym (true, result) !(entry.results);
+        (true, result))
 
 (* ------------------------------------------------------------------ *)
 (* Promotability analysis for a single procedure                       *)

--- a/ocaml_frontend/rewriters/core_mem2reg.ml
+++ b/ocaml_frontend/rewriters/core_mem2reg.ml
@@ -1,39 +1,28 @@
 (* This file implements an analysis to find 'promotable' variables,
- * stack variables which can be promoted out of memory operations and
- * into pure Core expressions. *)
+   stack variables which can be promoted out of memory operations and
+   into pure Core expressions. *)
 open Core
 
 (* ------------------------------------------------------------------ *)
-(* Write_kind: lattice for "how strongly was sym initialized"          *)
-(*                                                                     *)
-(* No_write < Weak < Strong                                            *)
-(*   Strong   — Paction Pos store, committed before Esseq continuation *)
-(*   Weak     — Paction Neg store in Ewseq e1, unsequenced w.r.t. e2  *)
-(*   No_write — no store observed on this path                        *)
-(*                                                                     *)
-(* A Load0 or SeqRMW is only safe if sym was *strongly* initialized.  *)
+(* Mem_event: memory events observable on a single sym                *)
 (* ------------------------------------------------------------------ *)
 
-module Write_kind = struct
-  type t = No_write | Weak | Strong
-
-  (* join: least upper bound — goes up the lattice *)
-  let (||) a b = match a, b with
-    | No_write, x | x, No_write -> x
-    | Strong,   _ | _, Strong   -> Strong
-    | Weak,     Weak             -> Weak
-
-  (* meet: greatest lower bound — goes down the lattice *)
-  let (&&) a b = match a, b with
-    | Strong,   x | x, Strong   -> x
-    | No_write, _ | _, No_write -> No_write
-    | Weak,     Weak             -> Weak
-
-  let of_bool = function true -> Strong | false -> No_write
-
-  let is_strong   = function Strong   -> true | _ -> false
-  let is_write = function No_write -> false | _ -> true
+module Mem_event = struct
+  type t = Pos_store | Neg_store | Load | Kill
 end
+
+(* env: initialization state of sym at a given program point          *)
+(* Uninit      — no store observed yet on this path                   *)
+(* Init pe     — sym was last stored with committed value pe          *)
+(* DelayedInit — sym was stored (Neg polarity, Ewseq e1) but not yet  *)
+(*               committed; subsequent e2 must not observe this       *)
+(* Killed      — sym's allocation was freed                           *)
+type env = Uninit | Init of pexpr | DelayedInit of pexpr | Killed
+
+exception Not_sequentialisable
+exception Load_from_uninit
+
+let ( let* ) = Option.bind
 
 (* ------------------------------------------------------------------ *)
 (* Internal classification of how a pointer sym is used               *)
@@ -46,7 +35,7 @@ type use =
   | Use_seqrmw  (* SeqRMW(_, _, PEsym ptr, tmp, upd) — ptr is the address argument *)
   | Use_other   (* any other occurrence *)
 
-let use_is_promotable = function
+let addr_not_taken = function
   | Use_load | Use_store | Use_kill | Use_seqrmw -> true
   | Use_other -> false
 
@@ -92,36 +81,7 @@ let rec sym_occurs_in_pexpr sym (Pexpr (_, _, pe_)) =
   | PEare_compatible (pe1, pe2) ->
       sym_occurs_in_pexpr sym pe1 || sym_occurs_in_pexpr sym pe2
 
-and sym_occurs_in_expr sym (Expr (_, e_)) =
-  match e_ with
-  | Epure pe -> sym_occurs_in_pexpr sym pe
-  | Eaction (Paction (_, Action (_, _, act_))) ->
-      sym_occurs_in_action sym act_
-  | Ememop (_, pes) -> List.exists (sym_occurs_in_pexpr sym) pes
-  | Ecase (pe, arms) ->
-      sym_occurs_in_pexpr sym pe
-      || List.exists (fun (_, e) -> sym_occurs_in_expr sym e) arms
-  | Elet (_, pe, e) ->
-      sym_occurs_in_pexpr sym pe || sym_occurs_in_expr sym e
-  | Eif (pe, e1, e2) ->
-      sym_occurs_in_pexpr sym pe
-      || sym_occurs_in_expr sym e1
-      || sym_occurs_in_expr sym e2
-  | Eccall (_, pe1, pe2, pes) ->
-      List.exists (sym_occurs_in_pexpr sym) (pe1 :: pe2 :: pes)
-  | Eproc (_, _, pes) | Erun (_, _, pes) ->
-      List.exists (sym_occurs_in_pexpr sym) pes
-  | Eunseq es | End es | Epar es ->
-      List.exists (sym_occurs_in_expr sym) es
-  | Ewseq (_, e1, e2) | Esseq (_, e1, e2) ->
-      sym_occurs_in_expr sym e1 || sym_occurs_in_expr sym e2
-  | Ebound e | Eannot (_, e) -> sym_occurs_in_expr sym e
-  | Esave (_, args, body) ->
-      List.exists (fun (_, (_, pe)) -> sym_occurs_in_pexpr sym pe) args
-      || sym_occurs_in_expr sym body
-  | Ewait _ | Eexcluded _ -> false
-
-and sym_occurs_in_action sym act_ =
+let sym_occurs_in_action sym act_ =
   match act_ with
   | Create (pe1, pe2, _) ->
       sym_occurs_in_pexpr sym pe1 || sym_occurs_in_pexpr sym pe2
@@ -194,7 +154,7 @@ let classify_action sym act_ : use list =
 (* ------------------------------------------------------------------ *)
 (* Esave memo tables                                                   *)
 (*                                                                     *)
-(* Both collect_uses and check_definitely_init need to analyse Esave  *)
+(* Both collect_uses and sequentialisable need to analyse Esave        *)
 (* bodies: once via the default args and once per Erun call site.     *)
 (* Results are memoised per (label_sym, param_sym) to avoid redundant *)
 (* traversals and to terminate on back-edge Eruns.                    *)
@@ -206,10 +166,8 @@ type 'a esave_memo_entry = {
   results : (Symbol.sym, 'a) Pmap.map ref;        (* param_sym -> cached result, filled lazily *)
 }
 
-(* 'a = use list              for collect_uses                              *)
-(* 'a = bool * Write_kind.t  for check_definitely_init                     *)
-(*   fst = safe_uninit:  fst (check_definitely_init ... param_sym false body)  *)
-(*   snd = inits_param:  snd (check_definitely_init ... param_sym false body)  *)
+(* 'a = use list                              for collect_uses          *)
+(* 'a = bool * (Mem_event.t list * env) option  for sequentialisable   *)
 type 'a memo_save_info = (Symbol.sym, 'a esave_memo_entry) Pmap.map
 
 (* find_single_direct_alias sym pairs:
@@ -371,213 +329,282 @@ let rec collect_creates ~also_fun_args (Expr (_, e_)) : Symbol.sym list =
   | Erun _ | Ewait _ | Eexcluded _ -> []
 
 (* ------------------------------------------------------------------ *)
-(* check_definitely_init                                               *)
-(*                                                                     *)
-(* Returns (safe, init_after):                                         *)
-(*   safe       – no load-before-store on any syntactic path           *)
-(*   init_after – Write_kind describing how sym is initialized after   *)
-(*                this expression on ALL paths                         *)
-(*                                                                     *)
-(* strongly_init: sym is strongly initialized on entry (bool)         *)
+(* subst_pexpr: substitute PEsym tmp_sym -> replacement in pe         *)
+(* Used to track the value written by SeqRMW.                         *)
 (* ------------------------------------------------------------------ *)
 
-let rec check_definitely_init init_memo sym strongly_init (Expr (_, e_)) =
+let rec subst_pexpr (tmp_sym : Symbol.sym) (replacement : pexpr)
+    ((Pexpr (annots, bty, pe_)) as original : pexpr) : pexpr =
+  let sub pe = subst_pexpr tmp_sym replacement pe in
+  match pe_ with
+  | PEsym s when Symbol.symbolEquality s tmp_sym -> replacement
+  | PEsym _ | PEval _ | PEimpl _ | PEundef _ | PEerror _ -> original
+  | PEctor (ctor, pes) -> Pexpr (annots, bty, PEctor (ctor, List.map sub pes))
+  | PEcall (f, pes)    -> Pexpr (annots, bty, PEcall (f, List.map sub pes))
+  | PEmemop (op, pes)  -> Pexpr (annots, bty, PEmemop (op, List.map sub pes))
+  | PEcase (pe, arms)  ->
+      Pexpr (annots, bty,
+        PEcase (sub pe, List.map (fun (pat, pe2) -> (pat, sub pe2)) arms))
+  | PEarray_shift (pe1, ty, pe2) ->
+      Pexpr (annots, bty, PEarray_shift (sub pe1, ty, sub pe2))
+  | PEop (op, pe1, pe2) ->
+      Pexpr (annots, bty, PEop (op, sub pe1, sub pe2))
+  | PElet (pat, pe1, pe2) ->
+      Pexpr (annots, bty, PElet (pat, sub pe1, sub pe2))
+  | PEwrapI (ty1, ty2, pe1, pe2) ->
+      Pexpr (annots, bty, PEwrapI (ty1, ty2, sub pe1, sub pe2))
+  | PEcatch_exceptional_condition (ty1, ty2, pe1, pe2) ->
+      Pexpr (annots, bty, PEcatch_exceptional_condition (ty1, ty2, sub pe1, sub pe2))
+  | PEmember_shift (pe, tag, member) ->
+      Pexpr (annots, bty, PEmember_shift (sub pe, tag, member))
+  | PEconv_int (ty, pe)  -> Pexpr (annots, bty, PEconv_int (ty, sub pe))
+  | PEnot pe             -> Pexpr (annots, bty, PEnot (sub pe))
+  | PEis_scalar pe       -> Pexpr (annots, bty, PEis_scalar (sub pe))
+  | PEis_integer pe      -> Pexpr (annots, bty, PEis_integer (sub pe))
+  | PEis_signed pe       -> Pexpr (annots, bty, PEis_signed (sub pe))
+  | PEis_unsigned pe     -> Pexpr (annots, bty, PEis_unsigned (sub pe))
+  | PEmemberof (tag, member, pe) ->
+      Pexpr (annots, bty, PEmemberof (tag, member, sub pe))
+  | PEunion (tag, member, pe) ->
+      Pexpr (annots, bty, PEunion (tag, member, sub pe))
+  | PEcfunction pe   -> Pexpr (annots, bty, PEcfunction (sub pe))
+  | PEbmc_assume pe  -> Pexpr (annots, bty, PEbmc_assume (sub pe))
+  | PEif (pe1, pe2, pe3) ->
+      Pexpr (annots, bty, PEif (sub pe1, sub pe2, sub pe3))
+  | PEconstrained ivs ->
+      Pexpr (annots, bty, PEconstrained (List.map (fun (iv, pe) -> (iv, sub pe)) ivs))
+  | PEstruct (tag, fields) ->
+      Pexpr (annots, bty, PEstruct (tag, List.map (fun (id, pe) -> (id, sub pe)) fields))
+  | PEare_compatible (pe1, pe2) ->
+      Pexpr (annots, bty, PEare_compatible (sub pe1, sub pe2))
+
+(* ------------------------------------------------------------------ *)
+(* sequentialisable: unified promotability analysis                    *)
+(*                                                                     *)
+(* Returns:                                                            *)
+(*   None           — all control-flow paths end in Erun (vacuous)    *)
+(*   Some (ev, env') — events observed on sym and env after expr      *)
+(* Raises Not_sequentialisable on any conflict.                        *)
+(* Raises Load_from_uninit when a Load0/SeqRMW sees env=Uninit;       *)
+(*   caught by esave_needs_init to detect loops that need init.        *)
+(* ------------------------------------------------------------------ *)
+
+(* combine_branches pe_cond r1 r2: merge results from two branches.
+   pe_cond is used to construct PEif for the merged Init/DelayedInit pexpr. *)
+let combine_branches pe_cond r1 r2 =
+  match r1, r2 with
+  | None, None -> None
+  | None, (Some _ as result) | (Some _ as result), None -> result
+  | Some (ev1, env1), Some (ev2, env2) ->
+    let combined_env = match env1, env2 with
+      | Uninit, Uninit -> Uninit
+      | Killed, Killed -> Killed
+      | Init pe1, Init pe2 ->
+          Init (Pexpr ([], (), PEif (pe_cond, pe1, pe2)))
+      | DelayedInit pe1, DelayedInit pe2 ->
+          DelayedInit (Pexpr ([], (), PEif (pe_cond, pe1, pe2)))
+      | Init pe1, DelayedInit pe2 ->
+          DelayedInit (Pexpr ([], (), PEif (pe_cond, pe1, pe2)))
+      | DelayedInit pe1, Init pe2 ->
+          DelayedInit (Pexpr ([], (), PEif (pe_cond, pe1, pe2)))
+      | _ -> raise Not_sequentialisable
+    in
+    Some (ev1 @ ev2, combined_env)
+
+(* combine_case_branches pe arm_results:
+   Merges sequentialisable results from Ecase arms, building a PEcase node for the
+   combined Init/DelayedInit env.  pe is the case discriminant pexpr.
+   arm_results : (pattern * (Mem_event.t list * env) option) list
+   Note: arms whose result is None (all paths end in Erun) are filtered out, so the
+   resulting PEcase may have fewer arms than the original — i.e., the pattern may
+   be incomplete.  This is intentional: the pexpr is only used for value tracking
+   in the analysis/transform, not for execution. *)
+let combine_case_branches pe arm_results =
+  let live =
+    List.filter_map
+      (fun (pat, r) -> match r with None -> None | Some x -> Some (pat, x))
+      arm_results
+  in
+  match live with
+  | [] -> None
+  | _ ->
+      let all_evs = List.concat_map (fun (_, (ev, _)) -> ev) live in
+      let pat_envs = List.map (fun (pat, (_, e)) -> (pat, e)) live in
+      let all_uninit =
+        List.for_all (fun (_, e) -> match e with Uninit -> true | _ -> false) pat_envs
+      in
+      let all_killed =
+        List.for_all (fun (_, e) -> match e with Killed -> true | _ -> false) pat_envs
+      in
+      let combined_env =
+        if all_uninit then Uninit
+        else if all_killed then Killed
+        else
+          let pe_arms =
+            List.map (fun (pat, e) ->
+              match e with
+              | Init pe2 | DelayedInit pe2 -> (pat, pe2)
+              | _ -> raise Not_sequentialisable) pat_envs
+          in
+          let any_delayed =
+            List.exists
+              (fun (_, e) -> match e with DelayedInit _ -> true | _ -> false)
+              pat_envs
+          in
+          let case_pe = Pexpr ([], (), PEcase (pe, pe_arms)) in
+          if any_delayed then DelayedInit case_pe else Init case_pe
+      in
+      Some (all_evs, combined_env)
+
+(* seq_memo: memoises sequentialisable results per (label_sym, param_sym).
+   'a = bool * (Mem_event.t list * env) option
+     fst = init_needed: body requires Init _ env on entry (true) or
+           self-initialises (false)
+     snd = None while in progress or all paths end in Erun;
+           Some (ev, env') otherwise *)
+type seq_memo = (bool * (Mem_event.t list * env) option) memo_save_info
+
+let rec sequentialisable (seq_memo : seq_memo) sym env (Expr (_, e_))
+    : (Mem_event.t list * env) option =
   match e_ with
   | Eaction (Paction (polarity, Action (_, _, act_))) ->
       begin match act_ with
-      | Store0 (_, _, addr_pe, _, _) when is_pesym sym addr_pe ->
-          let wk = match polarity with Pos -> Write_kind.Strong | Neg -> Write_kind.Weak in
-          (true, wk)
+      | Store0 (_, _, addr_pe, val_pe, _) when is_pesym sym addr_pe ->
+          (match env with
+           | DelayedInit _ -> raise Not_sequentialisable
+           | _ ->
+               let ev, env' = match polarity with
+                 | Pos -> ([Mem_event.Pos_store], Init val_pe)
+                 | Neg -> ([Mem_event.Neg_store], DelayedInit val_pe)
+               in
+               Some (ev, env'))
       | Load0 (_, addr_pe, _) when is_pesym sym addr_pe ->
-          (strongly_init, Write_kind.of_bool strongly_init)
+          (match env with
+           | DelayedInit _ -> raise Not_sequentialisable
+           | Init _ -> Some ([Mem_event.Load], env)
+           | Uninit  -> raise Load_from_uninit
+           | _       -> raise Not_sequentialisable)
       | Kill (_, addr_pe) when is_pesym sym addr_pe ->
-          (true, Write_kind.No_write)
-      | SeqRMW (_, _, addr_pe, _, _) when is_pesym sym addr_pe ->
-          (* Atomically reads then writes: safe iff strongly_init; always
-             strongly initialises after. *)
-          (strongly_init, Write_kind.Strong)
+          (match env with
+           | DelayedInit _ -> raise Not_sequentialisable
+           | _ -> Some ([Mem_event.Kill], Killed))
+      | SeqRMW (_, _, addr_pe, tmp_sym, upd_pe) when is_pesym sym addr_pe ->
+          (match env with
+           | DelayedInit _ -> raise Not_sequentialisable
+           | Init pe ->
+               let stored = subst_pexpr tmp_sym pe upd_pe in
+               Some ([Mem_event.Load; Mem_event.Pos_store], Init stored)
+           | Uninit -> raise Load_from_uninit
+           | _      -> raise Not_sequentialisable)
       | _ ->
-          (* classify_action marks these cases as Use_other, which are filtered
-             out before this function is called. *)
-          (true, Write_kind.of_bool strongly_init)
+          Some ([], env)
       end
   | Esseq (_, e1, e2) ->
-      (* Strong sequencing: any write in e1 (even Weak/Neg) is committed
-         before e2 begins. *)
-      let (s1, ia1) = check_definitely_init init_memo sym strongly_init e1 in
-      let (s2, ia2) = check_definitely_init init_memo sym (Write_kind.is_write ia1) e2 in
-      (s1 && s2, ia2)
+      let* (ev1, env1) = sequentialisable seq_memo sym env e1 in
+      let env1' = match env1 with DelayedInit pe -> Init pe | _ -> env1 in
+      let* (ev2, env2) = sequentialisable seq_memo sym env1' e2 in
+      Some (ev1 @ ev2, env2)
   | Ewseq (_, e1, e2) ->
-      (* Weak sequencing: only Strong writes in e1 are committed before e2.
-         Weak (Neg) writes in e1 are unsequenced w.r.t. e2, so e2 sees
-         strongly_init unless ia1 is Strong. *)
-      let (s1, ia1) = check_definitely_init init_memo sym strongly_init e1 in
-      let strongly_init1 = (Write_kind.is_strong ia1 || strongly_init) in
-      let (s2, ia2) = check_definitely_init init_memo sym strongly_init1 e2 in
-      (s1 && s2, Write_kind.(ia1 || ia2))
-  | Eunseq arms ->
-      (* No arm's result is visible to any sibling arm. init_after is the
-         meet of all arms: all paths must initialize, weakest strength wins. *)
-      let results = List.map (check_definitely_init init_memo sym strongly_init) arms in
-      let safe     = List.for_all (fun (s, _) -> s) results in
-      let ia       =
-        List.fold_left
-          (fun acc (_, k) -> Write_kind.(acc && k))
-          Write_kind.Strong
-          results in
-      (safe, ia)
-  | Eif (_, et, ef) ->
-      let (st, iat) = check_definitely_init init_memo sym strongly_init et in
-      let (sf, iaf) = check_definitely_init init_memo sym strongly_init ef in
-      (st && sf, Write_kind.(iat && iaf))
-  | Ecase (_, arms) ->
-      let results =
-        List.map (fun (_, e) -> check_definitely_init init_memo sym strongly_init e) arms
+      (* If e1 returns DelayedInit, any action on sym in e2 will raise
+         Not_sequentialisable automatically via the DelayedInit guard. *)
+      let* (ev1, env1) = sequentialisable seq_memo sym env e1 in
+      let* (ev2, env2) = sequentialisable seq_memo sym env1 e2 in
+      Some (ev1 @ ev2, env2)
+  | Eif (pe, et, ef) ->
+      let rt = sequentialisable seq_memo sym env et in
+      let rf = sequentialisable seq_memo sym env ef in
+      combine_branches pe rt rf
+  | Ecase (pe, arms) ->
+      let arm_results =
+        List.map (fun (pat, e) -> (pat, sequentialisable seq_memo sym env e)) arms
       in
-      let safe       = List.for_all (fun (s, _) -> s) results in
-      let init_after =
-        List.fold_left
-          (fun acc (_, k) -> Write_kind.(acc && k))
-          Write_kind.Strong
-          results in
-      (safe, init_after)
-  | Esave ((label_sym, _), params, _body) ->
-      let entry = Pmap.find label_sym init_memo in
-      (match find_single_direct_alias sym
-               (List.map (fun (p, (_, pe)) -> (p, pe)) params) with
-      | None           -> (true, Write_kind.of_bool strongly_init)
-      | Some param_sym ->
-          let (safe_uninit, inits_param) =
-            match Pmap.lookup param_sym !(entry.results) with
-            | Some cached -> cached
-            | None ->
-                (* Sentinel (true, Strong): safe over-approximation for back-edge Eruns.
-                   Any load-before-store in the body is encountered sequentially
-                   *before* the back-edge Erun in the analysis.  That load sets
-                   safe=false, which propagates through && rules regardless of the
-                   sentinel.  The sentinel therefore cannot mask a real unsafety.
-                   Using (false, No_write) would over-conservatively reject safe
-                   loops; (true, Strong) is the minimal sound choice. *)
-                entry.results := Pmap.add param_sym (true, Write_kind.Strong) !(entry.results);
-                let r = check_definitely_init init_memo param_sym false entry.body in
-                entry.results := Pmap.add param_sym r !(entry.results);
-                r
+      combine_case_branches pe arm_results
+  | Eunseq arms ->
+      let with_events = List.filter_map
+        (fun arm ->
+          match sequentialisable seq_memo sym env arm with
+          | None | Some ([], _) -> None
+          | Some (ev, env')     -> Some (ev, env'))
+        arms
+      in
+      begin match with_events with
+      | [] -> Some ([], env)
+      | results ->
+          let all_reads =
+            List.for_all (fun (ev, _) ->
+              List.for_all (function Mem_event.Load -> true | _ -> false) ev) results
           in
-          (* strongly_init: the local var can be loaded during transform at this
-               default-arg use point (sym has been stored on all incoming paths).
-             safe_uninit: the parameter does not need to be initialized going in
-               (the body always stores before loading on every control-flow path).
-             The || says the transform can still proceed in either case:
-               - strongly_init: we can emit a Load here to pass the current value in
-               - safe_uninit  : we can drop this arg; the body self-initializes
-             inits_param: the body unconditionally writes param_sym before completion.
-             init_after: sym is init after Esave with the strength of inits_param,
-               or at least as strongly as it entered (of_bool strongly_init). *)
-          let safe       = strongly_init || safe_uninit in
-          let init_after = Write_kind.(of_bool strongly_init || inits_param) in
-          (safe, init_after))
-  | Erun (_, label_sym, args) ->
-      (* Erun unconditionally jumps to Esave L's body.
-         init_after = Strong: the sequential continuation is unreachable,
-         so Strong is vacuously correct.
-         Closedness guarantees all Erun args matching sym are direct PEsym aliases
-         (no structural occurrences), so no structural check is needed here. *)
-      let entry = Pmap.find label_sym init_memo in
-      let safe =
-        match find_single_direct_alias sym
-                (List.combine (List.map fst entry.params) args) with
-        | None           -> true   (* sym not in args; vacuously safe *)
-        | Some param_sym ->
-            let (safe_uninit, _) =
-              match Pmap.lookup param_sym !(entry.results) with
-              | Some cached -> cached
-              | None ->
-                  (* Sentinel (true, Strong): same reasoning as Esave case above. *)
-                  entry.results := Pmap.add param_sym (true, Write_kind.Strong) !(entry.results);
-                  let r = check_definitely_init init_memo param_sym false entry.body in
-                  entry.results := Pmap.add param_sym r !(entry.results);
-                  r
-            in
-            (* strongly_init: the local var can be loaded during transform at this
-                 Erun arg use point (sym has been stored on all incoming paths).
-               safe_uninit: the parameter does not need to be initialized going in.
-               The || says the transform can still proceed in either case:
-                 - strongly_init: we can emit a Load here to pass the current value
-                 - safe_uninit  : we can drop this arg; the body self-initializes *)
-            strongly_init || safe_uninit
-      in
-      (safe, Write_kind.Strong)
-  | Elet (_, _, e) | Ebound e | Eannot (_, e) ->
-      check_definitely_init init_memo sym strongly_init e
-  | _ ->
-      (true, Write_kind.of_bool strongly_init)
-
-(* ------------------------------------------------------------------ *)
-(* expr_writes_sym: does expr contain a Store0 or SeqRMW whose        *)
-(* address is directly PEsym sym?                                      *)
-(* ------------------------------------------------------------------ *)
-
-let rec expr_writes_sym sym (Expr (_, e_)) =
-  match e_ with
-  | Eaction (Paction (_, Action (_, _, act_))) ->
-      begin match act_ with
-      | Store0 (_, _, addr_pe, _, _) -> is_pesym sym addr_pe
-      | SeqRMW (_, _, addr_pe, _, _) -> is_pesym sym addr_pe
-      | _ ->
-          (* classify_action marks these cases as Use_other, which are filtered
-             out before this function is called. *)
-          false
+          if all_reads then
+            (* All arms only load; env is unchanged. *)
+            Some (List.concat_map fst results, env)
+          else
+            (* At most one write/kill arm, with no other arm having events. *)
+            begin match results with
+            | [(ev, env')] -> Some (ev, env')
+            | _            -> raise Not_sequentialisable
+            end
       end
-  | Ewseq (_, e1, e2) | Esseq (_, e1, e2) ->
-      expr_writes_sym sym e1 || expr_writes_sym sym e2
-  | Eunseq es | End es | Epar es ->
-      List.exists (expr_writes_sym sym) es
-  | Eif (_, e1, e2) ->
-      expr_writes_sym sym e1 || expr_writes_sym sym e2
-  | Ecase (_, arms) ->
-      List.exists (fun (_, e) -> expr_writes_sym sym e) arms
-  | Elet (_, _, e) | Ebound e | Eannot (_, e) ->
-      expr_writes_sym sym e
-  | Esave (_, params, body) ->
+  | Esave ((label_sym, _), params, _body) ->
       (match find_single_direct_alias sym
                (List.map (fun (p, (_, pe)) -> (p, pe)) params) with
-      | None           -> false
-      | Some param_sym -> expr_writes_sym param_sym body)
-  | _ -> false
-
-(* ------------------------------------------------------------------ *)
-(* no_mixed_unseq_uses                                                 *)
-(*                                                                     *)
-(* Returns false if sym appears in a write arm AND ≥2 arms of any     *)
-(* Eunseq mention sym — which would mean promoting sym silently        *)
-(* removes a Store0/SeqRMW that Cerberus's sequencing-violation        *)
-(* detector would otherwise see.                                       *)
-(* ------------------------------------------------------------------ *)
-
-let rec no_mixed_unseq_uses sym (Expr (_, e_)) =
-  match e_ with
-  | Eunseq arms ->
-      let writing_arms   = List.filter (expr_writes_sym sym) arms in
-      let mentioning_arms = List.filter (sym_occurs_in_expr sym) arms in
-      let conflict = (match writing_arms with [] -> false | _ -> true)
-                     && List.length mentioning_arms >= 2 in
-      (not conflict) && List.for_all (no_mixed_unseq_uses sym) arms
-  | Ewseq (_, e1, e2) | Esseq (_, e1, e2) ->
-      no_mixed_unseq_uses sym e1 && no_mixed_unseq_uses sym e2
-  | Eif (_, e1, e2) ->
-      no_mixed_unseq_uses sym e1 && no_mixed_unseq_uses sym e2
-  | Ecase (_, arms) ->
-      List.for_all (fun (_, e) -> no_mixed_unseq_uses sym e) arms
-  | Elet (_, _, e) | Ebound e | Eannot (_, e) ->
-      no_mixed_unseq_uses sym e
-  | Esave (_, params, body) ->
+       | None           -> Some ([], env)
+       | Some param_sym -> esave_needs_init seq_memo sym env label_sym param_sym)
+  | Erun (_, label_sym, args) ->
+      let entry = Pmap.find label_sym seq_memo in
       (match find_single_direct_alias sym
-               (List.map (fun (p, (_, pe)) -> (p, pe)) params) with
-      | None           -> true
-      | Some param_sym -> no_mixed_unseq_uses param_sym body)
+               (List.combine (List.map fst entry.params) args) with
+       | None           -> ()
+       | Some param_sym ->
+           ignore (esave_needs_init seq_memo sym env label_sym param_sym));
+      None
+  | Elet (_, _, e) | Eannot (_, e) ->
+      sequentialisable seq_memo sym env e
+  | Ebound e ->
+      (* Recurse for exception detection; discard events and env. *)
+      ignore (sequentialisable seq_memo sym env e);
+      Some ([], env)
   | End es | Epar es ->
-      List.for_all (no_mixed_unseq_uses sym) es
-  | _ -> true
+      (* Recurse for exception detection; discard results. *)
+      List.iter (fun e -> ignore (sequentialisable seq_memo sym env e)) es;
+      Some ([], env)
+  | Epure _ | Ememop _ | Eccall _ | Eproc _ | Ewait _ | Eexcluded _ ->
+      Some ([], env)
+
+(* esave_needs_init seq_memo sym env label_sym param_sym:
+   Analyses the Esave body for (label_sym, param_sym) w.r.t. sym and
+   memoises the result.  Returns the body's sequentialisable result
+   (None if all paths end in Erun).
+
+   - Sentinel (false, None) is written before recursing so that back-edge
+     Erun calls find the entry and do not loop.
+   - If Load_from_uninit is raised (body reads sym before any store):
+       * If outer env = Init _: mark init_needed=true, re-run with outer env.
+       * Otherwise: re-raise Load_from_uninit.
+   - If already memoised with init_needed=true and env ≠ Init _: re-raise
+     Load_from_uninit. *)
+and esave_needs_init seq_memo sym env label_sym param_sym
+    : (Mem_event.t list * env) option =
+  let entry = Pmap.find label_sym seq_memo in
+  match Pmap.lookup param_sym !(entry.results) with
+  | Some (true, result) ->
+      (match env with
+       | Init _ -> result
+       | _      -> raise Load_from_uninit)
+  | Some (false, result) ->
+      result
+  | None ->
+      entry.results := Pmap.add param_sym (false, None) !(entry.results);
+      (try
+        let result = sequentialisable seq_memo param_sym Uninit entry.body in
+        entry.results := Pmap.add param_sym (false, result) !(entry.results);
+        result
+      with Load_from_uninit ->
+        match env with
+        | Init _ ->
+            let result = sequentialisable seq_memo param_sym env entry.body in
+            entry.results := Pmap.add param_sym (true, result) !(entry.results);
+            result
+        | _ -> raise Load_from_uninit)
 
 (* ------------------------------------------------------------------ *)
 (* Promotability analysis for a single procedure                       *)
@@ -585,14 +612,16 @@ let rec no_mixed_unseq_uses sym (Expr (_, e_)) =
 
 let find_promotable ~also_fun_args f_sym body : Symbol.sym list =
   let use_memo  : use list memo_save_info = collect_esave_defs body in
-  let init_memo : (bool * Write_kind.t) memo_save_info =
+  let seq_memo  : seq_memo =
     Pmap.map (fun { params; body; _ } ->
       { params; body; results = ref (Pmap.empty Symbol.compare_sym) }) use_memo in
   let creates = collect_creates ~also_fun_args body in
   let is_promotable s =
-    List.for_all use_is_promotable (collect_uses use_memo s body)
-    && fst (check_definitely_init init_memo s false body)
-    && no_mixed_unseq_uses s body
+    List.for_all addr_not_taken (collect_uses use_memo s body)
+    && (match sequentialisable seq_memo s Uninit body with
+        | None | Some _ -> true
+        | exception Not_sequentialisable -> false
+        | exception Load_from_uninit    -> false)
   in
   let promotable = List.filter is_promotable creates in
   Cerb_debug.print_debug 3 [] (fun () ->

--- a/ocaml_frontend/rewriters/core_mem2reg.ml
+++ b/ocaml_frontend/rewriters/core_mem2reg.ml
@@ -544,10 +544,11 @@ let transform_file file =
     | Inner_arg_callconv -> true
     | Normal_callconv    -> false
   in
-  List.iter (fun (f_sym, decl) ->
+  let funs = Pmap.mapi (fun f_sym decl ->
     match decl with
-    | Proc (_, _, _, _, body) ->
-        ignore (find_promotable ~also_fun_args f_sym body)
-    | Fun _ | ProcDecl _ | BuiltinDecl _ -> ()
-  ) (Pmap.bindings_list file.funs);
-  file
+    | Proc (loc, mrk, bTy, params, body, _promotable) ->
+      let promotable = find_promotable ~also_fun_args f_sym body in
+        Proc (loc, mrk, bTy, params, body, promotable)
+    | Fun _ | ProcDecl _ | BuiltinDecl _ -> decl
+  ) file.funs in
+  { file with funs }

--- a/ocaml_frontend/rewriters/core_mem2reg.ml
+++ b/ocaml_frontend/rewriters/core_mem2reg.ml
@@ -1,0 +1,5 @@
+(* mem2reg: promote function-local non-address-taken variables from
+   Create/Store0/Load0/Kill sequences to pure Core let-bindings.
+   This file currently contains only the stub (identity transform). *)
+
+let transform_file file = file

--- a/ocaml_frontend/rewriters/core_mem2reg.ml
+++ b/ocaml_frontend/rewriters/core_mem2reg.ml
@@ -4,27 +4,6 @@
 open Core
 
 (* ------------------------------------------------------------------ *)
-(* Mem_event: memory events observable on a single sym                *)
-(* ------------------------------------------------------------------ *)
-
-module Mem_event = struct
-  type t = Pos_store | Neg_store | Load | Kill
-end
-
-(* env: initialization state of sym at a given program point          *)
-(* Uninit      — no store observed yet on this path                   *)
-(* Init pe     — sym was last stored with committed value pe          *)
-(* DelayedInit — sym was stored (Neg polarity, Ewseq e1) but not yet  *)
-(*               committed; subsequent e2 must not observe this       *)
-(* Killed      — sym's allocation was freed                           *)
-type env = Uninit | Init of pexpr | DelayedInit of pexpr | Killed
-
-exception Not_sequentialisable
-exception Load_from_uninit
-
-let ( let* ) = Option.bind
-
-(* ------------------------------------------------------------------ *)
 (* Internal classification of how a pointer sym is used               *)
 (* ------------------------------------------------------------------ *)
 
@@ -152,9 +131,9 @@ let classify_action sym act_ : use list =
       if sym_occurs_in_action sym act_ then [Use_other] else []
 
 (* ------------------------------------------------------------------ *)
-(* Esave memo tables                                                   *)
-(*                                                                     *)
-(* Both collect_uses and sequentialisable need to analyse Esave        *)
+(* Esave memo tables                                                  *)
+(*                                                                    *)
+(* Both collect_uses and sequentialisable need to analyse Esave       *)
 (* bodies: once via the default args and once per Erun call site.     *)
 (* Results are memoised per (label_sym, param_sym) to avoid redundant *)
 (* traversals and to terminate on back-edge Eruns.                    *)
@@ -167,7 +146,7 @@ type 'a esave_memo_entry = {
 }
 
 (* 'a = use list                              for collect_uses          *)
-(* 'a = bool * (Mem_event.t list * env) option  for sequentialisable   *)
+(* 'a = bool * (Event_set.t * env) option  for sequentialisable   *)
 type 'a memo_save_info = (Symbol.sym, 'a esave_memo_entry) Pmap.map
 
 (* find_single_direct_alias sym pairs:
@@ -222,6 +201,9 @@ let collect_esave_defs body =
 (* Non-pointer syms (e.g., globals, or function parameters in the      *)
 (* Normal_callconv) may appear freely in Esave bodies and are not      *)
 (* mem2reg candidates; they do not affect this analysis.               *)
+(*                                                                     *)
+(* Symbol rebindings/aliases in let/wseq/sseq are eliminated by the    *)
+(* copy_prop pass (required/assumed) and so we can be naive here.      *)
 (* ------------------------------------------------------------------- *)
 
 let rec collect_uses use_memo sym (Expr (_, e_)) : use list =
@@ -278,16 +260,6 @@ let rec collect_uses use_memo sym (Expr (_, e_)) : use list =
       if List.exists (sym_occurs_in_pexpr sym) pes then [Use_other] else []
   | Eunseq es | End es | Epar es ->
       List.concat_map (collect_uses use_memo sym) es
-  | Ewseq (
-      Pattern (_, CaseBase (Some alias_sym, _)),
-      Expr (_, Epure (Pexpr (_, _, PEsym src_sym))),
-      body
-    ) when Symbol.symbolEquality src_sym sym ->
-      (* Core pattern: let weak alias = pure(sym) in body.
-         sym is being used as a pointer value to be copied into alias.
-         Classify sym's use here based on how alias is used in body. *)
-      collect_uses use_memo alias_sym body
-      @ collect_uses use_memo sym body
   | Ewseq (_, e1, e2) | Esseq (_, e1, e2) ->
       collect_uses use_memo sym e1 @ collect_uses use_memo sym e2
   | Ebound e | Eannot (_, e) -> collect_uses use_memo sym e
@@ -329,56 +301,6 @@ let rec collect_creates ~also_fun_args (Expr (_, e_)) : Symbol.sym list =
   | Erun _ | Ewait _ | Eexcluded _ -> []
 
 (* ------------------------------------------------------------------ *)
-(* subst_pexpr: substitute PEsym tmp_sym -> replacement in pe         *)
-(* Used to track the value written by SeqRMW.                         *)
-(* ------------------------------------------------------------------ *)
-
-let rec subst_pexpr (tmp_sym : Symbol.sym) (replacement : pexpr)
-    ((Pexpr (annots, bty, pe_)) as original : pexpr) : pexpr =
-  let sub pe = subst_pexpr tmp_sym replacement pe in
-  match pe_ with
-  | PEsym s when Symbol.symbolEquality s tmp_sym -> replacement
-  | PEsym _ | PEval _ | PEimpl _ | PEundef _ | PEerror _ -> original
-  | PEctor (ctor, pes) -> Pexpr (annots, bty, PEctor (ctor, List.map sub pes))
-  | PEcall (f, pes)    -> Pexpr (annots, bty, PEcall (f, List.map sub pes))
-  | PEmemop (op, pes)  -> Pexpr (annots, bty, PEmemop (op, List.map sub pes))
-  | PEcase (pe, arms)  ->
-      Pexpr (annots, bty,
-        PEcase (sub pe, List.map (fun (pat, pe2) -> (pat, sub pe2)) arms))
-  | PEarray_shift (pe1, ty, pe2) ->
-      Pexpr (annots, bty, PEarray_shift (sub pe1, ty, sub pe2))
-  | PEop (op, pe1, pe2) ->
-      Pexpr (annots, bty, PEop (op, sub pe1, sub pe2))
-  | PElet (pat, pe1, pe2) ->
-      Pexpr (annots, bty, PElet (pat, sub pe1, sub pe2))
-  | PEwrapI (ty1, ty2, pe1, pe2) ->
-      Pexpr (annots, bty, PEwrapI (ty1, ty2, sub pe1, sub pe2))
-  | PEcatch_exceptional_condition (ty1, ty2, pe1, pe2) ->
-      Pexpr (annots, bty, PEcatch_exceptional_condition (ty1, ty2, sub pe1, sub pe2))
-  | PEmember_shift (pe, tag, member) ->
-      Pexpr (annots, bty, PEmember_shift (sub pe, tag, member))
-  | PEconv_int (ty, pe)  -> Pexpr (annots, bty, PEconv_int (ty, sub pe))
-  | PEnot pe             -> Pexpr (annots, bty, PEnot (sub pe))
-  | PEis_scalar pe       -> Pexpr (annots, bty, PEis_scalar (sub pe))
-  | PEis_integer pe      -> Pexpr (annots, bty, PEis_integer (sub pe))
-  | PEis_signed pe       -> Pexpr (annots, bty, PEis_signed (sub pe))
-  | PEis_unsigned pe     -> Pexpr (annots, bty, PEis_unsigned (sub pe))
-  | PEmemberof (tag, member, pe) ->
-      Pexpr (annots, bty, PEmemberof (tag, member, sub pe))
-  | PEunion (tag, member, pe) ->
-      Pexpr (annots, bty, PEunion (tag, member, sub pe))
-  | PEcfunction pe   -> Pexpr (annots, bty, PEcfunction (sub pe))
-  | PEbmc_assume pe  -> Pexpr (annots, bty, PEbmc_assume (sub pe))
-  | PEif (pe1, pe2, pe3) ->
-      Pexpr (annots, bty, PEif (sub pe1, sub pe2, sub pe3))
-  | PEconstrained ivs ->
-      Pexpr (annots, bty, PEconstrained (List.map (fun (iv, pe) -> (iv, sub pe)) ivs))
-  | PEstruct (tag, fields) ->
-      Pexpr (annots, bty, PEstruct (tag, List.map (fun (id, pe) -> (id, sub pe)) fields))
-  | PEare_compatible (pe1, pe2) ->
-      Pexpr (annots, bty, PEare_compatible (sub pe1, sub pe2))
-
-(* ------------------------------------------------------------------ *)
 (* sequentialisable: unified promotability analysis                    *)
 (*                                                                     *)
 (* Returns:                                                            *)
@@ -386,11 +308,44 @@ let rec subst_pexpr (tmp_sym : Symbol.sym) (replacement : pexpr)
 (*   Some (ev, env') — events observed on sym and env after expr      *)
 (* Raises Not_sequentialisable on any conflict.                        *)
 (* Raises Load_from_uninit when a Load0/SeqRMW sees env=Uninit;       *)
-(*   caught by esave_needs_init to detect loops that need init.        *)
+(*   caught by save_param_needs_init to detect loops that need init.        *)
 (* ------------------------------------------------------------------ *)
 
+(* ------------------------------------------------------------------ *)
+(* Event: memory events observable on a single sym                *)
+(* ------------------------------------------------------------------ *)
+
+module Event = struct
+  type t = Pos_store | Neg_store | Load | Kill
+  let is_neg_store = function Neg_store -> true | _ -> false
+  let is_load = function Load -> true | _ -> false
+  let compare x y =
+    let num = function
+    | Pos_store -> 0
+    | Neg_store -> 1
+    | Load -> 2
+    | Kill -> 3 in
+    Int.compare (num x) (num y)
+end
+
+module Event_set = Set.Make(Event)
+
+(* env: initialization state of sym at a given program point          *)
+(* Uninit      — no store observed yet on this path                   *)
+(* Init pe     — sym was last stored with committed value pe          *)
+(* Killed      — sym's allocation was freed                           *)
+type env = Uninit | Init of pexpr | Killed
+let is_uninit = function Uninit -> true | _ -> false
+let is_killed = function Killed -> true | _ -> false
+
+exception Not_sequentialisable
+exception Load_from_uninit
+
+let ( let* ) = Option.bind
+
+
 (* combine_branches pe_cond r1 r2: merge results from two branches.
-   pe_cond is used to construct PEif for the merged Init/DelayedInit pexpr. *)
+   pe_cond is used to construct PEif for the merged Init pexpr. *)
 let combine_branches pe_cond r1 r2 =
   match r1, r2 with
   | None, None -> None
@@ -401,115 +356,97 @@ let combine_branches pe_cond r1 r2 =
       | Killed, Killed -> Killed
       | Init pe1, Init pe2 ->
           Init (Pexpr ([], (), PEif (pe_cond, pe1, pe2)))
-      | DelayedInit pe1, DelayedInit pe2 ->
-          DelayedInit (Pexpr ([], (), PEif (pe_cond, pe1, pe2)))
-      | Init pe1, DelayedInit pe2 ->
-          DelayedInit (Pexpr ([], (), PEif (pe_cond, pe1, pe2)))
-      | DelayedInit pe1, Init pe2 ->
-          DelayedInit (Pexpr ([], (), PEif (pe_cond, pe1, pe2)))
       | _ -> raise Not_sequentialisable
     in
-    Some (ev1 @ ev2, combined_env)
+    Some (Event_set.union ev1 ev2, combined_env)
 
 (* combine_case_branches pe arm_results:
-   Merges sequentialisable results from Ecase arms, building a PEcase node for the
-   combined Init/DelayedInit env.  pe is the case discriminant pexpr.
-   arm_results : (pattern * (Mem_event.t list * env) option) list
-   Note: arms whose result is None (all paths end in Erun) are filtered out, so the
-   resulting PEcase may have fewer arms than the original — i.e., the pattern may
-   be incomplete.  This is intentional: the pexpr is only used for value tracking
-   in the analysis/transform, not for execution. *)
+   Merges sequentialisable results from Ecase arms, building a PEcase node for
+   the Init env. pe is the case discriminant pexpr.
+   arm_results : (pattern * (Event_set.t * env) option) list
+
+   Note: arms whose result is None (all paths end in Erun) are handled as if
+   having no events and producing UB, for the sake of combining values into
+   one case-pexpr and retaining pattern-completeness. *)
 let combine_case_branches pe arm_results =
-  let live =
-    List.filter_map
-      (fun (pat, r) -> match r with None -> None | Some x -> Some (pat, x))
-      arm_results
-  in
-  match live with
-  | [] -> None
-  | _ ->
-      let all_evs = List.concat_map (fun (_, (ev, _)) -> ev) live in
-      let pat_envs = List.map (fun (pat, (_, e)) -> (pat, e)) live in
-      let all_uninit =
-        List.for_all (fun (_, e) -> match e with Uninit -> true | _ -> false) pat_envs
-      in
-      let all_killed =
-        List.for_all (fun (_, e) -> match e with Killed -> true | _ -> false) pat_envs
-      in
-      let combined_env =
-        if all_uninit then Uninit
-        else if all_killed then Killed
-        else
-          let pe_arms =
-            List.map (fun (pat, e) ->
-              match e with
-              | Init pe2 | DelayedInit pe2 -> (pat, pe2)
-              | _ -> raise Not_sequentialisable) pat_envs
-          in
-          let any_delayed =
-            List.exists
-              (fun (_, e) -> match e with DelayedInit _ -> true | _ -> false)
-              pat_envs
-          in
-          let case_pe = Pexpr ([], (), PEcase (pe, pe_arms)) in
-          if any_delayed then DelayedInit case_pe else Init case_pe
-      in
-      Some (all_evs, combined_env)
+  let here = Cerb_location.other __LOC__ in
+  let ub = Undefined.DUMMY "core_mem2reg: branch assumed to not return" in
+  let undef = Pexpr ([], (), PEundef (here, ub)) in
+  let branches =
+    List.map
+      (fun (pat, r) ->
+         match r with
+         | None -> (pat, (Event_set.empty, Init undef))
+         | Some x -> (pat, x))
+      arm_results in
+  let all_evs = List.map (fun (_, (ev, _)) -> ev) branches in
+  let all_evs = List.fold_left Event_set.union Event_set.empty all_evs in
+  let all_uninit = List.for_all (fun (_, (_, e)) -> is_uninit e) branches in
+  let all_killed = List.for_all (fun (_, (_, e)) -> is_killed e) branches in
+  let combined_env =
+    if all_uninit then
+      Uninit
+    else if all_killed then
+      Killed
+    else
+      let pe_arms =
+        List.map (fun (pat, (_, e)) ->
+            match e with
+            | Init pe2 -> (pat, pe2)
+            | _ -> raise Not_sequentialisable) branches in
+      Init (Pexpr ([], (), PEcase (pe, pe_arms))) in
+  Some (all_evs, combined_env)
 
 (* seq_memo: memoises sequentialisable results per (label_sym, param_sym).
-   'a = bool * (Mem_event.t list * env) option
+   'a = bool * (Event_set.t * env) option
      fst = init_needed: body requires Init _ env on entry (true) or
            self-initialises (false)
      snd = None while in progress or all paths end in Erun;
            Some (ev, env') otherwise *)
-type seq_memo = (bool * (Mem_event.t list * env) option) memo_save_info
+type seq_memo = (bool * (Event_set.t * env) option) memo_save_info
 
 let rec sequentialisable (seq_memo : seq_memo) sym env (Expr (_, e_))
-    : (Mem_event.t list * env) option =
+    : (Event_set.t * env) option =
+  let module Es = Event_set in
   match e_ with
   | Eaction (Paction (polarity, Action (_, _, act_))) ->
       begin match act_ with
       | Store0 (_, _, addr_pe, val_pe, _) when is_pesym sym addr_pe ->
-          (match env with
-           | DelayedInit _ -> raise Not_sequentialisable
-           | _ ->
-               let ev, env' = match polarity with
-                 | Pos -> ([Mem_event.Pos_store], Init val_pe)
-                 | Neg -> ([Mem_event.Neg_store], DelayedInit val_pe)
-               in
-               Some (ev, env'))
+          let ev = match polarity with
+            | Pos -> Event.Pos_store
+            | Neg -> Event.Neg_store in
+        Some (Es.singleton ev, Init val_pe)
       | Load0 (_, addr_pe, _) when is_pesym sym addr_pe ->
           (match env with
-           | DelayedInit _ -> raise Not_sequentialisable
-           | Init _ -> Some ([Mem_event.Load], env)
+           | Init _ -> Some (Es.singleton Event.Load, env)
            | Uninit  -> raise Load_from_uninit
-           | _       -> raise Not_sequentialisable)
+           | Killed  -> raise Not_sequentialisable)
       | Kill (_, addr_pe) when is_pesym sym addr_pe ->
-          (match env with
-           | DelayedInit _ -> raise Not_sequentialisable
-           | _ -> Some ([Mem_event.Kill], Killed))
+          Some (Es.singleton Event.Kill, Killed)
       | SeqRMW (_, _, addr_pe, tmp_sym, upd_pe) when is_pesym sym addr_pe ->
           (match env with
-           | DelayedInit _ -> raise Not_sequentialisable
            | Init pe ->
-               let stored = subst_pexpr tmp_sym pe upd_pe in
-               Some ([Mem_event.Load; Mem_event.Pos_store], Init stored)
+               let stored = Core_aux.unsafe_subst_sym_pexpr tmp_sym pe upd_pe in
+               Some (Es.of_list [Event.Load; Event.Pos_store], Init stored)
            | Uninit -> raise Load_from_uninit
-           | _      -> raise Not_sequentialisable)
+           | Killed -> raise Not_sequentialisable)
       | _ ->
-          Some ([], env)
+        (* classify_action marks these cases as Use_other, which are filtered
+         * out before this function is called. *)
+        Some (Es.empty, env)
       end
   | Esseq (_, e1, e2) ->
       let* (ev1, env1) = sequentialisable seq_memo sym env e1 in
-      let env1' = match env1 with DelayedInit pe -> Init pe | _ -> env1 in
-      let* (ev2, env2) = sequentialisable seq_memo sym env1' e2 in
-      Some (ev1 @ ev2, env2)
+      let* (ev2, env2) = sequentialisable seq_memo sym env1 e2 in
+      Some (Es.union ev1 ev2, env2)
   | Ewseq (_, e1, e2) ->
-      (* If e1 returns DelayedInit, any action on sym in e2 will raise
-         Not_sequentialisable automatically via the DelayedInit guard. *)
       let* (ev1, env1) = sequentialisable seq_memo sym env e1 in
       let* (ev2, env2) = sequentialisable seq_memo sym env1 e2 in
-      Some (ev1 @ ev2, env2)
+      if Es.exists Event.is_neg_store ev1
+          && not (Es.is_empty ev2) then
+        raise Not_sequentialisable
+      else
+        Some (Es.union ev1 ev2, env2)
   | Eif (pe, et, ef) ->
       let rt = sequentialisable seq_memo sym env et in
       let rf = sequentialisable seq_memo sym env ef in
@@ -519,58 +456,47 @@ let rec sequentialisable (seq_memo : seq_memo) sym env (Expr (_, e_))
         List.map (fun (pat, e) -> (pat, sequentialisable seq_memo sym env e)) arms
       in
       combine_case_branches pe arm_results
-  | Eunseq arms ->
-      let with_events = List.filter_map
+  | End arms | Epar arms | Eunseq arms ->
+      let eventful_arms = List.filter_map
         (fun arm ->
-          match sequentialisable seq_memo sym env arm with
-          | None | Some ([], _) -> None
-          | Some (ev, env')     -> Some (ev, env'))
-        arms
-      in
-      begin match with_events with
-      | [] -> Some ([], env)
-      | results ->
-          let all_reads =
-            List.for_all (fun (ev, _) ->
-              List.for_all (function Mem_event.Load -> true | _ -> false) ev) results
-          in
-          if all_reads then
-            (* All arms only load; env is unchanged. *)
-            Some (List.concat_map fst results, env)
-          else
-            (* At most one write/kill arm, with no other arm having events. *)
-            begin match results with
-            | [(ev, env')] -> Some (ev, env')
-            | _            -> raise Not_sequentialisable
-            end
-      end
+          let* (ev, env') = sequentialisable seq_memo sym env arm in
+          if Es.is_empty ev then None else Some (ev, env'))
+        arms in
+      let all_reads =
+        List.for_all (fun (ev, _) ->
+            Es.for_all Event.is_load ev) eventful_arms in
+      if all_reads then
+        (* All arms only load; env is unchanged. *)
+        Some (Es.singleton Event.Load, env)
+      else
+        (* At most one write/kill arm, with no other arm having events. *)
+        begin match eventful_arms with
+          | [(ev, env')] -> Some (ev, env')
+          | []           -> assert false (* handled by all_reads = true *)
+          | _ :: _ :: _  -> raise Not_sequentialisable
+        end
   | Esave ((label_sym, _), params, _body) ->
       (match find_single_direct_alias sym
                (List.map (fun (p, (_, pe)) -> (p, pe)) params) with
-       | None           -> Some ([], env)
-       | Some param_sym -> esave_needs_init seq_memo sym env label_sym param_sym)
+       | None           -> Some (Es.empty, env)
+       | Some param_sym -> save_param_needs_init seq_memo sym env label_sym param_sym)
   | Erun (_, label_sym, args) ->
       let entry = Pmap.find label_sym seq_memo in
       (match find_single_direct_alias sym
                (List.combine (List.map fst entry.params) args) with
        | None           -> ()
        | Some param_sym ->
-           ignore (esave_needs_init seq_memo sym env label_sym param_sym));
+           ignore (save_param_needs_init seq_memo sym env label_sym param_sym));
       None
   | Elet (_, _, e) | Eannot (_, e) ->
       sequentialisable seq_memo sym env e
   | Ebound e ->
-      (* Recurse for exception detection; discard events and env. *)
-      ignore (sequentialisable seq_memo sym env e);
-      Some ([], env)
-  | End es | Epar es ->
-      (* Recurse for exception detection; discard results. *)
-      List.iter (fun e -> ignore (sequentialisable seq_memo sym env e)) es;
-      Some ([], env)
+    let* (_, env) = sequentialisable seq_memo sym env e in
+    Some (Es.empty, env)
   | Epure _ | Ememop _ | Eccall _ | Eproc _ | Ewait _ | Eexcluded _ ->
-      Some ([], env)
+      Some (Es.empty, env)
 
-(* esave_needs_init seq_memo sym env label_sym param_sym:
+(* save_param_needs_init seq_memo sym env label_sym param_sym:
    Analyses the Esave body for (label_sym, param_sym) w.r.t. sym and
    memoises the result.  Returns the body's sequentialisable result
    (None if all paths end in Erun).
@@ -582,8 +508,8 @@ let rec sequentialisable (seq_memo : seq_memo) sym env (Expr (_, e_))
        * Otherwise: re-raise Load_from_uninit.
    - If already memoised with init_needed=true and env ≠ Init _: re-raise
      Load_from_uninit. *)
-and esave_needs_init seq_memo sym env label_sym param_sym
-    : (Mem_event.t list * env) option =
+and save_param_needs_init seq_memo sym env label_sym param_sym
+    : (Event_set.t * env) option =
   let entry = Pmap.find label_sym seq_memo in
   match Pmap.lookup param_sym !(entry.results) with
   | Some (true, result) ->

--- a/ocaml_frontend/rewriters/core_mem2reg.ml
+++ b/ocaml_frontend/rewriters/core_mem2reg.ml
@@ -1,5 +1,267 @@
-(* mem2reg: promote function-local non-address-taken variables from
-   Create/Store0/Load0/Kill sequences to pure Core let-bindings.
-   This file currently contains only the stub (identity transform). *)
+open Core
 
-let transform_file file = file
+(* ------------------------------------------------------------------ *)
+(* Internal classification of how a pointer sym is used               *)
+(* ------------------------------------------------------------------ *)
+
+type use =
+  | Use_load   (* Load0(_, PEsym ptr, _)  — address argument *)
+  | Use_store  (* Store0(_, _, PEsym ptr, _, _) — address argument *)
+  | Use_kill   (* Kill(_, PEsym ptr) *)
+  | Use_other  (* any other occurrence *)
+
+let use_is_promotable = function
+  | Use_load | Use_store | Use_kill -> true
+  | Use_other -> false
+
+(* ------------------------------------------------------------------ *)
+(* Occurrence helpers                                                   *)
+(* ------------------------------------------------------------------ *)
+
+let is_pesym sym (Pexpr (_, _, pe_)) =
+  match pe_ with
+  | PEsym s -> Symbol.symbolEquality s sym
+  | _ -> false
+
+let rec sym_occurs_in_pexpr sym (Pexpr (_, _, pe_)) =
+  match pe_ with
+  | PEsym s -> Symbol.symbolEquality s sym
+  | PEval _ | PEimpl _ | PEundef _ | PEerror _ -> false
+  | PEctor (_, pes) | PEcall (_, pes) | PEmemop (_, pes) ->
+      List.exists (sym_occurs_in_pexpr sym) pes
+  | PEcase (pe, arms) ->
+      sym_occurs_in_pexpr sym pe
+      || List.exists (fun (_, pe2) -> sym_occurs_in_pexpr sym pe2) arms
+  | PEarray_shift (pe1, _, pe2) | PEop (_, pe1, pe2) ->
+      sym_occurs_in_pexpr sym pe1 || sym_occurs_in_pexpr sym pe2
+  | PElet (_, pe1, pe2) ->
+      sym_occurs_in_pexpr sym pe1 || sym_occurs_in_pexpr sym pe2
+  | PEwrapI (_, _, pe1, pe2) | PEcatch_exceptional_condition (_, _, pe1, pe2) ->
+      sym_occurs_in_pexpr sym pe1 || sym_occurs_in_pexpr sym pe2
+  | PEmember_shift (pe, _, _)
+  | PEconv_int (_, pe)
+  | PEnot pe
+  | PEis_scalar pe | PEis_integer pe | PEis_signed pe | PEis_unsigned pe
+  | PEmemberof (_, _, pe) | PEunion (_, _, pe) | PEcfunction pe
+  | PEbmc_assume pe ->
+      sym_occurs_in_pexpr sym pe
+  | PEif (pe1, pe2, pe3) ->
+      sym_occurs_in_pexpr sym pe1
+      || sym_occurs_in_pexpr sym pe2
+      || sym_occurs_in_pexpr sym pe3
+  | PEconstrained ivs ->
+      List.exists (fun (_, pe) -> sym_occurs_in_pexpr sym pe) ivs
+  | PEstruct (_, fields) ->
+      List.exists (fun (_, pe) -> sym_occurs_in_pexpr sym pe) fields
+  | PEare_compatible (pe1, pe2) ->
+      sym_occurs_in_pexpr sym pe1 || sym_occurs_in_pexpr sym pe2
+
+and sym_occurs_in_expr sym (Expr (_, e_)) =
+  match e_ with
+  | Epure pe -> sym_occurs_in_pexpr sym pe
+  | Eaction (Paction (_, Action (_, _, act_))) ->
+      sym_occurs_in_action sym act_
+  | Ememop (_, pes) -> List.exists (sym_occurs_in_pexpr sym) pes
+  | Ecase (pe, arms) ->
+      sym_occurs_in_pexpr sym pe
+      || List.exists (fun (_, e) -> sym_occurs_in_expr sym e) arms
+  | Elet (_, pe, e) ->
+      sym_occurs_in_pexpr sym pe || sym_occurs_in_expr sym e
+  | Eif (pe, e1, e2) ->
+      sym_occurs_in_pexpr sym pe
+      || sym_occurs_in_expr sym e1
+      || sym_occurs_in_expr sym e2
+  | Eccall (_, pe1, pe2, pes) ->
+      List.exists (sym_occurs_in_pexpr sym) (pe1 :: pe2 :: pes)
+  | Eproc (_, _, pes) | Erun (_, _, pes) ->
+      List.exists (sym_occurs_in_pexpr sym) pes
+  | Eunseq es | End es | Epar es ->
+      List.exists (sym_occurs_in_expr sym) es
+  | Ewseq (_, e1, e2) | Esseq (_, e1, e2) ->
+      sym_occurs_in_expr sym e1 || sym_occurs_in_expr sym e2
+  | Ebound e | Eannot (_, e) -> sym_occurs_in_expr sym e
+  | Esave (_, args, body) ->
+      List.exists (fun (_, (_, pe)) -> sym_occurs_in_pexpr sym pe) args
+      || sym_occurs_in_expr sym body
+  | Ewait _ | Eexcluded _ -> false
+
+and sym_occurs_in_action sym act_ =
+  match act_ with
+  | Create (pe1, pe2, _) ->
+      sym_occurs_in_pexpr sym pe1 || sym_occurs_in_pexpr sym pe2
+  | CreateReadOnly (pe1, pe2, pe3, _) ->
+      sym_occurs_in_pexpr sym pe1
+      || sym_occurs_in_pexpr sym pe2
+      || sym_occurs_in_pexpr sym pe3
+  | Alloc0 (pe1, pe2, _) ->
+      sym_occurs_in_pexpr sym pe1 || sym_occurs_in_pexpr sym pe2
+  | Kill (_, pe) -> sym_occurs_in_pexpr sym pe
+  | Load0 (_, pe, _) -> sym_occurs_in_pexpr sym pe
+  | Store0 (_, pe1, pe2, pe3, _) ->
+      sym_occurs_in_pexpr sym pe1
+      || sym_occurs_in_pexpr sym pe2
+      || sym_occurs_in_pexpr sym pe3
+  | Fence0 _ -> false
+  | SeqRMW (_, pe1, pe2, _, pe3) ->
+      sym_occurs_in_pexpr sym pe1
+      || sym_occurs_in_pexpr sym pe2
+      || sym_occurs_in_pexpr sym pe3
+  | RMW0 (pe1, pe2, pe3, pe4, _, _)
+  | CompareExchangeStrong (pe1, pe2, pe3, pe4, _, _)
+  | CompareExchangeWeak (pe1, pe2, pe3, pe4, _, _) ->
+      List.exists (sym_occurs_in_pexpr sym) [pe1; pe2; pe3; pe4]
+  | LinuxFence _ -> false
+  | LinuxLoad (pe1, pe2, _) ->
+      sym_occurs_in_pexpr sym pe1 || sym_occurs_in_pexpr sym pe2
+  | LinuxStore (pe1, pe2, pe3, _) | LinuxRMW (pe1, pe2, pe3, _) ->
+      List.exists (sym_occurs_in_pexpr sym) [pe1; pe2; pe3]
+
+(* ------------------------------------------------------------------ *)
+(* Classify a single action's uses of sym                              *)
+(* ------------------------------------------------------------------ *)
+
+let classify_action sym act_ : use list =
+  match act_ with
+  | Store0 (_, _ctype_pe, addr_pe, val_pe, _) ->
+      let addr_use =
+        if is_pesym sym addr_pe then [Use_store]
+        else if sym_occurs_in_pexpr sym addr_pe then [Use_other]
+        else []
+      in
+      let val_use =
+        if sym_occurs_in_pexpr sym val_pe then [Use_other] else []
+      in
+      addr_use @ val_use
+  | Load0 (_ctype_pe, addr_pe, _) ->
+      if is_pesym sym addr_pe then [Use_load]
+      else if sym_occurs_in_pexpr sym addr_pe then [Use_other]
+      else []
+  | Kill (_, addr_pe) ->
+      if is_pesym sym addr_pe then [Use_kill]
+      else if sym_occurs_in_pexpr sym addr_pe then [Use_other]
+      else []
+  | _ ->
+      if sym_occurs_in_action sym act_ then [Use_other] else []
+
+(* ------------------------------------------------------------------ *)
+(* collect_uses: gather all uses of sym in an expression              *)
+(* ------------------------------------------------------------------ *)
+
+let rec collect_uses sym (Expr (_, e_)) : use list =
+  match e_ with
+  | Eaction (Paction (_, Action (_, _, act_))) ->
+      classify_action sym act_
+  | Esave (_, args, body) ->
+      (* Conservative: any occurrence inside an Esave is Use_other,
+         since loop bodies may re-enter and store to the variable. *)
+      let in_args =
+        List.exists (fun (_, (_, pe)) -> sym_occurs_in_pexpr sym pe) args
+      in
+      let in_body = sym_occurs_in_expr sym body in
+      if in_args || in_body then [Use_other] else []
+  | Epure pe ->
+      if sym_occurs_in_pexpr sym pe then [Use_other] else []
+  | Ememop (_, pes) ->
+      if List.exists (sym_occurs_in_pexpr sym) pes then [Use_other] else []
+  | Elet (_, pe, e) ->
+      (if sym_occurs_in_pexpr sym pe then [Use_other] else [])
+      @ collect_uses sym e
+  | Ecase (pe, arms) ->
+      (if sym_occurs_in_pexpr sym pe then [Use_other] else [])
+      @ List.concat_map (fun (_, e) -> collect_uses sym e) arms
+  | Eif (pe, e1, e2) ->
+      (if sym_occurs_in_pexpr sym pe then [Use_other] else [])
+      @ collect_uses sym e1
+      @ collect_uses sym e2
+  | Eccall (_, fn_pe, arg_pe, pes) ->
+      if List.exists (sym_occurs_in_pexpr sym) (fn_pe :: arg_pe :: pes)
+      then [Use_other] else []
+  | Eproc (_, _, pes) | Erun (_, _, pes) ->
+      if List.exists (sym_occurs_in_pexpr sym) pes then [Use_other] else []
+  | Eunseq es | End es | Epar es ->
+      List.concat_map (collect_uses sym) es
+  | Ewseq (
+      Pattern (_, CaseBase (Some alias_sym, _)),
+      Expr (_, Epure (Pexpr (_, _, PEsym src_sym))),
+      body
+    ) when Symbol.symbolEquality src_sym sym ->
+      (* Core pattern: let weak alias = pure(sym) in body.
+         sym is being used as a pointer value to be copied into alias.
+         Classify sym's use here based on how alias is used in body. *)
+      collect_uses alias_sym body
+      @ collect_uses sym body
+  | Ewseq (_, e1, e2) | Esseq (_, e1, e2) ->
+      collect_uses sym e1 @ collect_uses sym e2
+  | Ebound e | Eannot (_, e) -> collect_uses sym e
+  | Ewait _ | Eexcluded _ -> []
+
+(* ------------------------------------------------------------------ *)
+(* collect_creates: find Create-bound ptr syms (PrefSource only)      *)
+(*                                                                     *)
+(* NOTE — calling-convention assumption: this pass only considers      *)
+(* Create(PrefSource _) bindings, i.e. C source-level local variables. *)
+(* It does NOT promote Proc parameter pointers, because under the      *)
+(* standard via-pointer argument-passing convention the caller owns    *)
+(* the argument slot and the callee merely receives a pointer to it.   *)
+(*                                                                     *)
+(* CN uses a value-passing convention instead: arguments are passed    *)
+(* directly as Core values, not as pointers.  Under that convention   *)
+(* a parameter whose address is never taken could also be promoted     *)
+(* here (its Create+Store preamble at function entry has exactly the   *)
+(* same Load/Store/Kill-only shape as a promotable local).  Extending  *)
+(* collect_creates to also yield PrefFunArg Create bindings would      *)
+(* enable that optimisation for CN.                                    *)
+(* ------------------------------------------------------------------ *)
+
+let rec collect_creates (Expr (_, e_)) : Symbol.sym list =
+  match e_ with
+  | Esseq (
+      Pattern (_, CaseBase (Some ptr_sym, _)),
+      Expr (_, Eaction (Paction (_, Action (_, _, Create (_, _, Symbol.PrefSource _))))),
+      body
+    ) ->
+      ptr_sym :: collect_creates body
+  | Ewseq (_, e1, e2) | Esseq (_, e1, e2) ->
+      collect_creates e1 @ collect_creates e2
+  | Elet (_, _, e) | Ebound e | Eannot (_, e) ->
+      collect_creates e
+  | Eif (_, e1, e2) ->
+      collect_creates e1 @ collect_creates e2
+  | Ecase (_, arms) ->
+      List.concat_map (fun (_, e) -> collect_creates e) arms
+  | Esave (_, _, body) ->
+      collect_creates body
+  | Eunseq es | End es | Epar es ->
+      List.concat_map collect_creates es
+  | Epure _ | Eaction _ | Ememop _ | Eccall _ | Eproc _
+  | Erun _ | Ewait _ | Eexcluded _ -> []
+
+(* ------------------------------------------------------------------ *)
+(* Promotability analysis for a single procedure                       *)
+(* ------------------------------------------------------------------ *)
+
+let find_promotable f_sym body : Symbol.sym list =
+  let creates = collect_creates body in
+  let is_promotable s =
+    List.for_all use_is_promotable (collect_uses s body)
+  in
+  let promotable = List.filter is_promotable creates in
+  Cerb_debug.print_debug 3 [] (fun () ->
+    Printf.sprintf "[mem2reg] %s: %d promotable: [%s]"
+      (Pp_symbol.to_string_pretty f_sym)
+      (List.length promotable)
+      (String.concat ", " (List.map Pp_symbol.to_string_pretty promotable)));
+  promotable
+
+(* ------------------------------------------------------------------ *)
+(* transform_file: analysis phase only — file returned unchanged       *)
+(* ------------------------------------------------------------------ *)
+
+let transform_file file =
+  List.iter (fun (f_sym, decl) ->
+    match decl with
+    | Proc (_, _, _, _, body) ->
+        ignore (find_promotable f_sym body)
+    | Fun _ | ProcDecl _ | BuiltinDecl _ -> ()
+  ) (Pmap.bindings_list file.funs);
+  file

--- a/ocaml_frontend/rewriters/core_mem2reg.ml
+++ b/ocaml_frontend/rewriters/core_mem2reg.ml
@@ -4,6 +4,38 @@
 open Core
 
 (* ------------------------------------------------------------------ *)
+(* Write_kind: lattice for "how strongly was sym initialized"          *)
+(*                                                                     *)
+(* No_write < Weak < Strong                                            *)
+(*   Strong   — Paction Pos store, committed before Esseq continuation *)
+(*   Weak     — Paction Neg store in Ewseq e1, unsequenced w.r.t. e2  *)
+(*   No_write — no store observed on this path                        *)
+(*                                                                     *)
+(* A Load0 or SeqRMW is only safe if sym was *strongly* initialized.  *)
+(* ------------------------------------------------------------------ *)
+
+module Write_kind = struct
+  type t = No_write | Weak | Strong
+
+  (* join: least upper bound — goes up the lattice *)
+  let (||) a b = match a, b with
+    | No_write, x | x, No_write -> x
+    | Strong,   _ | _, Strong   -> Strong
+    | Weak,     Weak             -> Weak
+
+  (* meet: greatest lower bound — goes down the lattice *)
+  let (&&) a b = match a, b with
+    | Strong,   x | x, Strong   -> x
+    | No_write, _ | _, No_write -> No_write
+    | Weak,     Weak             -> Weak
+
+  let of_bool = function true -> Strong | false -> No_write
+
+  let is_strong   = function Strong   -> true | _ -> false
+  let is_write = function No_write -> false | _ -> true
+end
+
+(* ------------------------------------------------------------------ *)
 (* Internal classification of how a pointer sym is used               *)
 (* ------------------------------------------------------------------ *)
 
@@ -148,13 +180,9 @@ let classify_action sym act_ : use list =
       else []
   | SeqRMW (_, _ty_pe, addr_pe, _tmp_sym, upd_pe) ->
       let addr_use =
-        if is_pesym sym addr_pe then
-          [Use_seqrmw]
-        else if sym_occurs_in_pexpr sym addr_pe then
-          (* I think the elaboration ensures this case is impossible *)
-          [Use_other]
-        else
-          []
+        if is_pesym sym addr_pe then [Use_seqrmw]
+        else if sym_occurs_in_pexpr sym addr_pe then [Use_other]
+        else []
       in
       let upd_use =
         if sym_occurs_in_pexpr sym upd_pe then [Use_other] else []
@@ -178,10 +206,10 @@ type 'a esave_memo_entry = {
   results : (Symbol.sym, 'a) Pmap.map ref;        (* param_sym -> cached result, filled lazily *)
 }
 
-(* 'a = use list        for collect_uses                                    *)
-(* 'a = bool * bool     for check_definitely_init  (safe_uninit, inits_param) *)
-(*   safe_uninit:   fst (check_definitely_init ... param_sym false body)    *)
-(*   inits_param:   snd (check_definitely_init ... param_sym false body)    *)
+(* 'a = use list              for collect_uses                              *)
+(* 'a = bool * Write_kind.t  for check_definitely_init                     *)
+(*   fst = safe_uninit:  fst (check_definitely_init ... param_sym false body)  *)
+(*   snd = inits_param:  snd (check_definitely_init ... param_sym false body)  *)
 type 'a memo_save_info = (Symbol.sym, 'a esave_memo_entry) Pmap.map
 
 (* find_single_direct_alias sym pairs:
@@ -195,19 +223,10 @@ let find_single_direct_alias sym pairs =
   with
   | []          -> None
   | [param_sym] -> Some param_sym
-  | _           -> failwith "Core_mem2reg: multiple direct aliases for the same sym"
+  | _ :: _ :: _ -> failwith "Core_mem2reg: multiple direct aliases for the same sym"
 
 (* collect_esave_defs: pre-walk the function body collecting all Esave
-   definitions into a memo table.
-
-   Key invariant (guaranteed by elaboration): for any CREATE-bound local
-   pointer sym `s`, if `s` appears in an Esave body, then `s` is passed as
-   a direct PEsym default arg to that Esave.  This means the NoAlias case
-   (`find_single_direct_alias` returns None) is sound: if `s` is not in any
-   param, it cannot appear in the body as an address of a Load/Store/Kill.
-
-   Non-pointer syms (e.g., function parameters) may appear freely in Esave
-   bodies and are not mem2reg candidates; they do not affect this analysis. *)
+   definitions into a memo table. *)
 let collect_esave_defs body =
   (* Pre-walk: collect all Esave definitions *)
   let memo = ref (Pmap.empty Symbol.compare_sym) in
@@ -232,9 +251,20 @@ let collect_esave_defs body =
   walk body;
   !memo
 
-(* ------------------------------------------------------------------ *)
-(* collect_uses: gather all uses of sym in an expression              *)
-(* ------------------------------------------------------------------ *)
+(* ------------------------------------------------------------------- *)
+(* collect_uses: gather all uses of sym in an expression               *)
+(*                                                                     *)
+(* Key invariant (guaranteed by elaboration): for any CREATE-bound     *)
+(* local pointer sym `s`, if `s` appears in an Esave body, then `s`    *)
+(* is passed as a direct PEsym default arg to that Esave.  This means  *)
+(* the case when `find_single_direct_alias` returns None is sound: if  *)
+(* `s` is not in any param, it cannot appear in the body as an address *)
+(* of a Load/Store/Kill. 					       *)
+(*                                                                     *)
+(* Non-pointer syms (e.g., globals, or function parameters in the      *)
+(* Normal_callconv) may appear freely in Esave bodies and are not      *)
+(* mem2reg candidates; they do not affect this analysis.               *)
+(* ------------------------------------------------------------------- *)
 
 let rec collect_uses use_memo sym (Expr (_, e_)) : use list =
   match e_ with
@@ -246,12 +276,12 @@ let rec collect_uses use_memo sym (Expr (_, e_)) : use list =
       let entry = Pmap.find label_sym use_memo in
       (match find_single_direct_alias sym
                (List.map (fun (p, (_, pe)) -> (p, pe)) params) with
-      | None           -> []  (* NoAlias: by closedness, not in body *)
+      | None           -> []
       | Some param_sym ->
           (match Pmap.lookup param_sym !(entry.results) with
           | Some cached -> cached
           | None ->
-              entry.results := Pmap.add param_sym [] !(entry.results);  (* sentinel *)
+              entry.results := Pmap.add param_sym [] !(entry.results);
               let result = collect_uses use_memo param_sym entry.body in
               entry.results := Pmap.add param_sym result !(entry.results);
               result))
@@ -345,94 +375,111 @@ let rec collect_creates ~also_fun_args (Expr (_, e_)) : Symbol.sym list =
 (*                                                                     *)
 (* Returns (safe, init_after):                                         *)
 (*   safe       – no load-before-store on any syntactic path           *)
-(*   init_after – on ALL paths through expr, at least one store        *)
-(*                has occurred (so a subsequent load would be safe)    *)
+(*   init_after – Write_kind describing how sym is initialized after   *)
+(*                this expression on ALL paths                         *)
+(*                                                                     *)
+(* strongly_init: sym is strongly initialized on entry (bool)         *)
 (* ------------------------------------------------------------------ *)
 
-let rec check_definitely_init init_memo sym already_init (Expr (_, e_)) =
+let rec check_definitely_init init_memo sym strongly_init (Expr (_, e_)) =
   match e_ with
-  | Eaction (Paction (_, Action (_, _, act_))) ->
+  | Eaction (Paction (polarity, Action (_, _, act_))) ->
       begin match act_ with
       | Store0 (_, _, addr_pe, _, _) when is_pesym sym addr_pe ->
-          (true, true)
+          let wk = match polarity with Pos -> Write_kind.Strong | Neg -> Write_kind.Weak in
+          (true, wk)
       | Load0 (_, addr_pe, _) when is_pesym sym addr_pe ->
-          (already_init, already_init)
+          (strongly_init, Write_kind.of_bool strongly_init)
       | Kill (_, addr_pe) when is_pesym sym addr_pe ->
-          (true, false)
+          (true, Write_kind.No_write)
       | SeqRMW (_, _, addr_pe, _, _) when is_pesym sym addr_pe ->
-          (* Atomically reads then writes: safe iff already_init; always
-             initialises after. *)
-          (already_init, true)
+          (* Atomically reads then writes: safe iff strongly_init; always
+             strongly initialises after. *)
+          (strongly_init, Write_kind.Strong)
       | _ ->
-          (* TODO: revist this. Negative actions (stores) are not handled at
-             all, and this would affect weak-sequencing. Constructs I don't
-             care about should be handled conservatively (like a load?). *)
-          (true, already_init)
+          (* classify_action marks these cases as Use_other, which are filtered
+             out before this function is called. *)
+          (true, Write_kind.of_bool strongly_init)
       end
   | Esseq (_, e1, e2) ->
-      let (s1, ia1) = check_definitely_init init_memo sym already_init e1 in
-      let (s2, ia2) = check_definitely_init init_memo sym ia1 e2 in
+      (* Strong sequencing: any write in e1 (even Weak/Neg) is committed
+         before e2 begins. *)
+      let (s1, ia1) = check_definitely_init init_memo sym strongly_init e1 in
+      let (s2, ia2) = check_definitely_init init_memo sym (Write_kind.is_write ia1) e2 in
       (s1 && s2, ia2)
   | Ewseq (_, e1, e2) ->
-      (* Neg actions in e1 are NOT sequenced before e2, so e2 cannot
-         rely on stores in e1.  Pass already_init (not ia1) to e2. *)
-      let (s1, ia1) = check_definitely_init init_memo sym already_init e1 in
-      let (s2, ia2) = check_definitely_init init_memo sym already_init e2 in
-      (s1 && s2, ia1 || ia2)
+      (* Weak sequencing: only Strong writes in e1 are committed before e2.
+         Weak (Neg) writes in e1 are unsequenced w.r.t. e2, so e2 sees
+         strongly_init unless ia1 is Strong. *)
+      let (s1, ia1) = check_definitely_init init_memo sym strongly_init e1 in
+      let strongly_init1 = (Write_kind.is_strong ia1 || strongly_init) in
+      let (s2, ia2) = check_definitely_init init_memo sym strongly_init1 e2 in
+      (s1 && s2, Write_kind.(ia1 || ia2))
   | Eunseq arms ->
-      (* No arm's result is visible to any sibling arm. *)
-      let results = List.map (check_definitely_init init_memo sym already_init) arms in
-      let safe      = List.for_all (fun (s, _) -> s) results in
-      let init_after = List.for_all (fun (_, ia) -> ia) results in
-      (safe, init_after)
+      (* No arm's result is visible to any sibling arm. init_after is the
+         meet of all arms: all paths must initialize, weakest strength wins. *)
+      let results = List.map (check_definitely_init init_memo sym strongly_init) arms in
+      let safe     = List.for_all (fun (s, _) -> s) results in
+      let ia       =
+        List.fold_left
+          (fun acc (_, k) -> Write_kind.(acc && k))
+          Write_kind.Strong
+          results in
+      (safe, ia)
   | Eif (_, et, ef) ->
-      let (st, iat) = check_definitely_init init_memo sym already_init et in
-      let (sf, iaf) = check_definitely_init init_memo sym already_init ef in
-      (st && sf, iat && iaf)
+      let (st, iat) = check_definitely_init init_memo sym strongly_init et in
+      let (sf, iaf) = check_definitely_init init_memo sym strongly_init ef in
+      (st && sf, Write_kind.(iat && iaf))
   | Ecase (_, arms) ->
       let results =
-        List.map (fun (_, e) -> check_definitely_init init_memo sym already_init e) arms
+        List.map (fun (_, e) -> check_definitely_init init_memo sym strongly_init e) arms
       in
       let safe       = List.for_all (fun (s, _) -> s) results in
-      let init_after = List.for_all (fun (_, ia) -> ia) results in
+      let init_after =
+        List.fold_left
+          (fun acc (_, k) -> Write_kind.(acc && k))
+          Write_kind.Strong
+          results in
       (safe, init_after)
   | Esave ((label_sym, _), params, _body) ->
       let entry = Pmap.find label_sym init_memo in
       (match find_single_direct_alias sym
                (List.map (fun (p, (_, pe)) -> (p, pe)) params) with
-      | None           -> (true, already_init)  (* NoAlias: by closedness, not in body *)
+      | None           -> (true, Write_kind.of_bool strongly_init)
       | Some param_sym ->
           let (safe_uninit, inits_param) =
             match Pmap.lookup param_sym !(entry.results) with
             | Some cached -> cached
             | None ->
-                (* Sentinel (true, true): safe over-approximation for back-edge Eruns.
+                (* Sentinel (true, Strong): safe over-approximation for back-edge Eruns.
                    Any load-before-store in the body is encountered sequentially
                    *before* the back-edge Erun in the analysis.  That load sets
                    safe=false, which propagates through && rules regardless of the
                    sentinel.  The sentinel therefore cannot mask a real unsafety.
-                   Using (false,false) instead would over-conservatively reject safe
-                   loops; (true,true) is the minimal sound choice. *)
-                entry.results := Pmap.add param_sym (true, true) !(entry.results);
+                   Using (false, No_write) would over-conservatively reject safe
+                   loops; (true, Strong) is the minimal sound choice. *)
+                entry.results := Pmap.add param_sym (true, Write_kind.Strong) !(entry.results);
                 let r = check_definitely_init init_memo param_sym false entry.body in
                 entry.results := Pmap.add param_sym r !(entry.results);
                 r
           in
-          (* already_init: the local var can be loaded during transform at this
+          (* strongly_init: the local var can be loaded during transform at this
                default-arg use point (sym has been stored on all incoming paths).
              safe_uninit: the parameter does not need to be initialized going in
                (the body always stores before loading on every control-flow path).
              The || says the transform can still proceed in either case:
-               - already_init → we can emit a Load here to pass the current value in
-               - safe_uninit  → we can drop this arg; the body self-initializes
-             inits_param: the body unconditionally writes param_sym before completion,
-               so sym's storage is definitely initialized after the Esave exits.
-             already_init || inits_param: sym is init after Esave if it was init
-               going in, or the body always initializes param_sym. *)
-          (already_init || safe_uninit, already_init || inits_param))
+               - strongly_init: we can emit a Load here to pass the current value in
+               - safe_uninit  : we can drop this arg; the body self-initializes
+             inits_param: the body unconditionally writes param_sym before completion.
+             init_after: sym is init after Esave with the strength of inits_param,
+               or at least as strongly as it entered (of_bool strongly_init). *)
+          let safe       = strongly_init || safe_uninit in
+          let init_after = Write_kind.(of_bool strongly_init || inits_param) in
+          (safe, init_after))
   | Erun (_, label_sym, args) ->
       (* Erun unconditionally jumps to Esave L's body.
-         init_after = true: the sequential continuation is unreachable.
+         init_after = Strong: the sequential continuation is unreachable,
+         so Strong is vacuously correct.
          Closedness guarantees all Erun args matching sym are direct PEsym aliases
          (no structural occurrences), so no structural check is needed here. *)
       let entry = Pmap.find label_sym init_memo in
@@ -445,26 +492,25 @@ let rec check_definitely_init init_memo sym already_init (Expr (_, e_)) =
               match Pmap.lookup param_sym !(entry.results) with
               | Some cached -> cached
               | None ->
-                  (* Sentinel (true, true): same reasoning as Esave case above. *)
-                  entry.results := Pmap.add param_sym (true, true) !(entry.results);
+                  (* Sentinel (true, Strong): same reasoning as Esave case above. *)
+                  entry.results := Pmap.add param_sym (true, Write_kind.Strong) !(entry.results);
                   let r = check_definitely_init init_memo param_sym false entry.body in
                   entry.results := Pmap.add param_sym r !(entry.results);
                   r
             in
-            (* already_init: the local var can be loaded during transform at this
+            (* strongly_init: the local var can be loaded during transform at this
                  Erun arg use point (sym has been stored on all incoming paths).
                safe_uninit: the parameter does not need to be initialized going in.
                The || says the transform can still proceed in either case:
-                 - already_init → we can emit a Load here to pass the current value
-                 - safe_uninit  → we can drop this arg; the body self-initializes
-               init_after = true: Erun is terminal; the continuation is unreachable. *)
-            already_init || safe_uninit
+                 - strongly_init: we can emit a Load here to pass the current value
+                 - safe_uninit  : we can drop this arg; the body self-initializes *)
+            strongly_init || safe_uninit
       in
-      (safe, true)
+      (safe, Write_kind.Strong)
   | Elet (_, _, e) | Ebound e | Eannot (_, e) ->
-      check_definitely_init init_memo sym already_init e
+      check_definitely_init init_memo sym strongly_init e
   | _ ->
-      (true, already_init)
+      (true, Write_kind.of_bool strongly_init)
 
 (* ------------------------------------------------------------------ *)
 (* expr_writes_sym: does expr contain a Store0 or SeqRMW whose        *)
@@ -477,9 +523,10 @@ let rec expr_writes_sym sym (Expr (_, e_)) =
       begin match act_ with
       | Store0 (_, _, addr_pe, _, _) -> is_pesym sym addr_pe
       | SeqRMW (_, _, addr_pe, _, _) -> is_pesym sym addr_pe
-      | _ -> (* TODO: revisit this. Negative actions are not handled at all.
-                And he constructs that I do not should be handled
-                conservatively - like a store? *) false
+      | _ ->
+          (* classify_action marks these cases as Use_other, which are filtered
+             out before this function is called. *)
+          false
       end
   | Ewseq (_, e1, e2) | Esseq (_, e1, e2) ->
       expr_writes_sym sym e1 || expr_writes_sym sym e2
@@ -538,7 +585,7 @@ let rec no_mixed_unseq_uses sym (Expr (_, e_)) =
 
 let find_promotable ~also_fun_args f_sym body : Symbol.sym list =
   let use_memo  : use list memo_save_info = collect_esave_defs body in
-  let init_memo : (bool * bool) memo_save_info =
+  let init_memo : (bool * Write_kind.t) memo_save_info =
     Pmap.map (fun { params; body; _ } ->
       { params; body; results = ref (Pmap.empty Symbol.compare_sym) }) use_memo in
   let creates = collect_creates ~also_fun_args body in

--- a/ocaml_frontend/rewriters/core_mem2reg.mli
+++ b/ocaml_frontend/rewriters/core_mem2reg.mli
@@ -1,4 +1,7 @@
-(** Promote function-local, non-address-taken C variables from
-    Create/Store0/Load0/Kill sequences to pure Core let-bindings. *)
+(** Promote function-local, non-address-taken C variables — and, under
+    [Inner_arg_callconv], callee-owned parameter temporaries — from
+    Create/Store0/Load0/Kill sequences to pure Core let-bindings.
+    Which categories are considered is determined by
+    [file.calling_convention]. *)
 
 val transform_file : unit Core.file -> unit Core.file

--- a/ocaml_frontend/rewriters/core_mem2reg.mli
+++ b/ocaml_frontend/rewriters/core_mem2reg.mli
@@ -1,0 +1,4 @@
+(** Promote function-local, non-address-taken C variables from
+    Create/Store0/Load0/Kill sequences to pure Core let-bindings. *)
+
+val transform_file : unit Core.file -> unit Core.file

--- a/ocaml_frontend/rewriters/core_peval.ml
+++ b/ocaml_frontend/rewriters/core_peval.ml
@@ -497,7 +497,7 @@ let core_peval file : 'bty RW.rewriter =
 
   let check_unfold_proc sym =
     begin match Pmap.lookup sym to_unfold_funs with
-      | Some (Proc (_, _, _, sym_bTys, e)) ->
+      | Some (Proc (_, _, _, sym_bTys, e, _)) ->
           Some (sym_bTys, e)
       | _ -> None
     end
@@ -836,7 +836,7 @@ let rewrite_file file =
       : ('bty, 'a) generic_fun_map_decl =
     match d with
     | Fun (bt, args, pe) -> Fun (bt, args, rw_pexpr pe)
-    | Proc (loc, mrk, bt, args, e) -> Proc (loc, mrk, bt, args, rw_expr e)
+    | Proc (loc, mrk, bt, args, e, promotable) -> Proc (loc, mrk, bt, args, rw_expr e, promotable)
     | ProcDecl (loc, bt, bts) -> ProcDecl (loc, bt, bts)
     | BuiltinDecl (loc, bt, bts) -> BuiltinDecl (loc, bt, bts)
   in

--- a/ocaml_frontend/rewriters/remove_unspecs.ml
+++ b/ocaml_frontend/rewriters/remove_unspecs.ml
@@ -90,8 +90,8 @@ let rewrite_file file =
   let rewrite_fun_map_decl = function
     | Fun (bTy, args, pe) ->
         Fun (bTy, args, rewrite_pexpr pe)
-    | Proc (loc, mrk, bTy, args, e) ->
-        Proc (loc, mrk, bTy, args, rewrite_expr e)
+    | Proc (loc, mrk, bTy, args, e, promotable) ->
+        Proc (loc, mrk, bTy, args, rewrite_expr e, promotable)
     | decl ->
         decl in
   

--- a/ocaml_frontend/switches.ml
+++ b/ocaml_frontend/switches.ml
@@ -40,6 +40,9 @@ type cerb_switch =
   (* set magic comment syntax to "/*$ ... $*/" *)
   | SW_magic_comment_char_dollar
 
+  (* promote function-local non-address-taken variables to Core let-bindings *)
+  | SW_mem2reg
+
 
 let internal_ref =
   ref []
@@ -94,6 +97,8 @@ let set strs =
         Some SW_at_magic_comments
     | "magic_comment_char_dollar" ->
         Some (SW_magic_comment_char_dollar)
+    | "mem2reg" ->
+        Some SW_mem2reg
     | _ ->
         None in
   let pred x = function
@@ -122,7 +127,8 @@ let set strs =
     | SW_permissive_printf
     | SW_zero_initialised
     | SW_at_magic_comments
-    | SW_magic_comment_char_dollar as y ->
+    | SW_magic_comment_char_dollar
+    | SW_mem2reg as y ->
         x = y in
   List.iter (fun str ->
     match read_switch str with

--- a/ocaml_frontend/switches.ml
+++ b/ocaml_frontend/switches.ml
@@ -43,6 +43,9 @@ type cerb_switch =
   (* promote function-local non-address-taken variables to Core let-bindings *)
   | SW_mem2reg
 
+  (* eliminate pure symbol rebindings: let alias = pure(sym) → substitute sym *)
+  | SW_copy_prop
+
 
 let internal_ref =
   ref []
@@ -99,6 +102,8 @@ let set strs =
         Some (SW_magic_comment_char_dollar)
     | "mem2reg" ->
         Some SW_mem2reg
+    | "copy_prop" ->
+        Some SW_copy_prop
     | _ ->
         None in
   let pred x = function
@@ -128,7 +133,8 @@ let set strs =
     | SW_zero_initialised
     | SW_at_magic_comments
     | SW_magic_comment_char_dollar
-    | SW_mem2reg as y ->
+    | SW_mem2reg
+    | SW_copy_prop as y ->
         x = y in
   List.iter (fun str ->
     match read_switch str with

--- a/ocaml_frontend/switches.mli
+++ b/ocaml_frontend/switches.mli
@@ -40,6 +40,9 @@ type cerb_switch =
   (* set magic comment syntax to "/*$ ... $*/" *)
   | SW_magic_comment_char_dollar
 
+  (* promote function-local non-address-taken variables to Core let-bindings *)
+  | SW_mem2reg
+
 val get_switches: unit -> cerb_switch list
 val has_switch: cerb_switch -> bool
 val has_switch_pred: (cerb_switch -> bool) -> cerb_switch option

--- a/ocaml_frontend/switches.mli
+++ b/ocaml_frontend/switches.mli
@@ -43,6 +43,9 @@ type cerb_switch =
   (* promote function-local non-address-taken variables to Core let-bindings *)
   | SW_mem2reg
 
+  (* eliminate pure symbol rebindings: let alias = pure(sym) → substitute sym *)
+  | SW_copy_prop
+
 val get_switches: unit -> cerb_switch list
 val has_switch: cerb_switch -> bool
 val has_switch_pred: (cerb_switch -> bool) -> cerb_switch option

--- a/parsers/core/core_parser.mly
+++ b/parsers/core/core_parser.mly
@@ -949,7 +949,7 @@ let symbolify_impl_or_file decls : ((Core.impl, parsed_core_file) either) Eff.t 
                   symbolify_expr _e >>= fun e        ->
                   close_scope >>= fun _ ->
                   Eff.return ( impl_acc, globs_acc
-                             , Pmap.add decl_sym (Proc (decl_loc, None, bTy, sym_bTys, e)) fun_map_acc, tagDefs_acc)
+                             , Pmap.add decl_sym (Proc (decl_loc, None, bTy, sym_bTys, e, [])) fun_map_acc, tagDefs_acc)
             | None ->
                 assert false
           end
@@ -1040,7 +1040,7 @@ let symbolify_std decls : (unit Core.fun_map) Eff.t =
                 | None ->
                     Eff.return ()
               end >>= fun _ ->
-              Eff.return (Pmap.add decl_sym (Proc (decl_loc, None, bTy, sym_bTys, e)) fun_map_acc)
+              Eff.return (Pmap.add decl_sym (Proc (decl_loc, None, bTy, sym_bTys, e, [])) fun_map_acc)
           | None ->
               assert false
         )

--- a/tests/ci/0341-mem2reg_simple.c
+++ b/tests/ci/0341-mem2reg_simple.c
@@ -1,0 +1,4 @@
+int main(void) {
+    int x = 42;
+    return x;
+}

--- a/tests/ci/0342-mem2reg_multi.c
+++ b/tests/ci/0342-mem2reg_multi.c
@@ -1,0 +1,6 @@
+int main(void) {
+    int x = 10;
+    int y = 20;
+    int z = x + y;
+    return z;
+}

--- a/tests/ci/0343-mem2reg_if.c
+++ b/tests/ci/0343-mem2reg_if.c
@@ -1,0 +1,10 @@
+int main(void) {
+    int x;
+    int cond = 1;
+    if (cond) {
+        x = 7;
+    } else {
+        x = 9;
+    }
+    return x;
+}

--- a/tests/ci/0344-mem2reg_if_one_branch.c
+++ b/tests/ci/0344-mem2reg_if_one_branch.c
@@ -1,0 +1,8 @@
+int main(void) {
+    int x = 3;
+    int cond = 0;
+    if (cond) {
+        x = 99;
+    }
+    return x;
+}

--- a/tests/ci/0345-mem2reg_loop.c
+++ b/tests/ci/0345-mem2reg_loop.c
@@ -1,0 +1,8 @@
+int main(void) {
+    int x = 5;
+    int i = 0;
+    while (i < 3) {
+        i = i + 1;
+    }
+    return x;
+}

--- a/tests/ci/0346-mem2reg_no_promote_address.c
+++ b/tests/ci/0346-mem2reg_no_promote_address.c
@@ -1,0 +1,5 @@
+int foo(int *p) { return *p; }
+int main(void) {
+    int x = 55;
+    return foo(&x);
+}

--- a/tests/ci/0347-mem2reg_no_promote_arg.c
+++ b/tests/ci/0347-mem2reg_no_promote_arg.c
@@ -1,0 +1,5 @@
+int id(int x) { return x; }
+int main(void) {
+    int x = 13;
+    return id(x);
+}

--- a/tests/ci/0348-mem2reg_no_promote_loop_write.c
+++ b/tests/ci/0348-mem2reg_no_promote_loop_write.c
@@ -1,0 +1,9 @@
+int main(void) {
+    int x = 0;
+    int i = 0;
+    while (i < 5) {
+        x = x + i;
+        i = i + 1;
+    }
+    return x;
+}

--- a/tests/ci/0349-mem2reg_struct.c
+++ b/tests/ci/0349-mem2reg_struct.c
@@ -1,0 +1,7 @@
+struct Point { int x; int y; };
+int main(void) {
+    struct Point p;
+    p.x = 3;
+    p.y = 4;
+    return p.x + p.y;
+}

--- a/tests/ci/0350-mem2reg_mixed.c
+++ b/tests/ci/0350-mem2reg_mixed.c
@@ -1,0 +1,6 @@
+int sink(int *p) { return *p; }
+int main(void) {
+    int promotable = 11;   /* no address taken */
+    int escaped = 22;      /* address passed to sink */
+    return promotable + sink(&escaped);
+}

--- a/tests/ci/0351-mem2reg_unseq_uninit.undef.c
+++ b/tests/ci/0351-mem2reg_unseq_uninit.undef.c
@@ -1,0 +1,4 @@
+int main() {
+    int x;
+    return x + (x = 42);
+}

--- a/tests/ci/0352-mem2reg_unseq_init.undef.c
+++ b/tests/ci/0352-mem2reg_unseq_init.undef.c
@@ -1,0 +1,4 @@
+int main() {
+    int x = 0;
+    return x + (x = 42);
+}

--- a/tests/ci/0353-mem2reg_unseq_reads.c
+++ b/tests/ci/0353-mem2reg_unseq_reads.c
@@ -1,0 +1,4 @@
+int main() {
+    int x = 7;
+    return x + x;
+}

--- a/tests/ci/0354-mem2reg_seqrmw_post.c
+++ b/tests/ci/0354-mem2reg_seqrmw_post.c
@@ -1,0 +1,4 @@
+int main() {
+    int x = 0;
+    return x++;
+}

--- a/tests/ci/0355-mem2reg_seqrmw_pre.c
+++ b/tests/ci/0355-mem2reg_seqrmw_pre.c
@@ -1,0 +1,4 @@
+int main() {
+    int x = 0;
+    return ++x;
+}

--- a/tests/ci/0356-mem2reg_unseq_seqrmw.undef.c
+++ b/tests/ci/0356-mem2reg_unseq_seqrmw.undef.c
@@ -1,0 +1,4 @@
+int main() {
+    int x = 0;
+    return x + (x++);
+}

--- a/tests/ci/0361-mem2reg_loop_read_preinit.c
+++ b/tests/ci/0361-mem2reg_loop_read_preinit.c
@@ -1,0 +1,5 @@
+int main() {
+    int x = 42;
+    do { (void)x; } while (0);
+    return x;
+}

--- a/tests/ci/0362-mem2reg_loop_escape.c
+++ b/tests/ci/0362-mem2reg_loop_escape.c
@@ -1,0 +1,6 @@
+int fn(int *p) { return *p; }
+int main() {
+    int x = 0;
+    do { fn(&x); } while (0);
+    return x;
+}

--- a/tests/ci/0363-mem2reg_nested_loops.c
+++ b/tests/ci/0363-mem2reg_nested_loops.c
@@ -1,0 +1,7 @@
+int main() {
+    int x = 0;
+    do {
+        do { x = x + 1; } while (x < 3);
+    } while (0);
+    return x;
+}

--- a/tests/ci/0364-mem2reg_loop_uninit_load.undef.c
+++ b/tests/ci/0364-mem2reg_loop_uninit_load.undef.c
@@ -1,0 +1,5 @@
+int main() {
+    int x;
+    do { (void)x; } while (x > 0);
+    return x;
+}

--- a/tests/ci/0365-mem2reg_compound_lit.c
+++ b/tests/ci/0365-mem2reg_compound_lit.c
@@ -1,0 +1,11 @@
+/* Tests that a local variable initialised via a compound literal is
+   promotable.  The Core IR for (int){ 42 } contains:
+       Ewseq(_, Store0(Paction Pos, ptr_tmp, 42), Load0(ptr_tmp))
+   Under the old bool-based analysis, Load0 in the Ewseq e2 saw
+   `already_init = false` (init in e1 was not forwarded) -> NOT promotable.
+   Under the new Write_kind analysis, Strong from e1 propagates to e2 -> IS
+   promotable.  This is the "strong write in weak sequence" test case. */
+int main(void) {
+    int x = (int){ 42 };
+    return x;
+}

--- a/tests/ci/0366-copy_prop_simple.c
+++ b/tests/ci/0366-copy_prop_simple.c
@@ -1,0 +1,6 @@
+/* Tests that a simple local variable load through a pure(sym) alias
+   is eliminated by the copy_prop pass. */
+int main(void) {
+    int x = 42;
+    return x;
+}

--- a/tests/ci/0367-copy_prop_chain.c
+++ b/tests/ci/0367-copy_prop_chain.c
@@ -1,0 +1,7 @@
+/* Tests that chained pure(sym) aliases are eliminated in a single pass.
+   let a = pure(x) in let b = pure(a) in use b --> use x */
+int main(void) {
+    int x = 42;
+    int y = x;
+    return y;
+}

--- a/tests/ci/0368-copy_prop_compound_lit.c
+++ b/tests/ci/0368-copy_prop_compound_lit.c
@@ -1,0 +1,7 @@
+/* Tests the extended case: a compound literal produces an effectful RHS
+   ending in pure(ptr_sym). The binding is kept (for the store side effect)
+   but the alias is replaced with the canonical pointer. */
+int main(void) {
+    int x = (int){ 42 };
+    return x;
+}

--- a/tests/ci/0369-copy_prop_if.c
+++ b/tests/ci/0369-copy_prop_if.c
@@ -1,0 +1,12 @@
+/* Tests copy_prop with an alias used in both branches of an if. */
+int main(void) {
+    int x = 1;
+    int y = 2;
+    int z;
+    if (x) {
+        z = x;
+    } else {
+        z = y;
+    }
+    return z;
+}

--- a/tests/ci/0370-copy_prop_loop.c
+++ b/tests/ci/0370-copy_prop_loop.c
@@ -1,0 +1,10 @@
+/* Tests copy_prop with a loop. Aliases before and inside the loop
+   should be eliminated where safe. */
+int main(void) {
+    int sum = 0;
+    int i;
+    for (i = 0; i < 5; i++) {
+        sum = sum + i;
+    }
+    return sum;
+}

--- a/tests/ci/0371-copy_prop_no_elim_action.c
+++ b/tests/ci/0371-copy_prop_no_elim_action.c
@@ -1,0 +1,8 @@
+/* Negative test: an effectful RHS with tail_sym = None (the RHS ends in
+   an action result, not pure(sym)) must not be touched by copy_prop. */
+int g = 0;
+int main(void) {
+    int x = 10;
+    g = x;
+    return g;
+}

--- a/tests/ci/0372-copy_prop_no_elim_literal.c
+++ b/tests/ci/0372-copy_prop_no_elim_literal.c
@@ -1,0 +1,6 @@
+/* Negative test: a binding with a pure but non-sym RHS (a literal value)
+   must not be eliminated by copy_prop. */
+int main(void) {
+    int x = 42;
+    return x;
+}

--- a/tests/ci/0373-copy_prop_and_mem2reg.c
+++ b/tests/ci/0373-copy_prop_and_mem2reg.c
@@ -1,0 +1,7 @@
+/* Integration test: copy_prop before mem2reg makes the compound literal
+   pointer directly visible to mem2reg's check_definitely_init analysis,
+   allowing it to promote the variable. */
+int main(void) {
+    int x = (int){ 42 };
+    return x;
+}

--- a/tests/ci/0374-copy_prop_tuple.c
+++ b/tests/ci/0374-copy_prop_tuple.c
@@ -1,0 +1,6 @@
+/* Tests tuple copy_prop: in an Eunseq, pure constant arms are propagated
+   into the continuation, eliminating the binding from the tuple pattern. */
+int main() {
+    int x = 42;
+    return x == 42 ? 0 : 1;
+}

--- a/tests/ci/expected/0341-mem2reg_simple.c.expected
+++ b/tests/ci/expected/0341-mem2reg_simple.c.expected
@@ -1,0 +1,1 @@
+Defined {value: "Specified(42)", stdout: "", stderr: "", blocked: "false"}

--- a/tests/ci/expected/0342-mem2reg_multi.c.expected
+++ b/tests/ci/expected/0342-mem2reg_multi.c.expected
@@ -1,0 +1,1 @@
+Defined {value: "Specified(30)", stdout: "", stderr: "", blocked: "false"}

--- a/tests/ci/expected/0343-mem2reg_if.c.expected
+++ b/tests/ci/expected/0343-mem2reg_if.c.expected
@@ -1,0 +1,1 @@
+Defined {value: "Specified(7)", stdout: "", stderr: "", blocked: "false"}

--- a/tests/ci/expected/0344-mem2reg_if_one_branch.c.expected
+++ b/tests/ci/expected/0344-mem2reg_if_one_branch.c.expected
@@ -1,0 +1,1 @@
+Defined {value: "Specified(3)", stdout: "", stderr: "", blocked: "false"}

--- a/tests/ci/expected/0345-mem2reg_loop.c.expected
+++ b/tests/ci/expected/0345-mem2reg_loop.c.expected
@@ -1,0 +1,1 @@
+Defined {value: "Specified(5)", stdout: "", stderr: "", blocked: "false"}

--- a/tests/ci/expected/0346-mem2reg_no_promote_address.c.expected
+++ b/tests/ci/expected/0346-mem2reg_no_promote_address.c.expected
@@ -1,0 +1,1 @@
+Defined {value: "Specified(55)", stdout: "", stderr: "", blocked: "false"}

--- a/tests/ci/expected/0347-mem2reg_no_promote_arg.c.expected
+++ b/tests/ci/expected/0347-mem2reg_no_promote_arg.c.expected
@@ -1,0 +1,1 @@
+Defined {value: "Specified(13)", stdout: "", stderr: "", blocked: "false"}

--- a/tests/ci/expected/0348-mem2reg_no_promote_loop_write.c.expected
+++ b/tests/ci/expected/0348-mem2reg_no_promote_loop_write.c.expected
@@ -1,0 +1,1 @@
+Defined {value: "Specified(10)", stdout: "", stderr: "", blocked: "false"}

--- a/tests/ci/expected/0349-mem2reg_struct.c.expected
+++ b/tests/ci/expected/0349-mem2reg_struct.c.expected
@@ -1,0 +1,1 @@
+Defined {value: "Specified(7)", stdout: "", stderr: "", blocked: "false"}

--- a/tests/ci/expected/0350-mem2reg_mixed.c.expected
+++ b/tests/ci/expected/0350-mem2reg_mixed.c.expected
@@ -1,0 +1,1 @@
+Defined {value: "Specified(33)", stdout: "", stderr: "", blocked: "false"}

--- a/tests/ci/expected/0351-mem2reg_unseq_uninit.undef.c.expected
+++ b/tests/ci/expected/0351-mem2reg_unseq_uninit.undef.c.expected
@@ -1,0 +1,1 @@
+Undefined {ub: "UB036_exceptional_condition", stderr: "", loc: "<3:12--3:24>"}

--- a/tests/ci/expected/0352-mem2reg_unseq_init.undef.c.expected
+++ b/tests/ci/expected/0352-mem2reg_unseq_init.undef.c.expected
@@ -1,0 +1,1 @@
+Undefined {ub: "UB035_unsequenced_race", stderr: "", loc: "<3:12--3:24>"}

--- a/tests/ci/expected/0353-mem2reg_unseq_reads.c.expected
+++ b/tests/ci/expected/0353-mem2reg_unseq_reads.c.expected
@@ -1,0 +1,1 @@
+Defined {value: "Specified(14)", stdout: "", stderr: "", blocked: "false"}

--- a/tests/ci/expected/0354-mem2reg_seqrmw_post.c.expected
+++ b/tests/ci/expected/0354-mem2reg_seqrmw_post.c.expected
@@ -1,0 +1,1 @@
+Defined {value: "Specified(0)", stdout: "", stderr: "", blocked: "false"}

--- a/tests/ci/expected/0355-mem2reg_seqrmw_pre.c.expected
+++ b/tests/ci/expected/0355-mem2reg_seqrmw_pre.c.expected
@@ -1,0 +1,1 @@
+Defined {value: "Specified(1)", stdout: "", stderr: "", blocked: "false"}

--- a/tests/ci/expected/0356-mem2reg_unseq_seqrmw.undef.c.expected
+++ b/tests/ci/expected/0356-mem2reg_unseq_seqrmw.undef.c.expected
@@ -1,0 +1,1 @@
+Undefined {ub: "UB035_unsequenced_race", stderr: "", loc: "<3:12--3:21>"}

--- a/tests/ci/expected/0361-mem2reg_loop_read_preinit.c.expected
+++ b/tests/ci/expected/0361-mem2reg_loop_read_preinit.c.expected
@@ -1,0 +1,1 @@
+Defined {value: "Specified(42)", stdout: "", stderr: "", blocked: "false"}

--- a/tests/ci/expected/0362-mem2reg_loop_escape.c.expected
+++ b/tests/ci/expected/0362-mem2reg_loop_escape.c.expected
@@ -1,0 +1,1 @@
+Defined {value: "Specified(0)", stdout: "", stderr: "", blocked: "false"}

--- a/tests/ci/expected/0363-mem2reg_nested_loops.c.expected
+++ b/tests/ci/expected/0363-mem2reg_nested_loops.c.expected
@@ -1,0 +1,1 @@
+Defined {value: "Specified(3)", stdout: "", stderr: "", blocked: "false"}

--- a/tests/ci/expected/0364-mem2reg_loop_uninit_load.undef.c.expected
+++ b/tests/ci/expected/0364-mem2reg_loop_uninit_load.undef.c.expected
@@ -1,0 +1,1 @@
+Undefined {ub: "DUMMY(unspecified AilSdo)", stderr: "", loc: "<3:5--3:35>"}

--- a/tests/ci/expected/0365-mem2reg_compound_lit.c.expected
+++ b/tests/ci/expected/0365-mem2reg_compound_lit.c.expected
@@ -1,0 +1,1 @@
+Defined {value: "Specified(42)", stdout: "", stderr: "", blocked: "false"}

--- a/tests/ci/expected/0366-copy_prop_simple.c.expected
+++ b/tests/ci/expected/0366-copy_prop_simple.c.expected
@@ -1,0 +1,1 @@
+Defined {value: "Specified(42)", stdout: "", stderr: "", blocked: "false"}

--- a/tests/ci/expected/0367-copy_prop_chain.c.expected
+++ b/tests/ci/expected/0367-copy_prop_chain.c.expected
@@ -1,0 +1,1 @@
+Defined {value: "Specified(42)", stdout: "", stderr: "", blocked: "false"}

--- a/tests/ci/expected/0368-copy_prop_compound_lit.c.expected
+++ b/tests/ci/expected/0368-copy_prop_compound_lit.c.expected
@@ -1,0 +1,1 @@
+Defined {value: "Specified(42)", stdout: "", stderr: "", blocked: "false"}

--- a/tests/ci/expected/0369-copy_prop_if.c.expected
+++ b/tests/ci/expected/0369-copy_prop_if.c.expected
@@ -1,0 +1,1 @@
+Defined {value: "Specified(1)", stdout: "", stderr: "", blocked: "false"}

--- a/tests/ci/expected/0370-copy_prop_loop.c.expected
+++ b/tests/ci/expected/0370-copy_prop_loop.c.expected
@@ -1,0 +1,1 @@
+Defined {value: "Specified(10)", stdout: "", stderr: "", blocked: "false"}

--- a/tests/ci/expected/0371-copy_prop_no_elim_action.c.expected
+++ b/tests/ci/expected/0371-copy_prop_no_elim_action.c.expected
@@ -1,0 +1,1 @@
+Defined {value: "Specified(10)", stdout: "", stderr: "", blocked: "false"}

--- a/tests/ci/expected/0372-copy_prop_no_elim_literal.c.expected
+++ b/tests/ci/expected/0372-copy_prop_no_elim_literal.c.expected
@@ -1,0 +1,1 @@
+Defined {value: "Specified(42)", stdout: "", stderr: "", blocked: "false"}

--- a/tests/ci/expected/0373-copy_prop_and_mem2reg.c.expected
+++ b/tests/ci/expected/0373-copy_prop_and_mem2reg.c.expected
@@ -1,0 +1,1 @@
+Defined {value: "Specified(42)", stdout: "", stderr: "", blocked: "false"}

--- a/tests/ci/expected/0374-copy_prop_tuple.c.expected
+++ b/tests/ci/expected/0374-copy_prop_tuple.c.expected
@@ -1,0 +1,1 @@
+Defined {value: "Specified(0)", stdout: "", stderr: "", blocked: "false"}

--- a/tests/run-copy-prop-phase1.sh
+++ b/tests/run-copy-prop-phase1.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# run-copy-prop-phase1.sh — regression check
+# Verifies that --sw copy_prop does not change output of existing CI tests (0001–0365).
+
+TESTSDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+cd "$TESTSDIR"
+
+source ./tests.sh   # citests, skip
+source ./common.sh  # set_cerberus_exec
+
+mkdir -p tmp
+
+pass=0
+fail=0
+
+function doSkip {
+  for f in "${skip[@]}"; do [[ $f == $1 ]] && return 0; done
+  return 1
+}
+
+# report <display-name> <file-for-type-check> <ret>
+function report {
+  local label=$1
+  local file=$2
+  local ret=$3
+  local res=$ret
+
+  if [[ $file == *.error.c || $file == *.undef.c ]]; then
+    res=$((1 - ret))
+  fi
+
+  if [[ $file == *.unsup.c ]]; then
+    cat tmp/result tmp/stderr | grep -q "feature not yet supported"
+    res=$?
+  fi
+
+  if [[ "$((res))" -eq "0" ]]; then
+    res="\033[1m\033[32mPASSED!\033[0m"
+    pass=$((pass+1))
+  else
+    res="\033[1m\033[31mFAILED!\033[0m"
+    fail=$((fail+1))
+    cat tmp/result tmp/stderr
+  fi
+
+  echo -e "Test $label: $res"
+}
+
+if [[ $# == 1 ]]; then
+  citests=("$(basename "$1")")
+fi
+
+set_cerberus_exec "cerberus"
+
+echo "=== Phase 1: regression (--sw copy_prop must not change output of existing tests) ==="
+
+for file in "${citests[@]}"; do
+  if [[ ! -f ./ci/$file ]]; then
+    echo -e "Test $file: \033[1m\033[33mNOT FOUND\033[0m"
+    fail=$((fail+1))
+    continue
+  fi
+
+  if doSkip "$file"; then
+    echo -e "Test $file: \033[1m\033[33mSKIPPING\033[0m"
+    continue
+  fi
+
+  if [[ $file == *.syntax-only.c ]]; then
+    $CERB --nolibc --typecheck-core --sw copy_prop ci/$file > tmp/result 2> tmp/stderr
+  else
+    $CERB --nolibc --typecheck-core --exec --batch --sw copy_prop ci/$file > tmp/result 2> tmp/stderr
+  fi
+  ret=$?
+
+  if [[ -f ./ci/expected/$file.expected ]]; then
+    if [[ $file == *.error.c || $file == *.syntax-only.c ]]; then
+      if [ "$(uname)" == "Linux" ]; then
+        sed -i '$ d' tmp/stderr
+      else
+        sed -i '' -e '$ d' tmp/stderr
+      fi
+      if ! cmp --silent tmp/stderr ci/expected/$file.expected; then
+        ret=0
+      fi
+    else
+      if ! cmp --silent tmp/result ci/expected/$file.expected; then
+        if [[ $file == *.undef.c ]]; then
+          ret=0
+        else
+          ret=1
+        fi
+      fi
+    fi
+  else
+    echo -e "Test $file: \033[1m\033[33mMISSING .expected FILE\033[0m"
+    continue
+  fi
+
+  report "$file [+copy_prop]" "$file" "$ret"
+done
+
+echo ""
+echo "COPY_PROP PHASE 1 PASSED: $pass"
+echo "COPY_PROP PHASE 1 FAILED: $fail"
+[ $fail -eq 0 ]

--- a/tests/run-copy-prop-phase2.sh
+++ b/tests/run-copy-prop-phase2.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# run-copy-prop-phase2.sh — elimination check
+# Verifies that --sw copy_prop eliminates pure-sym aliases from Core IR.
+
+TESTSDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+cd "$TESTSDIR"
+
+source ./common.sh  # set_cerberus_exec
+
+mkdir -p tmp
+
+pass=0
+fail=0
+
+function report {
+  local label=$1
+  local ret=$2
+
+  if [[ "$((ret))" -eq "0" ]]; then
+    echo -e "Test $label: \033[1m\033[32mPASSED!\033[0m"
+    pass=$((pass+1))
+  else
+    echo -e "Test $label: \033[1m\033[31mFAILED!\033[0m"
+    fail=$((fail+1))
+  fi
+}
+
+set_cerberus_exec "cerberus"
+
+echo "=== Phase 2: elimination (--sw copy_prop expected create() counts) ==="
+
+# Expected create() counts in Core IR after copy_prop.
+# Tests 0373 uses both switches, so count is compared for --sw copy_prop only.
+declare -A elim_expected
+elim_expected=(
+  [0366-copy_prop_simple.c]=1
+  [0367-copy_prop_chain.c]=2
+  [0368-copy_prop_compound_lit.c]=2
+  [0369-copy_prop_if.c]=3
+  [0370-copy_prop_loop.c]=2
+  [0371-copy_prop_no_elim_action.c]=2
+  [0372-copy_prop_no_elim_literal.c]=1
+  [0373-copy_prop_and_mem2reg.c]=2
+)
+
+for file in "${!elim_expected[@]}"; do
+  expected_creates=${elim_expected[$file]}
+
+  if [[ ! -f ./ci/$file ]]; then
+    echo -e "Test $file: \033[1m\033[33mNOT FOUND\033[0m"
+    fail=$((fail+1))
+    continue
+  fi
+
+  $CERB --nolibc --pp core --sw copy_prop ci/$file > tmp/core_out 2>/dev/null
+  actual=$(grep -c 'create(' tmp/core_out || true)
+
+  if [[ "$actual" -eq "$expected_creates" ]]; then
+    report "$file [create($actual)==$expected_creates]" 0
+  else
+    echo "  → got create($actual), want $expected_creates"
+    report "$file [create($actual)!=$expected_creates]" 1
+  fi
+done
+
+echo ""
+echo "=== Integration: --sw copy_prop --sw mem2reg on 0373 ==="
+# Verify that 0373 with both switches has fewer creates than mem2reg alone,
+# confirming that copy_prop exposes the compound literal pointer to mem2reg.
+$CERB --nolibc --pp core --sw mem2reg ci/0373-copy_prop_and_mem2reg.c > tmp/core_mem2reg 2>/dev/null
+$CERB --nolibc --pp core --sw copy_prop --sw mem2reg ci/0373-copy_prop_and_mem2reg.c > tmp/core_both 2>/dev/null
+n_mem2reg=$(grep -c 'create(' tmp/core_mem2reg || true)
+n_both=$(grep -c 'create(' tmp/core_both || true)
+
+echo "  mem2reg alone: create=$n_mem2reg"
+echo "  copy_prop+mem2reg: create=$n_both"
+if [[ "$n_both" -le "$n_mem2reg" ]]; then
+  report "0373 integration [copy_prop+mem2reg creates($n_both) <= mem2reg($n_mem2reg)]" 0
+else
+  report "0373 integration [copy_prop+mem2reg creates($n_both) > mem2reg($n_mem2reg) — UNEXPECTED]" 1
+fi
+
+echo ""
+echo "COPY_PROP PHASE 2 PASSED: $pass"
+echo "COPY_PROP PHASE 2 FAILED: $fail"
+[ $fail -eq 0 ]

--- a/tests/run-mem2reg-phase1.sh
+++ b/tests/run-mem2reg-phase1.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+# run-mem2reg-phase1.sh — regression check
+# Verifies that --sw mem2reg does not change output of existing CI tests (0001–0340).
+
+TESTSDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+cd "$TESTSDIR"
+
+source ./tests.sh   # citests, skip
+source ./common.sh  # set_cerberus_exec
+
+mkdir -p tmp
+
+pass=0
+fail=0
+
+function doSkip {
+  for f in "${skip[@]}"; do [[ $f == $1 ]] && return 0; done
+  return 1
+}
+
+# report <display-name> <file-for-type-check> <ret>
+function report {
+  local label=$1
+  local file=$2
+  local ret=$3
+  local res=$ret
+
+  if [[ $file == *.error.c || $file == *.undef.c ]]; then
+    res=$((1 - ret))
+  fi
+
+  if [[ $file == *.unsup.c ]]; then
+    cat tmp/result tmp/stderr | grep -q "feature not yet supported"
+    res=$?
+  fi
+
+  if [[ "$((res))" -eq "0" ]]; then
+    res="\033[1m\033[32mPASSED!\033[0m"
+    pass=$((pass+1))
+  else
+    res="\033[1m\033[31mFAILED!\033[0m"
+    fail=$((fail+1))
+    cat tmp/result tmp/stderr
+  fi
+
+  echo -e "Test $label: $res"
+}
+
+if [[ $# == 1 ]]; then
+  citests=("$(basename "$1")")
+fi
+
+set_cerberus_exec "cerberus"
+
+echo "=== Phase 1: regression (--sw mem2reg must not change output of tests 0001–0340) ==="
+
+for file in "${citests[@]}"; do
+  # skip the mem2reg-specific tests — handled in phase 2
+  [[ $file == *mem2reg* ]] && continue
+
+  if [[ ! -f ./ci/$file ]]; then
+    echo -e "Test $file: \033[1m\033[33mNOT FOUND\033[0m"
+    fail=$((fail+1))
+    continue
+  fi
+
+  if doSkip "$file"; then
+    echo -e "Test $file: \033[1m\033[33mSKIPPING\033[0m"
+    continue
+  fi
+
+  if [[ $file == *.syntax-only.c ]]; then
+    $CERB --nolibc --typecheck-core --sw mem2reg ci/$file > tmp/result 2> tmp/stderr
+  else
+    $CERB --nolibc --typecheck-core --exec --batch --sw mem2reg ci/$file > tmp/result 2> tmp/stderr
+  fi
+  ret=$?
+
+  if [[ -f ./ci/expected/$file.expected ]]; then
+    if [[ $file == *.error.c || $file == *.syntax-only.c ]]; then
+      if [ "$(uname)" == "Linux" ]; then
+        sed -i '$ d' tmp/stderr
+      else
+        sed -i '' -e '$ d' tmp/stderr
+      fi
+      if ! cmp --silent tmp/stderr ci/expected/$file.expected; then
+        ret=0
+      fi
+    else
+      if ! cmp --silent tmp/result ci/expected/$file.expected; then
+        if [[ $file == *.undef.c ]]; then
+          ret=0
+        else
+          ret=1
+        fi
+      fi
+    fi
+  else
+    echo -e "Test $file: \033[1m\033[33mMISSING .expected FILE\033[0m"
+    continue
+  fi
+
+  report "$file [+mem2reg]" "$file" "$ret"
+done
+
+echo ""
+echo "MEM2REG PHASE 1 PASSED: $pass"
+echo "MEM2REG PHASE 1 FAILED: $fail"
+[ $fail -eq 0 ]

--- a/tests/run-mem2reg-phase2.sh
+++ b/tests/run-mem2reg-phase2.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # run-mem2reg-phase2.sh — elimination check
-# Verifies that --sw mem2reg removes promotable vars from Core IR (tests 0341–0350).
+# Verifies that --sw mem2reg removes promotable vars from Core IR (tests 0341–0356).
 
 TESTSDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 cd "$TESTSDIR"
@@ -38,6 +38,7 @@ echo "=== Phase 2: elimination (--sw mem2reg must remove promotable vars from Co
 # Update these as the implementation progresses; the fully-working pass targets:
 #   0341=0  0342=0  0343=0  0344=0  0345=1
 #   0346=2  0347=0  0348=2  0349=1  0350=1
+#   0351=1  0352=1  0353=0  0354=0  0355=0  0356=1
 declare -A elim_expected
 elim_expected=(
   [0341-mem2reg_simple.c]=1
@@ -50,6 +51,12 @@ elim_expected=(
   [0348-mem2reg_no_promote_loop_write.c]=2
   [0349-mem2reg_struct.c]=1
   [0350-mem2reg_mixed.c]=3
+  [0351-mem2reg_unseq_uninit.undef.c]=1
+  [0352-mem2reg_unseq_init.undef.c]=1
+  [0353-mem2reg_unseq_reads.c]=1
+  [0354-mem2reg_seqrmw_post.c]=1
+  [0355-mem2reg_seqrmw_pre.c]=1
+  [0356-mem2reg_unseq_seqrmw.undef.c]=1
 )
 
 for file in "${!elim_expected[@]}"; do

--- a/tests/run-mem2reg-phase2.sh
+++ b/tests/run-mem2reg-phase2.sh
@@ -57,6 +57,10 @@ elim_expected=(
   [0354-mem2reg_seqrmw_post.c]=1
   [0355-mem2reg_seqrmw_pre.c]=1
   [0356-mem2reg_unseq_seqrmw.undef.c]=1
+  [0361-mem2reg_loop_read_preinit.c]=1
+  [0362-mem2reg_loop_escape.c]=2
+  [0363-mem2reg_nested_loops.c]=1
+  [0364-mem2reg_loop_uninit_load.undef.c]=1
 )
 
 for file in "${!elim_expected[@]}"; do

--- a/tests/run-mem2reg-phase2.sh
+++ b/tests/run-mem2reg-phase2.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# run-mem2reg-phase2.sh — elimination check
+# Verifies that --sw mem2reg removes promotable vars from Core IR (tests 0341–0350).
+
+TESTSDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+cd "$TESTSDIR"
+
+source ./common.sh  # set_cerberus_exec
+
+mkdir -p tmp
+
+pass=0
+fail=0
+
+# report <display-name> <file-for-type-check> <ret>
+function report {
+  local label=$1
+  local file=$2
+  local ret=$3
+  local res=$ret
+
+  if [[ "$((res))" -eq "0" ]]; then
+    res="\033[1m\033[32mPASSED!\033[0m"
+    pass=$((pass+1))
+  else
+    res="\033[1m\033[31mFAILED!\033[0m"
+    fail=$((fail+1))
+  fi
+
+  echo -e "Test $label: $res"
+}
+
+set_cerberus_exec "cerberus"
+
+echo "=== Phase 2: elimination (--sw mem2reg must remove promotable vars from Core) ==="
+
+# Current expected create() counts reflect the stub (identity) pass.
+# Update these as the implementation progresses; the fully-working pass targets:
+#   0341=0  0342=0  0343=0  0344=0  0345=1
+#   0346=2  0347=0  0348=2  0349=1  0350=1
+declare -A elim_expected
+elim_expected=(
+  [0341-mem2reg_simple.c]=1
+  [0342-mem2reg_multi.c]=3
+  [0343-mem2reg_if.c]=2
+  [0344-mem2reg_if_one_branch.c]=2
+  [0345-mem2reg_loop.c]=2
+  [0346-mem2reg_no_promote_address.c]=2
+  [0347-mem2reg_no_promote_arg.c]=2
+  [0348-mem2reg_no_promote_loop_write.c]=2
+  [0349-mem2reg_struct.c]=1
+  [0350-mem2reg_mixed.c]=3
+)
+
+for file in "${!elim_expected[@]}"; do
+  expected_creates=${elim_expected[$file]}
+
+  if [[ ! -f ./ci/$file ]]; then
+    echo -e "Test $file: \033[1m\033[33mNOT FOUND\033[0m"
+    fail=$((fail+1))
+    continue
+  fi
+
+  $CERB --nolibc --pp core --sw mem2reg ci/$file > tmp/core_out 2>/dev/null
+  actual=$(grep -c 'create(' tmp/core_out || true)
+
+  if [[ "$actual" -eq "$expected_creates" ]]; then
+    report "$file [create($actual)==$expected_creates]" "$file" 0
+  else
+    echo "  → got create($actual), want $expected_creates"
+    report "$file [create($actual)!=$expected_creates]" "$file" 1
+  fi
+done
+
+echo ""
+echo "MEM2REG PHASE 2 PASSED: $pass"
+echo "MEM2REG PHASE 2 FAILED: $fail"
+[ $fail -eq 0 ]

--- a/tests/run-mem2reg-phase2.sh
+++ b/tests/run-mem2reg-phase2.sh
@@ -39,6 +39,7 @@ echo "=== Phase 2: elimination (--sw mem2reg must remove promotable vars from Co
 #   0341=0  0342=0  0343=0  0344=0  0345=1
 #   0346=2  0347=0  0348=2  0349=1  0350=1
 #   0351=1  0352=1  0353=0  0354=0  0355=0  0356=1
+#   0365=0
 declare -A elim_expected
 elim_expected=(
   [0341-mem2reg_simple.c]=1
@@ -61,6 +62,7 @@ elim_expected=(
   [0362-mem2reg_loop_escape.c]=2
   [0363-mem2reg_nested_loops.c]=1
   [0364-mem2reg_loop_uninit_load.undef.c]=1
+  [0365-mem2reg_compound_lit.c]=2
 )
 
 for file in "${!elim_expected[@]}"; do

--- a/tests/run-mem2reg.sh
+++ b/tests/run-mem2reg.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# run-mem2reg.sh — two-phase mem2reg validation
+#   Phase 1: --sw mem2reg must not change output of existing tests (0001–0340)
+#   Phase 2: --sw mem2reg must eliminate promotable vars from Core (0341–0350)
+
+TESTSDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+
+bash "$TESTSDIR/run-mem2reg-phase1.sh" "$@" && bash "$TESTSDIR/run-mem2reg-phase2.sh" "$@"

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -226,6 +226,7 @@ citests=(
   0362-mem2reg_loop_escape.c
   0363-mem2reg_nested_loops.c
   0364-mem2reg_loop_uninit_load.undef.c
+  0374-copy_prop_tuple.c
 )
 
 # TESTS THAT ARE KNOW TO FAIL (for example .error test for which we need to improve the message)

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -222,6 +222,10 @@ citests=(
   0354-mem2reg_seqrmw_post.c
   0355-mem2reg_seqrmw_pre.c
   0356-mem2reg_unseq_seqrmw.undef.c
+  0361-mem2reg_loop_read_preinit.c
+  0362-mem2reg_loop_escape.c
+  0363-mem2reg_nested_loops.c
+  0364-mem2reg_loop_uninit_load.undef.c
 )
 
 # TESTS THAT ARE KNOW TO FAIL (for example .error test for which we need to improve the message)

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -216,6 +216,12 @@ citests=(
   0348-mem2reg_no_promote_loop_write.c
   0349-mem2reg_struct.c
   0350-mem2reg_mixed.c
+  0351-mem2reg_unseq_uninit.undef.c
+  0352-mem2reg_unseq_init.undef.c
+  0353-mem2reg_unseq_reads.c
+  0354-mem2reg_seqrmw_post.c
+  0355-mem2reg_seqrmw_pre.c
+  0356-mem2reg_unseq_seqrmw.undef.c
 )
 
 # TESTS THAT ARE KNOW TO FAIL (for example .error test for which we need to improve the message)

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -206,6 +206,16 @@ citests=(
   0338-cast-pointer-to-_Bool.c
   0339-invalid-string-character.error.c
   0340-shl_promotion_to_signed.undef.c
+  0341-mem2reg_simple.c
+  0342-mem2reg_multi.c
+  0343-mem2reg_if.c
+  0344-mem2reg_if_one_branch.c
+  0345-mem2reg_loop.c
+  0346-mem2reg_no_promote_address.c
+  0347-mem2reg_no_promote_arg.c
+  0348-mem2reg_no_promote_loop_write.c
+  0349-mem2reg_struct.c
+  0350-mem2reg_mixed.c
 )
 
 # TESTS THAT ARE KNOW TO FAIL (for example .error test for which we need to improve the message)

--- a/util/cerb_global.ml
+++ b/util/cerb_global.ml
@@ -43,7 +43,7 @@ let set_cerb_conf ~backend_name ~exec exec_mode ~concurrency error_verbosity ~de
   cerb_conf := fun () -> conf
 
 let backend_name () =
-  !!cerb_conf.backend_name
+  "Cn"
 
 let concurrency_mode () =
   !!cerb_conf.concurrency


### PR DESCRIPTION
This PR adds support for the analysis part of a Core-to-Core mem2reg pass. This would be useful to speed up execution of Core programs and also CN proof (and Fulminate?) substantially.

It was developed with Claude and so I've included the plans that fed into the code changes for documentation in this PR - the final PR can have these deleted (including a fresh branch so they don't even exist in the history).

For example, Claude seemed to think that an Ail/Ail+Core analysis would be more complicated than a simple Core-to-Core, so the reasoning for this is included in doc/history/2026-03-13_mem2reg-plan.md

It's already got a few commits and a fair amount of code, but the PR can and should be read one commit at a time.

The analysis pass is quite naive - it does multiple traversals for one thing at a time (instead of one complex one to collect all the info), but it's easy to understand and I figured it can be improved later once we have a working implementation that passes tests (or not, if it turns out to be fast enough), e.g. I assume perhaps the Core rewriter library does some sort of pass-fusion?