### PR TITLE
Add support for empty structs (under a switch)

### DIFF
--- a/frontend/model/cabs_to_ail.lem
+++ b/frontend/model/cabs_to_ail.lem
@@ -1571,6 +1571,9 @@ let rec desugar_type_specifiers specs =
             else match Utils.last all_membDefs with
               | Nothing ->
                   (* xs was an empty list *)
+if Global.has_switch Global.SW_empty_structs then
+                  E.return Nothing
+else
                   (* STD §6.7.2.1#8, sentence 3 *)
                   E.undef loc Undefined.UB061_no_named_members
               | Just ((last_ident, (lastMemb_attrs, _, lastMemb_qs, lastMemb_ty)), membDefs) ->

--- a/frontend/model/global.lem
+++ b/frontend/model/global.lem
@@ -54,6 +54,7 @@ type cerb_switch =
   | SW_permissive_printf
   | SW_no_integer_provenance
   | SW_CHERI
+  | SW_empty_structs
 
 declare ocaml target_rep function SW_strict_reads = `Switches.SW_strict_reads`
 declare ocaml target_rep function SW_forbid_nullptr_free = `Switches.SW_forbid_nullptr_free`
@@ -62,6 +63,7 @@ declare ocaml target_rep function SW_inner_arg_temps = `Switches.SW_inner_arg_te
 declare ocaml target_rep function SW_permissive_printf = `Switches.SW_permissive_printf`
 declare ocaml target_rep function SW_no_integer_provenance = `Switches.SW_no_integer_provenance`
 declare ocaml target_rep function SW_CHERI = `Switches.SW_CHERI`
+declare ocaml target_rep function SW_empty_structs = `Switches.SW_empty_structs`
 
 
 val is_CHERI: unit -> bool

--- a/memory/concrete/impl_mem.ml
+++ b/memory/concrete/impl_mem.ml
@@ -167,8 +167,9 @@ and sizeof ?(tagDefs= Tags.tagDefs ()) (Ctype (_, ty) as cty) : Z.t =
            (hence the `ignore_flexible` in the call to offsetof) *)
         let (_, max_offset) = offsetsof ~ignore_flexible:true tagDefs tag_sym in
         let align = of_int (alignof ~tagDefs cty) in
-        let x = modulus max_offset align in
-        if equal x zero then max_offset else Z.add max_offset (Z.sub align x)
+        if equal align zero then zero else
+          let x = modulus max_offset align in
+          if equal x zero then max_offset else Z.add max_offset (Z.sub align x)
     | Union tag_sym ->
         begin match Pmap.find tag_sym (Tags.tagDefs ()) with
           | _, StructDef _ ->
@@ -1250,6 +1251,7 @@ module Concrete : Memory = struct
     begin
       let open Z in
       let z = sub st.last_address sz in
+      if equal align zero then return z else
       let (q,m) = quomod z align in
       let z' = sub z (if q < zero then neg m else m) in
       if z' <= zero then

--- a/memory/vip/common.ml
+++ b/memory/vip/common.ml
@@ -75,8 +75,9 @@ and sizeof ?(tagDefs= Tags.tagDefs ()) (Ctype (_, ty) as cty) =
            (hence the `ignore_flexible` in the call to offsetof) *)
         let (_, max_offset) = offsetsof ~ignore_flexible:true tagDefs tag_sym in
         let align = alignof ~tagDefs cty in
-        let x = max_offset mod align in
-        if x = 0 then max_offset else max_offset + (align - x)
+        if align = 0 then 0 else
+          let x = max_offset mod align in
+          if x = 0 then max_offset else max_offset + (align - x)
     | Union tag_sym ->
         begin match Pmap.find tag_sym (Tags.tagDefs ()) with
           | _, StructDef _ ->

--- a/memory/vip/impl_mem.ml
+++ b/memory/vip/impl_mem.ml
@@ -205,6 +205,7 @@ let allocator (sz: Z.t) (align: Z.t) : (allocation_id * address) memM =
   begin
     let open Z in
     let z = sub st.last_address sz in
+    if equal align zero then return z else
     let (q,m) = quomod z align in
     let z' = sub z (if q < zero then neg m else m) in
     if z' <= zero then

--- a/ocaml_frontend/switches.ml
+++ b/ocaml_frontend/switches.ml
@@ -43,6 +43,9 @@ type cerb_switch =
   (* eliminate pure expr rebindings: let pat = C[pure(pexpr)] -> substitute pexpr *)
   | SW_copy_prop
 
+  (* allow empty structs *)
+  | SW_empty_structs
+
 
 let internal_ref =
   ref []
@@ -99,6 +102,8 @@ let set strs =
         Some (SW_magic_comment_char_dollar)
     | "copy_prop" ->
         Some SW_copy_prop
+    | "empty_structs" ->
+        Some SW_empty_structs
     | _ ->
         None in
   let pred x = function
@@ -128,7 +133,8 @@ let set strs =
     | SW_zero_initialised
     | SW_at_magic_comments
     | SW_magic_comment_char_dollar
-    | SW_copy_prop as y ->
+    | SW_copy_prop
+    | SW_empty_structs as y ->
         x = y in
   List.iter (fun str ->
     match read_switch str with

--- a/ocaml_frontend/switches.mli
+++ b/ocaml_frontend/switches.mli
@@ -43,6 +43,9 @@ type cerb_switch =
   (* eliminate pure symbol rebindings: let alias = pure(sym) → substitute sym *)
   | SW_copy_prop
 
+  (* allow empty structs *)
+  | SW_empty_structs
+
 val get_switches: unit -> cerb_switch list
 val has_switch: cerb_switch -> bool
 val has_switch_pred: (cerb_switch -> bool) -> cerb_switch option

--- a/tests/ci/0342-empty_struct.c
+++ b/tests/ci/0342-empty_struct.c
@@ -1,0 +1,24 @@
+#include <inttypes.h>
+#include <assert.h>
+#include <stdio.h>
+
+struct T {
+};
+
+struct S {
+  int mem;
+};
+
+int main() {
+    struct S y1;
+    struct S y2;
+    struct T x;
+    struct S y3;
+    assert (sizeof(x) == 0);
+    uintptr_t y1_addr = (uintptr_t)&y1;
+    uintptr_t y2_addr = (uintptr_t)&y2;
+    uintptr_t x_addr = (uintptr_t)&x;
+    uintptr_t y3_addr = (uintptr_t)&y3;
+    printf("y1: %"PRIxPTR", y2: %"PRIxPTR", x: %"PRIxPTR", y3: %"PRIxPTR"\n", y1_addr, y2_addr, x_addr, y3_addr);
+    return sizeof(x);
+}


### PR DESCRIPTION
So GCC and Clang and the allocator are all I guess impl-defined, so doing different things.
```
17:18 ➜  cerberus git:(empty-structs) cerberus --nolibc --typecheck-core --exec --batch --switches empty_structs tests/ci/0342-empty_struct.c
Defined {value: "Specified(0)", stdout: "y1: ffffffffffd4, y2: ffffffffffd0, x: ffffffffffd0, y3: ffffffffffcc\n", stderr: "", blocked: "false"}
Time spent: 0.061306 seconds
17:19 ➜  cerberus git:(empty-structs) cerberus-vip --nolibc --typecheck-core --exec --batch --switches empty_structs tests/ci/0342-empty_struct.c
Defined {value: "Specified(0)", stdout: "y1: ffffffffffd4, y2: ffffffffffd0, x: ffffffffffd0, y3: ffffffffffcc\n", stderr: "", blocked: "false"}
Time spent: 0.084719 seconds
17:19 ➜  cerberus git:(empty-structs) gcc --version && gcc tests/ci/0342-empty_struct.c && ./a.out
gcc (Ubuntu 11.4.0-1ubuntu1~22.04.3) 11.4.0
...
y1: 7ffcbdf304ec, y2: 7ffcbdf304f0, x: 7ffcbdf304eb, y3: 7ffcbdf304f4
17:19 ➜  cerberus git:(empty-structs) clang-15 --version && clang-15 tests/ci/0342-empty_struct.c && ./a.out
Ubuntu clang version 15.0.7
...
y1: 7ffc74254748, y2: 7ffc74254740, x: 7ffc74254738, y3: 7ffc74254730
```